### PR TITLE
[Feature] Allow // as a comment that stays in compiled file

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -151,7 +151,7 @@ impl AmberCompiler {
 
     pub fn translate(&self, block: Block, meta: ParserMetadata) -> String {
         let ast_forest = self.get_sorted_ast_forest(block, &meta);
-        let mut meta_translate = TranslateMetadata::new(meta);
+        let mut meta_translate = TranslateMetadata::new(meta, &self.cli_opts);
         let time = Instant::now();
         let mut result = vec![];
         for (_path, block) in ast_forest {
@@ -182,8 +182,7 @@ impl AmberCompiler {
                     .format("%Y-%m-%d %H:%M:%S")
                     .to_string()
                     .as_str()),
-        ]
-        .join("\n");
+        ].join("\n");
         format!("{}\n{}", header, res)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,10 @@ pub struct Cli {
     /// Don't format the output file
     #[arg(long)]
     disable_format: bool,
+
+    /// Optimize the code for release (for now it just removes comments)
+    #[arg(long)]
+    release: bool,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/src/modules/block.rs
+++ b/src/modules/block.rs
@@ -40,11 +40,6 @@ impl SyntaxModule<ParserMetadata> for Block {
                 meta.increment_index();
                 continue;
             }
-            // Handle comments
-            if token.word.starts_with("//") && !token.word.starts_with("///") {
-                meta.increment_index();
-                continue
-            }
             // Handle block end
             else if token.word == "}" {
                 break;

--- a/src/modules/statement/comment.rs
+++ b/src/modules/statement/comment.rs
@@ -1,0 +1,41 @@
+use heraclitus_compiler::prelude::*;
+use crate::docs::module::DocumentationModule;
+use crate::utils::metadata::ParserMetadata;
+use crate::translate::module::TranslateModule;
+
+#[derive(Debug, Clone)]
+pub struct Comment {
+    pub value: String
+}
+
+impl SyntaxModule<ParserMetadata> for Comment {
+    syntax_name!("Comment");
+
+    fn new() -> Self {
+        Comment {
+            value: String::new()
+        }
+    }
+
+    fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
+        let value = token_by(meta, |word| word.starts_with("//"))?;
+        self.value = value.get(2..).unwrap_or("").trim().to_string();
+        Ok(())
+    }
+}
+
+impl TranslateModule for Comment {
+    fn translate(&self, meta: &mut crate::utils::TranslateMetadata) -> String {
+        if meta.release {
+            return "".to_string();
+        } else {
+            format!("# {}", self.value)
+        }
+    }
+}
+
+impl DocumentationModule for Comment {
+    fn document(&self, _meta: &ParserMetadata) -> String {
+        self.value.clone() + "\n\n"
+    }
+}

--- a/src/modules/statement/comment_doc.rs
+++ b/src/modules/statement/comment_doc.rs
@@ -10,7 +10,7 @@ pub struct CommentDoc {
 }
 
 impl SyntaxModule<ParserMetadata> for CommentDoc {
-    syntax_name!("Parenthesis");
+    syntax_name!("Comment Doc");
 
     fn new() -> Self {
         CommentDoc {

--- a/src/modules/statement/mod.rs
+++ b/src/modules/statement/mod.rs
@@ -1,2 +1,3 @@
 pub mod stmt;
+pub mod comment;
 pub mod comment_doc;

--- a/src/modules/statement/stmt.rs
+++ b/src/modules/statement/stmt.rs
@@ -40,6 +40,7 @@ use crate::modules::builtin::{
     cd::Cd
 };
 use super::comment_doc::CommentDoc;
+use super::comment::Comment;
 
 #[derive(Debug, Clone)]
 pub enum StatementType {
@@ -66,6 +67,7 @@ pub enum StatementType {
     Echo(Echo),
     Mv(Mv),
     CommandModifier(CommandModifier),
+    Comment(Comment),
     CommentDoc(CommentDoc)
 }
 
@@ -93,7 +95,7 @@ impl Statement {
         // Command
         CommandModifier, Echo, Mv, Cd,
         // Comment doc
-        CommentDoc,
+        CommentDoc, Comment,
         // Expression
         Expr
     ]);
@@ -127,13 +129,6 @@ impl SyntaxModule<ParserMetadata> for Statement {
         let mut error = None;
         let statements = self.get_modules();
         for statement in statements {
-            // Handle comments
-            if let Some(token) = meta.get_current_token() {
-                if token.word.starts_with("//") && !token.word.starts_with("///") {
-                    meta.increment_index();
-                    continue
-                }
-            }
             // Try to parse the statement
             match self.parse_match(meta, statement) {
                 Ok(()) => return Ok(()),

--- a/src/utils/metadata/translate.rs
+++ b/src/utils/metadata/translate.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use crate::{translate::compute::ArithType, utils::function_cache::FunctionCache};
+use crate::{translate::compute::ArithType, utils::function_cache::FunctionCache, Cli};
 use super::ParserMetadata;
 
 pub struct TranslateMetadata {
@@ -22,11 +22,13 @@ pub struct TranslateMetadata {
     /// Determines whether the current context should be silenced.
     pub silenced: bool,
     /// The current indentation level.
-    pub indent: i64
+    pub indent: i64,
+    /// Determines if release flag was set.
+    pub release: bool
 }
 
 impl TranslateMetadata {
-    pub fn new(meta: ParserMetadata) -> Self {
+    pub fn new(meta: ParserMetadata, cli: &Cli) -> Self {
         TranslateMetadata {
             arith_module: ArithType::BcSed,
             fun_cache: meta.fun_cache,
@@ -36,7 +38,8 @@ impl TranslateMetadata {
             value_id: 0,
             eval_ctx: false,
             silenced: false,
-            indent: -1
+            indent: -1,
+            release: cli.release
         }
     }
 


### PR DESCRIPTION
- Comment is now translated to a bash comment
- Added `--release` flag to optimise resulting code for production. For now it just removes the comments