### PR TITLE
Test Nix on CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,30 @@
+name: Build verify Amber Nix
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  nix_build:
+    name: Nix build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+      - name: Check Nix flake
+        run: nix flake check --all-systems
+      - name: Build in Nix shell
+        run: nix develop --command cargo build --release
+      - name: Build with Nix
+        run: |
+          nix build
+
+          # Ensure that the `amber` binary runs
+          ./result/bin/amber --version
+
+          # Ensure that the `bc` command is correctly provided
+          echo "import { exit } from \"std/env\"\n\$which bc && bc --version\$ failed { echo \"Failed to run basic calculator\"\nexit(1) }" | ./result/bin/amber -

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,8 @@ on:
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
+      - flake.nix
+      - flake.lock
   pull_request:
     paths:
       - src/**
@@ -18,6 +20,8 @@ on:
       - Cargo.toml
       - Cargo.lock
       - rust-toolchain.toml
+      - flake.nix
+      - flake.lock
 
 env:
   CARGO_TERM_COLOR: always
@@ -44,3 +48,18 @@ jobs:
         run: cargo test --all-targets --all-features
       - name: Run clippy check
         run: cargo clippy --all-targets --all-features -- -D warnings
+  nix_build:
+    name: Nix build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+      - name: Check Nix flake
+        run: nix flake check --all-systems
+      - name: Build in Nix shell
+        run: nix develop --command cargo build --release
+      - name: Build with Nix
+        run: |
+          nix build
+          ./result/bin/amber --version
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,4 +66,4 @@ jobs:
           ./result/bin/amber --version
           
           # Ensure that the `bc` command is correctly provided
-          echo "\$which bc; bc --version\$ failed { echo \"Failed to run basic calculator\" }" | ./result/bin/amber -
+          echo "import { exit } from \"std/env\"\n\$which bc && bc --version\$ failed { echo \"Failed to run basic calculator\"\nexit(1) }" | ./result/bin/amber -

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,22 +48,3 @@ jobs:
         run: cargo test --all-targets --all-features
       - name: Run clippy check
         run: cargo clippy --all-targets --all-features -- -D warnings
-  nix_build:
-    name: Nix build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v27
-      - name: Check Nix flake
-        run: nix flake check --all-systems
-      - name: Build in Nix shell
-        run: nix develop --command cargo build --release
-      - name: Build with Nix
-        run: |
-          nix build
-          
-          # Ensure that the `amber` binary runs
-          ./result/bin/amber --version
-          
-          # Ensure that the `bc` command is correctly provided
-          echo "import { exit } from \"std/env\"\n\$which bc && bc --version\$ failed { echo \"Failed to run basic calculator\"\nexit(1) }" | ./result/bin/amber -

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,5 +61,9 @@ jobs:
       - name: Build with Nix
         run: |
           nix build
+          
+          # Ensure that the `amber` binary runs
           ./result/bin/amber --version
-
+          
+          # Ensure that the `bc` command is correctly provided
+          echo "\$which bc; bc --version\$ failed { echo \"Failed to run basic calculator\" }" | ./result/bin/amber -

--- a/flake.lock
+++ b/flake.lock
@@ -37,28 +37,32 @@
         "type": "github"
       }
     },
-    "nixpkgs-mozilla": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1704373101,
-        "narHash": "sha256-+gi59LRWRQmwROrmE1E2b3mtocwueCQqZ60CwLG+gbg=",
-        "owner": "mozilla",
-        "repo": "nixpkgs-mozilla",
-        "rev": "9b11a87c0cc54e308fa83aac5b4ee1816d5418a2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mozilla",
-        "repo": "nixpkgs-mozilla",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "naersk": "naersk",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-mozilla": "nixpkgs-mozilla",
+        "rust-overlay": "rust-overlay",
         "utils": "utils"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1722479030,
+        "narHash": "sha256-98tsdV+N9wSVU0vlzjJ30+9QL2bescJs5jWFurTpvAw=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c02e7d32607e4e16c80152a40ee141c4877b00cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,14 +2,16 @@
   "nodes": {
     "naersk": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1718727675,
-        "narHash": "sha256-uFsCwWYI2pUpt0awahSBorDUrUfBhaAiyz+BPTS2MHk=",
+        "lastModified": 1721727458,
+        "narHash": "sha256-r/xppY958gmZ4oTfLiHN0ZGuQ+RSTijDblVgVLFi1mw=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "941ce6dc38762a7cfb90b5add223d584feed299b",
+        "rev": "3fb418eaf352498f6b6c30592e3beb63df42ef11",
         "type": "github"
       },
       "original": {
@@ -21,14 +23,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-EYekUHJE2gxeo2pM/zM9Wlqw1Uw2XTJXOSAO79ksc4Y=",
-        "path": "/nix/store/qmh8bas1qni03drm0lnjas2azh7h87cn-source",
-        "type": "path"
+        "lastModified": 1722415718,
+        "narHash": "sha256-5US0/pgxbMksF92k1+eOa8arJTJiPvsdZj9Dl+vJkM4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c3392ad349a5227f4a3464dce87bcc5046692fce",
+        "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-mozilla": {
@@ -47,26 +53,10 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1720955038,
-        "narHash": "sha256-GaliJqfFwyYxReFywxAa8orCO+EnDq2NK2F+5aSc8vo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "aa247c0c90ecf4ae7a032c54fdc21b91ca274062",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "naersk": "naersk",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "nixpkgs-mozilla": "nixpkgs-mozilla",
         "utils": "utils"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
           src = ./.;
           nativeBuildInputs = [ pkgs.makeWrapper ];
           postInstall = ''
-            wrapProgram "$out/bin/amber" --set PATH ${nixpkgs.lib.makeBinPath [ pkgs.bc ]}
+            wrapProgram "$out/bin/amber" --prefix PATH : ${nixpkgs.lib.makeBinPath [ pkgs.bc ]}
           '';
         };
         devShells.default =

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,11 @@
 {
   inputs = {
-    naersk.url = "github:nix-community/naersk/master";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixpkgs-unstable";
+
+    naersk = {
+        url = "github:nix-community/naersk?ref=master";
+        inputs.nixpkgs.follows = "nixpkgs";
+    };
     utils.url = "github:numtide/flake-utils";
     nixpkgs-mozilla = {
       url = "github:mozilla/nixpkgs-mozilla";


### PR DESCRIPTION
I was recently unable to build because of the wrapProgram issue #359. That is now resolved, but it would be good to test that Amber is building correctly with Nix on CI. I've added a workflow job to do that.

I also noticed that you have duplicate nixpkgs coming in through naersk. I have configured naersk to use the same nixpkgs as the Amber project is using.