### PR TITLE
Shellcheck wrap variables

### DIFF
--- a/src/modules/condition/ifchain.rs
+++ b/src/modules/condition/ifchain.rs
@@ -82,11 +82,11 @@ impl TranslateModule for IfChain {
         let mut is_first = true;
         for (cond, block) in self.cond_blocks.iter() {
             if is_first {
-                result.push(format!("if [ {} != 0 ]; then", cond.translate(meta)));
+                result.push(format!("if [ \"{}\" != 0 ]; then", cond.translate(meta)));
                 result.push(block.translate(meta));
                 is_first = false;
             } else {
-                result.push(format!("elif [ {} != 0 ]; then", cond.translate(meta)));
+                result.push(format!("elif [ \"{}\" != 0 ]; then", cond.translate(meta)));
                 result.push(block.translate(meta));
             }
         }

--- a/src/modules/condition/ifcond.rs
+++ b/src/modules/condition/ifcond.rs
@@ -91,7 +91,11 @@ impl SyntaxModule<ParserMetadata> for IfCondition {
 impl TranslateModule for IfCondition {
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
         let mut result = vec![];
-        result.push(format!("if [ \"{}\" != 0 ]; then", self.expr.translate(meta)));
+        if self.expr.translate(meta).starts_with("\"") {
+            result.push(format!("if [ {} != 0 ]; then", self.expr.translate(meta)));
+        } else {
+            result.push(format!("if [ \"{}\" != 0 ]; then", self.expr.translate(meta)));
+        }
         result.push(self.true_block.translate(meta));
         if let Some(false_block) = &self.false_block {
             result.push("else".to_string());

--- a/src/modules/condition/ifcond.rs
+++ b/src/modules/condition/ifcond.rs
@@ -91,7 +91,7 @@ impl SyntaxModule<ParserMetadata> for IfCondition {
 impl TranslateModule for IfCondition {
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
         let mut result = vec![];
-        result.push(format!("if [ {} != 0 ]; then", self.expr.translate(meta)));
+        result.push(format!("if [ \"{}\" != 0 ]; then", self.expr.translate(meta)));
         result.push(self.true_block.translate(meta));
         if let Some(false_block) = &self.false_block {
             result.push("else".to_string());

--- a/src/modules/condition/ternary.rs
+++ b/src/modules/condition/ternary.rs
@@ -54,7 +54,7 @@ impl TranslateModule for Ternary {
         let cond = self.cond.translate(meta);
         let true_expr = self.true_expr.translate(meta);
         let false_expr = self.false_expr.translate(meta);
-        meta.gen_subprocess(&format!("if [ {} != 0 ]; then echo {}; else echo {}; fi", cond, true_expr, false_expr))
+        meta.gen_subprocess(&format!("if [ \"{}\" != 0 ]; then echo {}; else echo {}; fi", cond, true_expr, false_expr))
     }
 }
 

--- a/src/modules/function/invocation.rs
+++ b/src/modules/function/invocation.rs
@@ -148,9 +148,13 @@ impl TranslateModule for FunctionInvocation {
             } else {
                 let translation = arg.translate_eval(meta, false);
                 // If the argument is an array, we have to get just the "name[@]" part
-                (translation.starts_with("\"${") && translation.ends_with("[@]}\""))
-                    .then(|| translation.get(3..translation.len() - 2).unwrap().to_string())
-                    .unwrap_or(translation)
+                if translation.starts_with("\"${") && translation.ends_with("[@]}\"") {
+                    translation.get(3..translation.len() - 2).unwrap().to_string()
+                } else if translation.starts_with("${") && translation.ends_with("}") {
+                    format!("\"{}\"", translation)
+                } else {
+                    translation
+                }
             }
         }).collect::<Vec<String>>().join(" ");
 

--- a/src/translate/compute.rs
+++ b/src/translate/compute.rs
@@ -50,7 +50,7 @@ pub fn translate_computation(meta: &TranslateMetadata, operation: ArithOp, left:
                 ArithOp::Or => "||"
             };
             let math_lib_flag = if math_lib_flag { "-l" } else { "" };
-            meta.gen_subprocess(&format!("echo {left} '{op}' {right} | bc {math_lib_flag} | sed '{sed_regex}'"))
+            meta.gen_subprocess(&format!("echo \"{left}\" '{op}' \"{right}\" | bc {math_lib_flag} | sed '{sed_regex}'"))
         }
     }
 }


### PR DESCRIPTION
Taking as example the date_compare.ab test we have this issues:

```
In /tmp/amber-sc-tests/date_compare.ab.sh line 9:
    if [ $(
         ^-- SC2046 (warning): Quote this to prevent word splitting.


In /tmp/amber-sc-tests/date_compare.ab.sh line 11:
        echo $?
             ^-- SC2319 (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.


In /tmp/amber-sc-tests/date_compare.ab.sh line 15:
    if [ $(
         ^-- SC2046 (warning): Quote this to prevent word splitting.


In /tmp/amber-sc-tests/date_compare.ab.sh line 17:
        echo $?
             ^-- SC2319 (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.


In /tmp/amber-sc-tests/date_compare.ab.sh line 23:
    if [ ${utc} != 0 ]; then
         ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    if [ "${utc}" != 0 ]; then


In /tmp/amber-sc-tests/date_compare.ab.sh line 49:
    if [ $(
         ^-- SC2046 (warning): Quote this to prevent word splitting.


In /tmp/amber-sc-tests/date_compare.ab.sh line 53:
        date_posix__0_v0 "" "" ${utc}
                               ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        date_posix__0_v0 "" "" "${utc}"


In /tmp/amber-sc-tests/date_compare.ab.sh line 58:
    date_posix__0_v0 "%s" "${date_a}" ${utc}
                                      ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    date_posix__0_v0 "%s" "${date_a}" "${utc}"


In /tmp/amber-sc-tests/date_compare.ab.sh line 66:
    date_posix__0_v0 "%s" "${date_b}" ${utc}
                                      ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    date_posix__0_v0 "%s" "${date_b}" "${utc}"


In /tmp/amber-sc-tests/date_compare.ab.sh line 74:
    if [ $(echo ${timestamp_a} '>' ${timestamp_b} | bc -l | sed '/\./ s/\.\{0,1\}0\{1,\}$//') != 0 ]; then
         ^-- SC2046 (warning): Quote this to prevent word splitting.
                ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                   ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    if [ $(echo "${timestamp_a}" '>' "${timestamp_b}" | bc -l | sed '/\./ s/\.\{0,1\}0\{1,\}$//') != 0 ]; then


In /tmp/amber-sc-tests/date_compare.ab.sh line 78:
    if [ $(echo ${timestamp_a} '==' ${timestamp_b} | bc -l | sed '/\./ s/\.\{0,1\}0\{1,\}$//') != 0 ]; then
         ^-- SC2046 (warning): Quote this to prevent word splitting.
                ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                    ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    if [ $(echo "${timestamp_a}" '==' "${timestamp_b}" | bc -l | sed '/\./ s/\.\{0,1\}0\{1,\}$//') != 0 ]; then


In /tmp/amber-sc-tests/date_compare.ab.sh line 82:
    if [ $(echo ${timestamp_a} '<' ${timestamp_b} | bc -l | sed '/\./ s/\.\{0,1\}0\{1,\}$//') != 0 ]; then
         ^-- SC2046 (warning): Quote this to prevent word splitting.
                ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                   ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    if [ $(echo "${timestamp_a}" '<' "${timestamp_b}" | bc -l | sed '/\./ s/\.\{0,1\}0\{1,\}$//') != 0 ]; then


In /tmp/amber-sc-tests/date_compare.ab.sh line 94:
if [ $(echo $(echo "$__AF_date_compare3_v0__4_16" '==' $(echo '-' 1 | bc -l | sed '/\./ s/\.\{0,1\}0\{1,\}$//') | bc -l | sed '/\./ s/\.\{0,1\}0\{1,\}$//') '&&' $(echo "$__AF_date_compare3_v0__4_60" '==' 1 | bc -l | sed '/\./ s/\.\{0,1\}0\{1,\}$//') | bc -l | sed '/\./ s/\.\{0,1\}0\{1,\}$//') != 0 ]; then
     ^-- SC2046 (warning): Quote this to prevent word splitting.
            ^-- SC2046 (warning): Quote this to prevent word splitting.
                                                       ^-- SC2046 (warning): Quote this to prevent word splitting.
                                                                                                                                                                 ^-- SC2046 (warning): Quote this to prevent word splitting.

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2319 -- This $? refers to a condition, no...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

We fix some of those issues (also in other tests) but I am still working on some of the warning here.