### PR TITLE
Remove sed for condition

### DIFF
--- a/src/std/math.ab
+++ b/src/std/math.ab
@@ -29,6 +29,6 @@ pub fun ceil(number: Num): Num {
 /// Returns the absolute value of a number
 #[allow_absurd_cast]
 pub fun abs(number: Num): Num {
-    if number < 0: return -number
+    if number < 0: return number * -1
     return number
 }

--- a/src/translate/compute.rs
+++ b/src/translate/compute.rs
@@ -27,12 +27,14 @@ pub fn translate_computation(meta: &TranslateMetadata, operation: ArithOp, left:
         ArithType::BcSed => {
             let (left, right) = (left.unwrap_or_default(), right.unwrap_or_default());
             let mut scale = "";
+            let mut after_bc = "";
+            let sed_regex = "| sed \"/\\./ s/\\.\\{0,1\\}0\\{1,\\}$//\"";
             let op = match operation {
                 ArithOp::Add => "+",
                 ArithOp::Sub => "-",
                 ArithOp::Mul => "*",
                 ArithOp::Div => {
-                    scale = "scale=0;";
+                    after_bc = sed_regex;
                     "/"
                 },
                 ArithOp::Modulo => {
@@ -50,7 +52,7 @@ pub fn translate_computation(meta: &TranslateMetadata, operation: ArithOp, left:
                 ArithOp::And => "&&",
                 ArithOp::Or => "||"
             };
-            meta.gen_subprocess(&format!("echo \"{scale}{left}{op}{right}\" | bc -l"))
+            meta.gen_subprocess(&format!("echo \"{scale}{left}{op}{right}\" | bc -l{after_bc}"))
         }
     }
 }

--- a/src/translate/compute.rs
+++ b/src/translate/compute.rs
@@ -50,7 +50,6 @@ pub fn translate_computation(meta: &TranslateMetadata, operation: ArithOp, left:
                 ArithOp::And => "&&",
                 ArithOp::Or => "||"
             };
-            let math_lib_flag = if math_lib_flag { "-l" } else { "" };
             meta.gen_subprocess(&format!("echo \"{scale}{left}{op}{right}\" | bc -l"))
         }
     }

--- a/src/translate/compute.rs
+++ b/src/translate/compute.rs
@@ -25,10 +25,11 @@ pub enum ArithOp {
 pub fn translate_computation(meta: &TranslateMetadata, operation: ArithOp, left: Option<String>, right: Option<String>) -> String {
     match meta.arith_module {
         ArithType::BcSed => {
-            let (left, right) = (left.unwrap_or_default(), right.unwrap_or_default());
+            let left = left.unwrap_or_default();
+            let right = right.unwrap_or_default();
             let mut scale = "";
             let mut after_bc = "";
-            let sed_regex = "| sed \"/\\./ s/\\.\\{0,1\\}0\\{1,\\}$//\"";
+            let sed_regex = " | sed \"s/\\(\\.\\(0\\|[0-9]*[1-9]\\)\\)00*$/\\1/\"";
             let op = match operation {
                 ArithOp::Add => "+",
                 ArithOp::Sub => "-",

--- a/src/translate/compute.rs
+++ b/src/translate/compute.rs
@@ -26,16 +26,17 @@ pub fn translate_computation(meta: &TranslateMetadata, operation: ArithOp, left:
     match meta.arith_module {
         ArithType::BcSed => {
             let (left, right) = (left.unwrap_or_default(), right.unwrap_or_default());
-            let mut math_lib_flag = true;
-            // Removes trailing zeros from the expression
-            let sed_regex = "/\\./ s/\\.\\{0,1\\}0\\{1,\\}$//";
+            let mut scale = "";
             let op = match operation {
                 ArithOp::Add => "+",
                 ArithOp::Sub => "-",
                 ArithOp::Mul => "*",
-                ArithOp::Div => "/",
+                ArithOp::Div => {
+                    scale = "scale=0;";
+                    "/"
+                },
                 ArithOp::Modulo => {
-                    math_lib_flag = false;
+                    scale = "scale=0;";
                     "%"
                 },
                 ArithOp::Neg => "-",
@@ -50,7 +51,7 @@ pub fn translate_computation(meta: &TranslateMetadata, operation: ArithOp, left:
                 ArithOp::Or => "||"
             };
             let math_lib_flag = if math_lib_flag { "-l" } else { "" };
-            meta.gen_subprocess(&format!("echo {left} '{op}' {right} | bc {math_lib_flag} | sed '{sed_regex}'"))
+            meta.gen_subprocess(&format!("echo \"{scale}{left}{op}{right}\" | bc -l"))
         }
     }
 }


### PR DESCRIPTION
Ref: #366 

In this way we are configuring the scale we want to approximate.

Right now some tests doens't work as we have again issues on bash generation:

```
function foo__0_v0 {
    local a=$1
    local b=$2
    eval "${a}=$(
        eval "echo "scale=0
        ${!a}/${b}" | bc -l"
    )"
}
```
Instead it should be:
```
function foo__0_v0 {
    local a=$1
    local b=$2
    eval "${a}=$(
        eval "echo \"scale=0
        ${!a}/${b}\" | bc -l"
    )"
}
```

As you can see the  eco inside the second eval is not escaped.
I guess the issue is there https://github.com/amber-lang/amber/blob/master/src/modules/shorthand/add.rs#L68

But it is a similar issue of https://github.com/amber-lang/amber/pull/376 with missing/wrong escaping.