### PR TITLE
Add confirm prompt (Yes/No) in Stdlib

### DIFF
--- a/src/std/env.ab
+++ b/src/std/env.ab
@@ -59,6 +59,19 @@ pub fun input(prompt: Text): Text {
     return "\$REPLY"
 }
 
+// Confirm prompt (Yes/No), return true if choice is Yes
+// "No" is the default choice, set default_yes to true for "Yes" as default choice
+pub fun confirm(prompt: Text, default_yes: Bool = false): Bool {
+    let choice_default = default_yes then " [\x1b[1mY/\x1b[0mn]" else " [y/\x1b[1mN\x1b[0m]"
+    unsafe {
+        $printf "\x1b[1m{prompt}\x1b[0m{choice_default}"$
+        $read -s -n 1$
+        $printf "\n"$
+    }
+    let result = lower(unsafe $echo \$REPLY$)
+    return result == "y" or (result == "" and default_yes)
+}
+
 pub fun has_failed(command: Text): Bool {
     unsafe silent $eval {command}$
     return status != 0

--- a/src/std/env.ab
+++ b/src/std/env.ab
@@ -59,8 +59,8 @@ pub fun input(prompt: Text): Text {
     return "\$REPLY"
 }
 
-// Confirm prompt (Yes/No), return true if choice is Yes
-// "No" is the default choice, set default_yes to true for "Yes" as default choice
+/// Confirm prompt (Yes/No), return true if choice is Yes
+/// "No" is the default choice, set default_yes to true for "Yes" as default choice
 pub fun confirm(prompt: Text, default_yes: Bool = false): Bool {
     let choice_default = default_yes then " [\x1b[1mY/\x1b[0mn]" else " [y/\x1b[1mN\x1b[0m]"
     unsafe {

--- a/src/tests/stdlib/confirm.ab
+++ b/src/tests/stdlib/confirm.ab
@@ -1,0 +1,11 @@
+import * from "std/env"
+main {
+    unsafe $echo "Y" > /tmp/test_confirm$
+    unsafe $exec 0< /tmp/test_confirm$
+    if confirm("Yes"): echo "Confirm Yes"
+    unsafe $echo "N" > /tmp/test_confirm$
+    if not confirm("No"): echo "Confirm No"
+    unsafe $echo "" > /tmp/test_confirm$
+    if confirm("Default", true): echo "Confirm Default"
+    unsafe $rm /tmp/test_confirm$
+}

--- a/src/tests/stdlib/confirm.output.txt
+++ b/src/tests/stdlib/confirm.output.txt
@@ -1,0 +1,6 @@
+[1mYes[0m [y/[1mN[0m]
+Confirm Yes
+[1mNo[0m [y/[1mN[0m]
+Confirm No
+[1mDefault[0m [[1mY/[0mn]
+Confirm Default


### PR DESCRIPTION
this function : `confirm(prompt: Text, default_yes: Bool = false)` add a simple function to make yes/No prompt more easy.
default choice is printed in bold : "File not exist, would you like to create it ? [y/**N**]"

i think is useful in many use case, for example :
```
if(confirm("File not exist, would you like to create it ?")) {
    // some code....
}
```