### PR TITLE
fix(test): missing function parameters

### DIFF
--- a/src/tests/validity/function_optional_argument_array.ab
+++ b/src/tests/validity/function_optional_argument_array.ab
@@ -10,4 +10,4 @@ fun sum_array(a : [Num] = [Num]): Num {
 }
 let x = [100,1000]
 let result = sum_array(x)
-echo "1100"
+echo result

--- a/src/tests/validity/function_optional_argument_array.ab
+++ b/src/tests/validity/function_optional_argument_array.ab
@@ -1,0 +1,13 @@
+// Output
+// 1000
+
+fun sum_array(a : [Num] = [Num]): Num {
+    let sum = 0
+    loop n in a {
+        sum += n;
+    }
+    return sum;
+}
+let x = [100,1000]
+let result = sum_array(x)
+echo "{1100}"

--- a/src/tests/validity/function_optional_argument_array.ab
+++ b/src/tests/validity/function_optional_argument_array.ab
@@ -10,4 +10,4 @@ fun sum_array(a : [Num] = [Num]): Num {
 }
 let x = [100,1000]
 let result = sum_array(x)
-echo "{1100}"
+echo "1100"

--- a/src/tests/validity/function_optional_argument_array.ab
+++ b/src/tests/validity/function_optional_argument_array.ab
@@ -1,5 +1,5 @@
 // Output
-// 1000
+// 1100
 
 fun sum_array(a : [Num] = [Num]): Num {
     let sum = 0

--- a/src/tests/validity/function_optional_argument_array_default.ab
+++ b/src/tests/validity/function_optional_argument_array_default.ab
@@ -1,0 +1,12 @@
+// Output
+// 1000
+
+fun sum_array(a : [Num] = [100,200,300,400]): Num {
+    let sum = 0
+    loop n in a {
+        sum += n;
+    }
+    return sum;
+}
+let result = sum_array();
+echo "{1000}"

--- a/src/tests/validity/function_optional_argument_array_default.ab
+++ b/src/tests/validity/function_optional_argument_array_default.ab
@@ -9,4 +9,4 @@ fun sum_array(a : [Num] = [100,200,300,400]): Num {
     return sum;
 }
 let result = sum_array();
-echo "{1000}"
+echo "1000"

--- a/src/tests/validity/function_optional_argument_array_default.ab
+++ b/src/tests/validity/function_optional_argument_array_default.ab
@@ -9,4 +9,4 @@ fun sum_array(a : [Num] = [100,200,300,400]): Num {
     return sum;
 }
 let result = sum_array();
-echo "1000"
+echo result

--- a/src/tests/validity/function_optional_argument_generic.ab
+++ b/src/tests/validity/function_optional_argument_generic.ab
@@ -1,0 +1,7 @@
+// Output
+// hello
+
+fun echo_var(a = 100){
+    echo a
+}
+echo_var("hello")

--- a/src/tests/validity/function_optional_argument_int.ab
+++ b/src/tests/validity/function_optional_argument_int.ab
@@ -1,0 +1,9 @@
+// Output
+// 1010
+
+fun addition(a: Num, b: Num = 100): Num {
+    return a + b
+}
+
+let result = addition(10, 1000)
+echo "{result}"

--- a/src/tests/validity/function_optional_argument_int.ab
+++ b/src/tests/validity/function_optional_argument_int.ab
@@ -6,4 +6,4 @@ fun addition(a: Num, b: Num = 100): Num {
 }
 
 let result = addition(10, 1000)
-echo "{result}"
+echo result

--- a/src/tests/validity/function_optional_argument_int_default.ab
+++ b/src/tests/validity/function_optional_argument_int_default.ab
@@ -4,4 +4,4 @@ fun addition(a: Num, b: Num = 100): Num {
     return a + b
 }
 let result = addition(10)
-echo "{result}"
+echo result

--- a/src/tests/validity/function_optional_argument_int_default.ab
+++ b/src/tests/validity/function_optional_argument_int_default.ab
@@ -1,0 +1,7 @@
+// Output
+// 110
+fun addition(a: Num, b: Num = 100): Num {
+    return a + b
+}
+let result = addition(10)
+echo "{result}"


### PR DESCRIPTION
I noticed that the tests implemented on https://github.com/amber-lang/amber/pull/260/ are missing in the actual release.

Probably during the various PR and changes they are gone.
This PR will implement back.