### PR TITLE
Add empty variable declaration support

### DIFF
--- a/src/modules/block.rs
+++ b/src/modules/block.rs
@@ -60,7 +60,7 @@ impl SyntaxModule<ParserMetadata> for Block {
         }
         for var in meta.get_all_vars() {
             if var.is_empty().unwrap() {
-                return error_pos!(meta, var.declared_at.clone(), "Variable declared but not assigned!");
+                return error_pos!(meta, var.declared_at.clone(), "Variable declared but never assigned!");
             }
         }
         meta.pop_scope();

--- a/src/modules/block.rs
+++ b/src/modules/block.rs
@@ -21,6 +21,11 @@ impl Block {
     pub fn push_statement(&mut self, statement: Statement) {
         self.statements.push(statement);
     }
+
+    // Check for compile time issues 
+    pub fn check(&self) {
+
+    }
 }
 
 impl SyntaxModule<ParserMetadata> for Block {

--- a/src/modules/block.rs
+++ b/src/modules/block.rs
@@ -58,6 +58,11 @@ impl SyntaxModule<ParserMetadata> for Block {
             }
             self.statements.push(statemant);
         }
+        for var in meta.get_all_vars() {
+            if var.is_empty().unwrap() {
+                return error_pos!(meta, var.declared_at.clone(), "Variable declared but not assigned!");
+            }
+        }
         meta.pop_scope();
         Ok(())
     }

--- a/src/modules/block.rs
+++ b/src/modules/block.rs
@@ -21,11 +21,6 @@ impl Block {
     pub fn push_statement(&mut self, statement: Statement) {
         self.statements.push(statement);
     }
-
-    // Check for compile time issues 
-    pub fn check(&self) {
-
-    }
 }
 
 impl SyntaxModule<ParserMetadata> for Block {

--- a/src/modules/function/invocation_utils.rs
+++ b/src/modules/function/invocation_utils.rs
@@ -57,7 +57,7 @@ fn run_function_with_args(meta: &mut ParserMetadata, mut fun: FunctionDecl, args
     // Create a sub context for new variables
     meta.push_scope();
     for (kind, name, is_ref) in izip!(args, &fun.arg_names, &fun.arg_refs) {
-        meta.add_param(name, kind.clone(), *is_ref);
+        meta.add_param(name, kind.clone(), *is_ref, tok.clone());
     }
     // Set the expected return type if specified
     if fun.returns != Type::Generic {

--- a/src/modules/loops/iter_loop.rs
+++ b/src/modules/loops/iter_loop.rs
@@ -50,9 +50,9 @@ impl SyntaxModule<ParserMetadata> for IterLoop {
             token(meta, "{")?;
             // Create iterator variable
             meta.push_scope();
-            meta.add_var(&self.iter_name, self.iter_type.clone());
+            meta.add_var(&self.iter_name, self.iter_type.clone(), false, tok.clone());
             if let Some(index) = self.iter_index.as_ref() {
-                meta.add_var(index, Type::Num);
+                meta.add_var(index, Type::Num, false, tok);
             }
             // Save loop context state and set it to true
             let mut new_is_loop_ctx = true;

--- a/src/modules/main.rs
+++ b/src/modules/main.rs
@@ -47,7 +47,7 @@ impl SyntaxModule<ParserMetadata> for Main {
             meta.push_scope();
             // Create variables
             for arg in self.args.iter() {
-                meta.add_var(arg, Type::Array(Box::new(Type::Text)));
+                meta.add_var(arg, Type::Array(Box::new(Type::Text)), false, tok.clone());
             }
             // Parse the block
             syntax(meta, &mut self.block)?;

--- a/src/modules/variable/get.rs
+++ b/src/modules/variable/get.rs
@@ -48,6 +48,9 @@ impl SyntaxModule<ParserMetadata> for VariableGet {
         let tok = meta.get_current_token();
         self.name = variable(meta, variable_name_extensions())?;
         let variable = handle_variable_reference(meta, tok.clone(), &self.name)?;
+        if variable.is_empty().unwrap() {
+            return error!(meta, tok, format!("Variable {} accessed before it is assigned a value!", variable.name))
+        }
         self.global_id = variable.global_id;
         self.is_ref = variable.is_ref;
         self.kind = variable.kind.clone();

--- a/src/modules/variable/init.rs
+++ b/src/modules/variable/init.rs
@@ -1,6 +1,6 @@
 use heraclitus_compiler::prelude::*;
 use crate::docs::module::DocumentationModule;
-use crate::modules::types::{Typed, Type};
+use crate::modules::types::{parse_type, Type, Typed};
 use crate::modules::expression::expr::Expr;
 use crate::translate::module::TranslateModule;
 use crate::utils::metadata::{ParserMetadata, TranslateMetadata};
@@ -11,13 +11,14 @@ pub struct VariableInit {
     name: String,
     expr: Box<Expr>,
     global_id: Option<usize>,
-    is_fun_ctx: bool
+    is_fun_ctx: bool,
+    is_declare: bool
 }
 
 impl VariableInit {
-    fn handle_add_variable(&mut self, meta: &mut ParserMetadata, name: &str, kind: Type, tok: Option<Token>) -> SyntaxResult {
-        handle_identifier_name(meta, name, tok)?;
-        self.global_id = meta.add_var(name, kind);
+    fn handle_add_variable(&mut self, meta: &mut ParserMetadata, name: &str, kind: Type, tok: Option<Token>, is_empty: bool) -> SyntaxResult {
+        handle_identifier_name(meta, name, tok.clone())?;
+        self.global_id = meta.add_var(name, kind, is_empty, tok);
         Ok(())
     }
 }
@@ -30,7 +31,8 @@ impl SyntaxModule<ParserMetadata> for VariableInit {
             name: String::new(),
             expr: Box::new(Expr::new()),
             global_id: None,
-            is_fun_ctx: false
+            is_fun_ctx: false,
+            is_declare: false
         }
     }
 
@@ -39,15 +41,25 @@ impl SyntaxModule<ParserMetadata> for VariableInit {
         // Get the variable name
         let tok = meta.get_current_token();
         self.name = variable(meta, variable_name_extensions())?;
+
+        if let Ok(_) = token(meta, ":") {
+            // matches declarations w/o assigning value:
+            // let name: Text
+            let typee = parse_type(meta)?;
+            self.handle_add_variable(meta, &self.name.clone(), typee, tok, true)?;
+            self.is_declare = true;
+            return Ok(());
+        }
+
         context!({
             token(meta, "=")?;
             syntax(meta, &mut *self.expr)?;
             // Add a variable to the memory
-            self.handle_add_variable(meta, &self.name.clone(), self.expr.get_type(), tok)?;
+            self.handle_add_variable(meta, &self.name.clone(), self.expr.get_type(), tok, false)?;
             self.is_fun_ctx = meta.context.is_fun_ctx;
             Ok(())
         }, |position| {
-            error_pos!(meta, position, format!("Expected '=' after variable name '{}'", self.name))
+            error_pos!(meta, position, format!("Expected '=' or ':' after variable name '{}'", self.name))
         })
     }
 }
@@ -55,7 +67,10 @@ impl SyntaxModule<ParserMetadata> for VariableInit {
 impl TranslateModule for VariableInit {
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
         let name = self.name.clone();
-        let mut  expr = self.expr.translate(meta);
+        if self.is_declare {
+            return format!("declare {name}");
+        }
+        let mut expr = self.expr.translate(meta);
         if let Type::Array(_) = self.expr.get_type() {
             expr = format!("({expr})");
         }

--- a/src/modules/variable/init.rs
+++ b/src/modules/variable/init.rs
@@ -68,7 +68,10 @@ impl TranslateModule for VariableInit {
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
         let name = self.name.clone();
         if self.is_declare {
-            return format!("declare {name}");
+            return match self.global_id {
+                Some(id) => format!("declare __{id}_{name}"),
+                None => format!("declare {name}")
+            }
         }
         let mut expr = self.expr.translate(meta);
         if let Type::Array(_) = self.expr.get_type() {

--- a/src/modules/variable/set.rs
+++ b/src/modules/variable/set.rs
@@ -58,7 +58,7 @@ impl SyntaxModule<ParserMetadata> for VariableSet {
             return error!(meta, tok, format!("Cannot assign value of type '{right_type}' to a variable of type '{left_type}'"));
         }
 
-        variable.set_is_empty(true).unwrap();
+        variable.set_is_empty(false).unwrap();
         
         Ok(())
     }

--- a/src/modules/variable/set.rs
+++ b/src/modules/variable/set.rs
@@ -57,6 +57,9 @@ impl SyntaxModule<ParserMetadata> for VariableSet {
         else if variable.kind != self.value.get_type() {
             return error!(meta, tok, format!("Cannot assign value of type '{right_type}' to a variable of type '{left_type}'"));
         }
+
+        variable.set_is_empty(true).unwrap();
+        
         Ok(())
     }
 }

--- a/src/tests/errors.rs
+++ b/src/tests/errors.rs
@@ -75,7 +75,7 @@ fn declared_accessed_before_assigned() {
 
 
 #[test]
-#[should_panic(expected = "ERROR: Cannot assign value of type 'Num' to a variable of type 'Text'!")]
+#[should_panic(expected = "ERROR: Cannot assign value of type 'Num' to a variable of type 'Text'")]
 fn declared_assigned_invalid_type() {
     let code = r#"
         let invalid_type_var: Text

--- a/src/tests/errors.rs
+++ b/src/tests/errors.rs
@@ -51,3 +51,24 @@ fn function_with_failable_typed_arg() {
 
     test_amber(code, "Hello, World!");
 }
+
+#[test]
+#[should_panic(expected = "ERROR: Variable declared but never assigned!")]
+fn declared_but_not_assigned_var() {
+    let code = r#"
+        let declared_not_assigned: Text
+    "#;
+
+    test_amber(code, "");
+}
+
+#[test]
+#[should_panic(expected = "Variable non_assigned_var accessed before it is assigned a value!")]
+fn declared_accessed_before_assigned() {
+    let code = r#"
+        let non_assigned_var: Text
+        echo non_assigned_var
+    "#;
+
+    test_amber(code, "");
+}

--- a/src/tests/errors.rs
+++ b/src/tests/errors.rs
@@ -72,3 +72,15 @@ fn declared_accessed_before_assigned() {
 
     test_amber(code, "");
 }
+
+
+#[test]
+#[should_panic(expected = "ERROR: Cannot assign value of type 'Num' to a variable of type 'Text'!")]
+fn declared_assigned_invalid_type() {
+    let code = r#"
+        let invalid_type_var: Text
+        invalid_type_var = 123
+    "#;
+
+    test_amber(code, "");
+}

--- a/src/tests/validity/declared_var.ab
+++ b/src/tests/validity/declared_var.ab
@@ -1,0 +1,6 @@
+// Output
+// 123
+
+let num: Num
+num = 123
+echo num

--- a/src/tests/validity/declared_var_redeclare.ab
+++ b/src/tests/validity/declared_var_redeclare.ab
@@ -1,0 +1,7 @@
+// Output
+// 123
+
+let num: Text
+let num: Num
+num = 123
+echo num


### PR DESCRIPTION
okay so i've implemented empty variable declarations for this syntax:

```ab
let variable: Text
let variable // wont work: generic not allowed
```

it translates like this: `let variable: Text` -> `declare variable`

and if the variable was declared but never assigned, it will throw a compile time error

closes #420