### PR TITLE
feature: add constant declarations

### DIFF
--- a/src/modules/loops/iter_loop.rs
+++ b/src/modules/loops/iter_loop.rs
@@ -50,9 +50,9 @@ impl SyntaxModule<ParserMetadata> for IterLoop {
             token(meta, "{")?;
             // Create iterator variable
             meta.push_scope();
-            meta.add_var(&self.iter_name, self.iter_type.clone());
+            meta.add_var(&self.iter_name, self.iter_type.clone(), false);
             if let Some(index) = self.iter_index.as_ref() {
-                meta.add_var(index, Type::Num);
+                meta.add_var(index, Type::Num, false);
             }
             // Save loop context state and set it to true
             let mut new_is_loop_ctx = true;

--- a/src/modules/main.rs
+++ b/src/modules/main.rs
@@ -47,7 +47,7 @@ impl SyntaxModule<ParserMetadata> for Main {
             meta.push_scope();
             // Create variables
             for arg in self.args.iter() {
-                meta.add_var(arg, Type::Array(Box::new(Type::Text)));
+                meta.add_var(arg, Type::Array(Box::new(Type::Text)), true);
             }
             // Parse the block
             syntax(meta, &mut self.block)?;

--- a/src/modules/main.rs
+++ b/src/modules/main.rs
@@ -71,7 +71,7 @@ impl TranslateModule for Main {
             let dollar = meta.gen_dollar();
             let args = self.args.clone().map_or_else(
                 String::new,
-                |name| format!("{name}=({quote}{dollar}0{quote} {quote}{dollar}@{quote})")
+                |name| format!("declare -r {name}=({quote}{dollar}0{quote} {quote}{dollar}@{quote})")
             );
             format!("{args}\n{}", self.block.translate(meta))
         }

--- a/src/modules/statement/stmt.rs
+++ b/src/modules/statement/stmt.rs
@@ -1,6 +1,7 @@
 use heraclitus_compiler::prelude::*;
 use itertools::Itertools;
 use crate::docs::module::DocumentationModule;
+use crate::modules::variable::constinit::ConstInit;
 use crate::utils::metadata::{ParserMetadata, TranslateMetadata};
 use crate::modules::expression::expr::{Expr, ExprType};
 use crate::translate::module::TranslateModule;
@@ -68,7 +69,8 @@ pub enum StatementType {
     Mv(Mv),
     CommandModifier(CommandModifier),
     Comment(Comment),
-    CommentDoc(CommentDoc)
+    CommentDoc(CommentDoc),
+    ConstInit(ConstInit)
 }
 
 #[derive(Debug, Clone)]
@@ -87,7 +89,7 @@ impl Statement {
         // Conditions
         IfChain, IfCondition,
         // Variables
-        VariableInit, VariableSet,
+        VariableInit, VariableSet, ConstInit,
         // Short hand
         ShorthandAdd, ShorthandSub,
         ShorthandMul, ShorthandDiv,

--- a/src/modules/variable/constinit.rs
+++ b/src/modules/variable/constinit.rs
@@ -7,26 +7,26 @@ use crate::utils::metadata::{ParserMetadata, TranslateMetadata};
 use super::{variable_name_extensions, handle_identifier_name};
 
 #[derive(Debug, Clone)]
-pub struct VariableInit {
+pub struct ConstInit {
     name: String,
     expr: Box<Expr>,
     global_id: Option<usize>,
     is_fun_ctx: bool
 }
 
-impl VariableInit {
-    fn handle_add_variable(&mut self, meta: &mut ParserMetadata, name: &str, kind: Type, tok: Option<Token>) -> SyntaxResult {
+impl ConstInit {
+    fn handle_add_const(&mut self, meta: &mut ParserMetadata, name: &str, kind: Type, tok: Option<Token>) -> SyntaxResult {
         handle_identifier_name(meta, name, tok)?;
-        self.global_id = meta.add_var(name, kind, false);
+        self.global_id = meta.add_var(name, kind, true);
         Ok(())
     }
 }
 
-impl SyntaxModule<ParserMetadata> for VariableInit {
-    syntax_name!("Variable Initialize");
+impl SyntaxModule<ParserMetadata> for ConstInit {
+    syntax_name!("Constant Initialization");
 
     fn new() -> Self {
-        VariableInit {
+        ConstInit {
             name: String::new(),
             expr: Box::new(Expr::new()),
             global_id: None,
@@ -35,7 +35,7 @@ impl SyntaxModule<ParserMetadata> for VariableInit {
     }
 
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
-        token(meta, "let")?;
+        token(meta, "const")?;
         // Get the variable name
         let tok = meta.get_current_token();
         self.name = variable(meta, variable_name_extensions())?;
@@ -43,7 +43,7 @@ impl SyntaxModule<ParserMetadata> for VariableInit {
             token(meta, "=")?;
             syntax(meta, &mut *self.expr)?;
             // Add a variable to the memory
-            self.handle_add_variable(meta, &self.name.clone(), self.expr.get_type(), tok)?;
+            self.handle_add_const(meta, &self.name.clone(), self.expr.get_type(), tok)?;
             self.is_fun_ctx = meta.context.is_fun_ctx;
             Ok(())
         }, |position| {
@@ -52,22 +52,21 @@ impl SyntaxModule<ParserMetadata> for VariableInit {
     }
 }
 
-impl TranslateModule for VariableInit {
+impl TranslateModule for ConstInit {
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
         let name = self.name.clone();
         let mut  expr = self.expr.translate(meta);
         if let Type::Array(_) = self.expr.get_type() {
             expr = format!("({expr})");
         }
-        let local = if self.is_fun_ctx { "local " } else { "" };
         match self.global_id {
-            Some(id) => format!("__{id}_{name}={expr}"),
-            None => format!("{local}{name}={expr}")
+            Some(id) => format!("declare -r __{id}_{name}={expr}"),
+            None => format!("declare -r {name}={expr}")
         }
     }
 }
 
-impl DocumentationModule for VariableInit {
+impl DocumentationModule for ConstInit {
     fn document(&self, _meta: &ParserMetadata) -> String {
         "".to_string()
     }

--- a/src/modules/variable/mod.rs
+++ b/src/modules/variable/mod.rs
@@ -8,6 +8,7 @@ use super::expression::expr::Expr;
 pub mod init;
 pub mod set;
 pub mod get;
+pub mod constinit;
 
 pub fn variable_name_extensions() -> Vec<char> {
     vec!['_']
@@ -18,7 +19,7 @@ pub fn variable_name_keywords() -> Vec<&'static str> {
         // Literals
         "true", "false", "null",
         // Variable keywords
-        "let", "as", "is",
+        "let", "as", "is", "const",
         // Control flow keywords
         "if", "then", "else",
         // Loop keywords

--- a/src/modules/variable/set.rs
+++ b/src/modules/variable/set.rs
@@ -36,6 +36,10 @@ impl SyntaxModule<ParserMetadata> for VariableSet {
         let variable = handle_variable_reference(meta, tok.clone(), &self.name)?;
         self.global_id = variable.global_id;
         self.is_ref = variable.is_ref;
+        // Check for constant reassignment
+        if variable.is_const {
+            return error!(meta, tok, format!("Cannot reassign constant"))
+        }
         // Typecheck the variable
         let left_type = variable.kind.clone();
         let right_type = self.value.get_type();

--- a/src/tests/validity/constant.ab
+++ b/src/tests/validity/constant.ab
@@ -1,10 +1,15 @@
 // Output
 // 1
 // 42
+// 1
+// 42
 
-main(args) {
+main {
     const x = 42
     unsafe $ x=123 $
     echo status // will output 1 if reassignment didnt succeed
+    echo x
+    unsafe $ unset x $
+    echo status // will output 1 if unsetting did not succeed
     echo x
 }

--- a/src/tests/validity/constant.ab
+++ b/src/tests/validity/constant.ab
@@ -1,0 +1,10 @@
+// Output
+// 1
+// 42
+
+main(args) {
+    const x = 42
+    unsafe $ x=123 $
+    echo status // will output 1 if reassignment didnt succeed
+    echo x
+}

--- a/src/utils/context.rs
+++ b/src/utils/context.rs
@@ -41,6 +41,7 @@ pub struct VariableDecl {
     pub kind: Type,
     pub global_id: Option<usize>,
     pub is_ref: bool,
+    pub is_const: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/src/utils/metadata/parser.rs
+++ b/src/utils/metadata/parser.rs
@@ -67,19 +67,20 @@ impl ParserMetadata {
     }
 
     /// Adds a variable to the current scope
-    pub fn add_var(&mut self, name: &str, kind: Type) -> Option<usize> {
+    pub fn add_var(&mut self, name: &str, kind: Type, is_const: bool) -> Option<usize> {
         let global_id = self.is_global_scope().then(|| self.gen_var_id());
         let scope = self.context.scopes.last_mut().unwrap();
         scope.add_var(VariableDecl {
             name: name.to_string(),
             kind,
             global_id,
-            is_ref: false
+            is_ref: false,
+            is_const
         });
         global_id
     }
 
-    /// Adds a parameter as variable to the current scope
+    /// Adds a function parameter as variable to the current scope
     pub fn add_param(&mut self, name: &str, kind: Type, is_ref: bool) -> Option<usize> {
         let global_id = self.is_global_scope().then(|| self.gen_var_id());
         let scope = self.context.scopes.last_mut().unwrap();
@@ -87,7 +88,8 @@ impl ParserMetadata {
             name: name.to_string(),
             kind,
             global_id,
-            is_ref
+            is_ref,
+            is_const: false
         });
         global_id
     }


### PR DESCRIPTION
i've added support for the `const X = Y` expression itself. it will resolve to `declare -r X=Y`, for both local and global variables, since `declare -r` is the same for locals as well

i also set `args` in `main(args)` to be constant. function parameters are never constant.

i don't know which is the minimal bash version for `declare -r`