### PR TITLE
fix: include argv0 into args

### DIFF
--- a/src/modules/main.rs
+++ b/src/modules/main.rs
@@ -71,7 +71,7 @@ impl TranslateModule for Main {
             let dollar = meta.gen_dollar();
             let args = self.args.clone().map_or_else(
                 String::new,
-                |name| format!("{name}=({quote}{dollar}@{quote})")
+                |name| format!("{name}=({quote}{dollar}0{quote} {quote}{dollar}@{quote})")
             );
             format!("{args}\n{}", self.block.translate(meta))
         }


### PR DESCRIPTION
install scripts don't need to be edited or recompiled, this doesnt affect them

closes #265