### PR TITLE
fix(std): round and comma/dot

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: bc
+          version: 1.0
       - uses: cachix/install-nix-action@v27
       - name: Check Nix flake
         run: nix flake check --all-systems

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        packages: bc
+        version: 1.0
       - uses: dtolnay/rust-toolchain@stable
       - name: Cache dependencies installed with cargo
         uses: actions/cache@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,8 +33,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: awalsh128/cache-apt-pkgs-action@latest
-        packages: bc
-        version: 1.0
+        with:
+          packages: bc
+          version: 1.0
       - uses: dtolnay/rust-toolchain@stable
       - name: Cache dependencies installed with cargo
         uses: actions/cache@v4

--- a/src/std/math.ab
+++ b/src/std/math.ab
@@ -6,7 +6,7 @@ pub fun sum(list: [Num]): Num {
 /// Returns the number rounded to the nearest integer
 #[allow_absurd_cast]
 pub fun round(number: Num): Num {
-    return unsafe $printf "%0.f" "{number}"$ as Num
+    return unsafe $LC_ALL=C printf "%0.f" "{number}"$ as Num
 }
 
 /// Returns the largest integer less than or equal to the number


### PR DESCRIPTION
Right now the tests for `round` on my machine doesn't work because I have configured a different language on my shell.
Italian use `,` instead of `.` as separator for decimals (like a lot of languages).
With this change we are forcing `printf` to use the default language that is english in the machine to avoid problems.