### PR TITLE
Optimize tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ opt-level = 3
 inherits = "release"
 lto = "thin"
 
+[profile.test]
+opt-level = 3
+
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)


### PR DESCRIPTION
apparently the only reason why tests were slow as heck was because they were running in non optimized debug mode

one trade off is additional few seconds for compilation, but i think we could live with that