### PR TITLE
Split stdlib into submodules

### DIFF
--- a/setup/install.ab
+++ b/setup/install.ab
@@ -1,4 +1,5 @@
-import { has_failed, includes, exit, chars } from "std"
+import { has_failed, includes, exit } from "std"
+import { chars } from "std/strings"
 import { get_os, get_arch, get_place, get_bins_folder } from "./shared.ab"
 
 let name = "AmberNative"

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -144,6 +144,7 @@ impl AmberCompiler {
         std_modules.insert("".to_string(), include_str!("std/main.ab").to_string());
         std_modules.insert("std".to_string(), include_str!("std/main.ab").to_string());
         std_modules.insert("strings".to_string(), include_str!("std/strings.ab").to_string());
+        std_modules.insert("fs".to_string(), include_str!("std/fs.ab").to_string());
 
         if let Some(module) = std_modules.get(&path.replace("std/", "")) {
             return Ok(module.clone())

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -4,6 +4,7 @@ use crate::translate::check_all_blocks;
 use crate::utils::{ParserMetadata, TranslateMetadata};
 use crate::translate::module::TranslateModule;
 use crate::rules;
+use std::collections::HashMap;
 use std::process::Command;
 use std::env;
 use std::time::Instant;
@@ -137,9 +138,17 @@ impl AmberCompiler {
         })
     }
 
-    pub fn import_std() -> String {
-        [
-            include_str!("std/main.ab")
-        ].join("\n")
+    pub fn resolve_std(path: String, meta: &mut ParserMetadata, token_import: Option<Token>) -> Result<String, Failure> {
+        let mut std_modules = HashMap::new();
+
+        std_modules.insert("".to_string(), include_str!("std/main.ab").to_string());
+        std_modules.insert("std".to_string(), include_str!("std/main.ab").to_string());
+        std_modules.insert("strings".to_string(), include_str!("std/strings.ab").to_string());
+
+        if let Some(module) = std_modules.get(&path.replace("std/", "")) {
+            return Ok(module.clone())
+        }
+        
+        Err(Failure::Loud(Message::new_err_at_token(meta, token_import).message("Module not found in stdlib")))
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -4,7 +4,6 @@ use crate::translate::check_all_blocks;
 use crate::utils::{ParserMetadata, TranslateMetadata};
 use crate::translate::module::TranslateModule;
 use crate::rules;
-use std::collections::HashMap;
 use std::process::Command;
 use std::env;
 use std::time::Instant;
@@ -136,20 +135,5 @@ impl AmberCompiler {
                 .output().unwrap();
             Ok(String::from_utf8_lossy(&child.stdout).to_string())
         })
-    }
-
-    pub fn resolve_std(path: String, meta: &mut ParserMetadata, token_import: Option<Token>) -> Result<String, Failure> {
-        let mut std_modules = HashMap::new();
-
-        std_modules.insert("".to_string(), include_str!("std/main.ab").to_string());
-        std_modules.insert("std".to_string(), include_str!("std/main.ab").to_string());
-        std_modules.insert("strings".to_string(), include_str!("std/strings.ab").to_string());
-        std_modules.insert("fs".to_string(), include_str!("std/fs.ab").to_string());
-
-        if let Some(module) = std_modules.get(&path.replace("std/", "")) {
-            return Ok(module.clone())
-        }
-        
-        Err(Failure::Loud(Message::new_err_at_token(meta, token_import).message("Module not found in stdlib")))
     }
 }

--- a/src/modules/imports/import.rs
+++ b/src/modules/imports/import.rs
@@ -157,13 +157,11 @@ impl SyntaxModule<ParserMetadata> for Import {
         self.token_path = meta.get_current_token();
         syntax(meta, &mut self.path)?;
         // Import code from file or standard library
-        let imported_code = if self.path.value == "[standard library]" {
-            self.add_import(meta, "[standard library]")?;
-            AmberCompiler::import_std()
+        self.add_import(meta, &self.path.value.clone())?;
+        let imported_code = if self.path.value.starts_with("std") {
+            AmberCompiler::resolve_std(self.path.value.clone(), meta, self.token_import.clone())?
         } else {
-            self.add_import(meta, &self.path.value.clone())?;
             self.resolve_import(meta)?
-
         };
         self.handle_import(meta, imported_code)?;
         Ok(())

--- a/src/modules/imports/import_string.rs
+++ b/src/modules/imports/import_string.rs
@@ -9,10 +9,8 @@ pub struct ImportString {
 
 impl ImportString {
     fn resolve_path(&mut self, meta: &ParserMetadata, tok: Option<Token>) -> SyntaxResult {
-        if self.value == "std" {
-            self.value = "[standard library]".to_string();
+        if self.value.starts_with("std") {
             return Ok(())
-
         }
         let mut path = meta.context.path.as_ref()
             .map_or_else(|| Path::new("."), |path| Path::new(path))

--- a/src/std/fs.ab
+++ b/src/std/fs.ab
@@ -1,0 +1,25 @@
+pub fun dir_exist(path) {
+    $[ -d "{path}" ]$ failed {
+        return false
+    }
+    return true
+}
+
+pub fun file_exist(path) {
+    $[ -f "{path}" ]$ failed {
+        return false
+    }
+    return true
+}
+
+pub fun file_read(path) {
+    return $cat "{path}"$?
+}
+
+pub fun file_write(path, content) {
+    return $echo "{content}" > "{path}"$?
+}
+
+pub fun file_append(path, content) {
+    return $echo "{content}" >> "{path}"$?
+}

--- a/src/std/main.ab
+++ b/src/std/main.ab
@@ -4,18 +4,6 @@ pub fun input(prompt: Text): Text {
     return "$REPLY"
 }
 
-pub fun replace_once(source, pattern, replacement) {
-    return unsafe $echo "\$\{source/{pattern}/{replacement}}"$
-}
-
-pub fun replace(source, pattern, replacement) {
-    return unsafe $echo "\$\{source//{pattern}/{replacement}}"$
-}
-
-pub fun replace_regex(source: Text, pattern: Text, replacement: Text): Text {
-    return unsafe $echo "{source}" | sed -e "s/{pattern}/{replacement}/g"$
-}
-
 pub fun dir_exist(path) {
     $[ -d "{path}" ]$ failed {
         return false
@@ -56,30 +44,6 @@ pub fun lines(text: Text): [Text] {
 
 pub fun words(text: Text): [Text] {
   return split(text, " ")
-}
-
-pub fun join(list: [Text], delimiter: Text): Text {
-    return unsafe $IFS="{delimiter}" ; echo "\$\{{nameof list}[*]}"$
-}
-
-pub fun trim(text: Text): Text {
-    return unsafe $echo "{text}" | xargs$
-}
-
-pub fun trim_left(text: Text): Text {
-    return unsafe $echo "{text}" | sed -e 's/^[[:space:]]*//'$
-}
-
-pub fun trim_right(text: Text): Text {
-    return unsafe $echo "{text}" | sed -e 's/[[:space:]]*\$//'$
-}
-
-pub fun lower(text: Text): Text {
-    return unsafe $echo "{text}" | tr '[:upper:]' '[:lower:]'$
-}
-
-pub fun upper(text: Text): Text {
-    return unsafe $echo "{text}" | tr '[:lower:]' '[:upper:]'$
 }
 
 #[allow_absurd_cast]

--- a/src/std/main.ab
+++ b/src/std/main.ab
@@ -30,20 +30,10 @@ pub fun file_append(path, content) {
     return $echo "{content}" >> "{path}"$?
 }
 
-pub fun split(text: Text, delimiter: Text): [Text] {
-    let result = [Text]
-    unsafe $IFS="{delimiter}" read -ra {nameof result} <<< "\${nameof text}"$
-    return result
-}
-
 pub fun lines(text: Text): [Text] {
     let result = [Text]
     unsafe $IFS=\$'\n' read -rd '' -a {nameof result} <<<"\${nameof text}"$
     return result
-}
-
-pub fun words(text: Text): [Text] {
-  return split(text, " ")
 }
 
 #[allow_absurd_cast]
@@ -54,20 +44,6 @@ pub fun len(value): Num {
         else:
             return $echo "\$\{#{nameof value}[@]}"$ as Num
     }
-}
-
-#[allow_absurd_cast]
-pub fun parse(text: Text): Num {
-    $[ -n "{text}" ] && [ "{text}" -eq "{text}" ] 2>/dev/null$?
-    return text as Num
-}
-
-pub fun chars(text: Text): [Text] {
-    let chars = [Text]
-    unsafe $for ((i=0; i<\$\{#{nameof text}}; i++)); do
-        {nameof chars}+=( "\$\{{nameof text}:\$i:1}" );
-    done;$
-    return chars
 }
 
 #[allow_absurd_cast]

--- a/src/std/main.ab
+++ b/src/std/main.ab
@@ -30,12 +30,6 @@ pub fun file_append(path, content) {
     return $echo "{content}" >> "{path}"$?
 }
 
-pub fun lines(text: Text): [Text] {
-    let result = [Text]
-    unsafe $IFS=\$'\n' read -rd '' -a {nameof result} <<<"\${nameof text}"$
-    return result
-}
-
 #[allow_absurd_cast]
 pub fun len(value): Num {
     unsafe {

--- a/src/std/main.ab
+++ b/src/std/main.ab
@@ -4,32 +4,6 @@ pub fun input(prompt: Text): Text {
     return "$REPLY"
 }
 
-pub fun dir_exist(path) {
-    $[ -d "{path}" ]$ failed {
-        return false
-    }
-    return true
-}
-
-pub fun file_exist(path) {
-    $[ -f "{path}" ]$ failed {
-        return false
-    }
-    return true
-}
-
-pub fun file_read(path) {
-    return $cat "{path}"$?
-}
-
-pub fun file_write(path, content) {
-    return $echo "{content}" > "{path}"$?
-}
-
-pub fun file_append(path, content) {
-    return $echo "{content}" >> "{path}"$?
-}
-
 #[allow_absurd_cast]
 pub fun len(value): Num {
     unsafe {

--- a/src/std/strings.ab
+++ b/src/std/strings.ab
@@ -1,0 +1,35 @@
+pub fun replace_once(source, pattern, replacement) {
+    return unsafe $echo "\$\{source/{pattern}/{replacement}}"$
+}
+
+pub fun replace(source, pattern, replacement) {
+    return unsafe $echo "\$\{source//{pattern}/{replacement}}"$
+}
+
+pub fun replace_regex(source: Text, pattern: Text, replacement: Text): Text {
+    return unsafe $echo "{source}" | sed -e "s/{pattern}/{replacement}/g"$
+}
+
+pub fun join(list: [Text], delimiter: Text): Text {
+    return unsafe $IFS="{delimiter}" ; echo "\$\{{nameof list}[*]}"$
+}
+
+pub fun trim(text: Text): Text {
+    return unsafe $echo "{text}" | xargs$
+}
+
+pub fun trim_left(text: Text): Text {
+    return unsafe $echo "{text}" | sed -e 's/^[[:space:]]*//'$
+}
+
+pub fun trim_right(text: Text): Text {
+    return unsafe $echo "{text}" | sed -e 's/[[:space:]]*\$//'$
+}
+
+pub fun lower(text: Text): Text {
+    return unsafe $echo "{text}" | tr '[:upper:]' '[:lower:]'$
+}
+
+pub fun upper(text: Text): Text {
+    return unsafe $echo "{text}" | tr '[:lower:]' '[:upper:]'$
+}

--- a/src/std/strings.ab
+++ b/src/std/strings.ab
@@ -57,3 +57,9 @@ pub fun chars(text: Text): [Text] {
 pub fun words(text: Text): [Text] {
   return split(text, " ")
 }
+
+pub fun lines(text: Text): [Text] {
+    let result = [Text]
+    unsafe $IFS=\$'\n' read -rd '' -a {nameof result} <<<"\${nameof text}"$
+    return result
+}

--- a/src/std/strings.ab
+++ b/src/std/strings.ab
@@ -14,16 +14,16 @@ pub fun join(list: [Text], delimiter: Text): Text {
     return unsafe $IFS="{delimiter}" ; echo "\$\{{nameof list}[*]}"$
 }
 
-pub fun trim(text: Text): Text {
-    return unsafe $echo "{text}" | xargs$
-}
-
 pub fun trim_left(text: Text): Text {
     return unsafe $echo "{text}" | sed -e 's/^[[:space:]]*//'$
 }
 
 pub fun trim_right(text: Text): Text {
     return unsafe $echo "{text}" | sed -e 's/[[:space:]]*\$//'$
+}
+
+pub fun trim(text: Text): Text {
+    return trim_left(trim_right(text))
 }
 
 pub fun lower(text: Text): Text {

--- a/src/std/strings.ab
+++ b/src/std/strings.ab
@@ -33,3 +33,27 @@ pub fun lower(text: Text): Text {
 pub fun upper(text: Text): Text {
     return unsafe $echo "{text}" | tr '[:lower:]' '[:upper:]'$
 }
+
+pub fun split(text: Text, delimiter: Text): [Text] {
+    let result = [Text]
+    unsafe $IFS="{delimiter}" read -ra {nameof result} <<< "\${nameof text}"$
+    return result
+}
+
+#[allow_absurd_cast]
+pub fun parse(text: Text): Num {
+    $[ -n "{text}" ] && [ "{text}" -eq "{text}" ] 2>/dev/null$?
+    return text as Num
+}
+
+pub fun chars(text: Text): [Text] {
+    let chars = [Text]
+    unsafe $for ((i=0; i<\$\{#{nameof text}}; i++)); do
+        {nameof chars}+=( "\$\{{nameof text}:\$i:1}" );
+    done;$
+    return chars
+}
+
+pub fun words(text: Text): [Text] {
+  return split(text, " ")
+}

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -1,0 +1,14 @@
+use include_dir::{include_dir, Dir};
+pub const STDLIB: Dir = include_dir!("src/std");
+
+pub fn resolve_std<T: Into<String>>(path: T) -> Option<String> {
+    let path = path.into();
+    let path = if path == "std" { "main".to_string() } else { path };
+
+    if let Some(module) = STDLIB.get_file(path + ".ab") {
+        let module = module.contents_utf8().unwrap().to_string();
+        Some(module)
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
reworked a little bit of stdlib. the whole thing is still in an early stage, but now it can have more than one file

stating the obvious, this is a breaking change by definition.

issues:

1. ~~hardcoded paths. i do not know macro-fu that much to dynamically load the modules~~
2. the commit history is a mess. sorry for that
3. most of already written amber code will break. heck, it took me about 20 minutes to rewrite stdlib tests. thankfully amber is still in its early stage
   1. ~~install script needs rewriting. working on that right now~~

this PR also introduces `include_dir` crate dependency