### PR TITLE
bash_error_exit_code use the english language

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: |
-            ./target
+            ./target/deps
             ~/.cargo
         key: rust-${{ hashFiles('Cargo.lock') }}
         restore-keys: rust-${{ hashFiles('Cargo.lock') }}

--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -23,6 +23,8 @@ fn bash_error_exit_code() -> Result<(), Box<dyn std::error::Error>> {
         "#
     )?;
 
+    cmd.env("LC_ALL", "C");
+    cmd.arg("--disable-format");
     cmd.arg(file.path());
     cmd.assert()
         .failure()

--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -23,6 +23,7 @@ fn bash_error_exit_code() -> Result<(), Box<dyn std::error::Error>> {
         "#
     )?;
 
+    // Changes locale to default
     cmd.env("LC_ALL", "C");
     cmd.arg("--disable-format");
     cmd.arg(file.path());


### PR DESCRIPTION
So if you have a computer configured with another language this test fails.

With this change it will force the english language with a environment variable.

I added also the parameter to disable the formatting and fixed the CI for https://github.com/amber-lang/amber/issues/217 as in this way it will compile from scratch instead of a cached version.