### PR TITLE
feat: restrict value type for builtin functions (`cd`, `mv`) to be of type `Text`

### DIFF
--- a/src/modules/builtin/cd.rs
+++ b/src/modules/builtin/cd.rs
@@ -1,6 +1,7 @@
 use heraclitus_compiler::prelude::*;
 use crate::modules::expression::expr::Expr;
 use crate::docs::module::DocumentationModule;
+use crate::modules::types::{Type, Typed};
 use crate::translate::module::TranslateModule;
 use crate::utils::{ParserMetadata, TranslateMetadata};
 
@@ -20,7 +21,15 @@ impl SyntaxModule<ParserMetadata> for Cd {
 
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         token(meta, "cd")?;
+        let tok = meta.get_current_token();
         syntax(meta, &mut self.value)?;
+        let path_type = self.value.get_type();
+        if path_type != Type::Text {
+            return error!(meta, tok => {
+                message: "Builtin function `cd` can only be used with values of type Text",
+                comment: format!("Given type: {}, expected type: {}", path_type, Type::Text)
+            });
+        }
         Ok(())
     }
 }

--- a/src/modules/builtin/cd.rs
+++ b/src/modules/builtin/cd.rs
@@ -21,11 +21,11 @@ impl SyntaxModule<ParserMetadata> for Cd {
 
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         token(meta, "cd")?;
-        let tok = meta.get_current_token();
         syntax(meta, &mut self.value)?;
         let path_type = self.value.get_type();
         if path_type != Type::Text {
-            return error!(meta, tok => {
+            let position = self.value.get_position(meta);
+            return error_pos!(meta, position => {
                 message: "Builtin function `cd` can only be used with values of type Text",
                 comment: format!("Given type: {}, expected type: {}", path_type, Type::Text)
             });

--- a/src/modules/builtin/mv.rs
+++ b/src/modules/builtin/mv.rs
@@ -5,6 +5,7 @@ use crate::modules::expression::expr::Expr;
 use crate::modules::condition::failed::Failed;
 use crate::translate::module::TranslateModule;
 use crate::docs::module::DocumentationModule;
+use crate::modules::types::{Type, Typed};
 use crate::utils::{ParserMetadata, TranslateMetadata};
 use crate::modules::command::modifier::CommandModifier;
 
@@ -32,8 +33,24 @@ impl SyntaxModule<ParserMetadata> for Mv {
         syntax(meta, &mut self.modifier)?;
         self.modifier.use_modifiers(meta, |_this, meta| {
             token(meta, "mv")?;
+            let mut tok = meta.get_current_token();
             syntax(meta, &mut self.source)?;
+            let mut path_type = self.source.get_type();
+            if path_type != Type::Text {
+                return error!(meta, tok => {
+                    message: "Builtin function `mv` can only be used with values of type Text",
+                    comment: format!("Given type: {}, expected type: {}", path_type, Type::Text)
+                });
+            }
+            tok = meta.get_current_token();
             syntax(meta, &mut self.destination)?;
+            path_type = self.destination.get_type();
+            if path_type != Type::Text {
+                return error!(meta, tok => {
+                    message: "Builtin function `mv` can only be used with values of type Text",
+                    comment: format!("Given type: {}, expected type: {}", path_type, Type::Text)
+                });
+            }
             syntax(meta, &mut self.failed)?;
             Ok(())
         })

--- a/src/modules/builtin/mv.rs
+++ b/src/modules/builtin/mv.rs
@@ -33,20 +33,20 @@ impl SyntaxModule<ParserMetadata> for Mv {
         syntax(meta, &mut self.modifier)?;
         self.modifier.use_modifiers(meta, |_this, meta| {
             token(meta, "mv")?;
-            let mut tok = meta.get_current_token();
             syntax(meta, &mut self.source)?;
             let mut path_type = self.source.get_type();
             if path_type != Type::Text {
-                return error!(meta, tok => {
+                let position = self.source.get_position(meta);
+                return error_pos!(meta, position => {
                     message: "Builtin function `mv` can only be used with values of type Text",
                     comment: format!("Given type: {}, expected type: {}", path_type, Type::Text)
                 });
             }
-            tok = meta.get_current_token();
             syntax(meta, &mut self.destination)?;
             path_type = self.destination.get_type();
             if path_type != Type::Text {
-                return error!(meta, tok => {
+                let position = self.destination.get_position(meta);
+                return error_pos!(meta, position => {
                     message: "Builtin function `mv` can only be used with values of type Text",
                     comment: format!("Given type: {}, expected type: {}", path_type, Type::Text)
                 });

--- a/src/modules/expression/expr.rs
+++ b/src/modules/expression/expr.rs
@@ -97,10 +97,14 @@ impl Typed for Expr {
 }
 
 impl Expr {
-    pub fn get_error_message(&self, meta: &mut ParserMetadata) -> Message {
+    pub fn get_position(&self, meta: &mut ParserMetadata) -> PositionInfo {
         let begin = meta.get_token_at(self.pos.0);
         let end = meta.get_token_at(self.pos.1);
-        let pos = PositionInfo::from_between_tokens(meta, begin, end);
+        PositionInfo::from_between_tokens(meta, begin, end)
+    }
+
+    pub fn get_error_message(&self, meta: &mut ParserMetadata) -> Message {
+        let pos = self.get_position(meta);
         Message::new_err_at_position(meta, pos)
     }
 


### PR DESCRIPTION
This update ensures that the arguments passed to the `cd` and `mv` commands are of type `Text`.

closes #369 