### PR TITLE
fix(shellcheck): another warning fixed

### DIFF
--- a/src/modules/function/invocation.rs
+++ b/src/modules/function/invocation.rs
@@ -128,9 +128,9 @@ impl FunctionInvocation {
         if matches!(self.kind, Type::Array(_)) {
             format!("{quote}{dollar}{{{name}[@]}}{quote}")
         } else if matches!(self.kind, Type::Text) {
-            format!("{quote}{dollar}{{{name}}}{quote}")
+            format!("{quote}{dollar}{name}{quote}")
         } else {
-            format!("{dollar}{name}")
+            format!("{quote}{dollar}{{{name}}}{quote}")
         }
     }
 }

--- a/src/modules/function/invocation.rs
+++ b/src/modules/function/invocation.rs
@@ -128,9 +128,9 @@ impl FunctionInvocation {
         if matches!(self.kind, Type::Array(_)) {
             format!("{quote}{dollar}{{{name}[@]}}{quote}")
         } else if matches!(self.kind, Type::Text) {
-            format!("{quote}{dollar}{name}{quote}")
-        } else {
             format!("{quote}{dollar}{{{name}}}{quote}")
+        } else {
+            format!("{quote}{dollar}{name}{quote}")
         }
     }
 }


### PR DESCRIPTION
Ref: https://github.com/Ph0enixKM/Amber/issues/72

Before the patch:

```
__AF_move_to_bin50_v0__25_1=$__AF_move_to_bin50_v0;
echo $__AF_move_to_bin50_v0__25_1 > /dev/null 2>&1
```

After:

```
__AF_move_to_bin50_v0__25_1=$__AF_move_to_bin50_v0;
echo "$__AF_move_to_bin50_v0__25_1" > /dev/null 2>&1
```

I am not sure if this check if there is a variable is needed but in this way the shellcheck issue is fixed.