### PR TITLE
feat: do compile time math for range neq

### DIFF
--- a/src/modules/expression/binop/range.rs
+++ b/src/modules/expression/binop/range.rs
@@ -61,7 +61,7 @@ impl TranslateModule for Range {
         let to = self.to.translate(meta);
         if self.neq {
             let to_neq = match &self.to.value.as_ref().unwrap() {
-                ExprType::Number(_) => (to.parse::<i64>().unwrap() - 1_i64).to_string(),
+                ExprType::Number(_) => (to.parse::<usize>().unwrap() - 1).to_string(),
                 _ => translate_computation(meta, ArithOp::Sub, Some(to), Some("1".to_string())),
             };
             meta.gen_subprocess(&format!("seq {} {}", from, to_neq))

--- a/src/modules/expression/binop/range.rs
+++ b/src/modules/expression/binop/range.rs
@@ -63,7 +63,7 @@ impl TranslateModule for Range {
             let to_neq = match &self.to.value.as_ref().unwrap() {
                 ExprType::Number(_) => (to.parse::<i64>().unwrap() - 1_i64).to_string(),
                 ExprType::VariableGet(_) => translate_computation(meta, ArithOp::Sub, Some(to), Some("1".to_string())),
-                _ => unreachable!("range to must be either Number or VariableGet"),
+                _ => unreachable!("range expression must be either Number or VariableGet"),
             };
             meta.gen_subprocess(&format!("seq {} {}", from, to_neq))
         } else {

--- a/src/modules/expression/binop/range.rs
+++ b/src/modules/expression/binop/range.rs
@@ -62,8 +62,7 @@ impl TranslateModule for Range {
         if self.neq {
             let to_neq = match &self.to.value.as_ref().unwrap() {
                 ExprType::Number(_) => (to.parse::<i64>().unwrap() - 1_i64).to_string(),
-                ExprType::VariableGet(_) => translate_computation(meta, ArithOp::Sub, Some(to), Some("1".to_string())),
-                _ => unreachable!("range expression must be either Number or VariableGet"),
+                _ => translate_computation(meta, ArithOp::Sub, Some(to), Some("1".to_string())),
             };
             meta.gen_subprocess(&format!("seq {} {}", from, to_neq))
         } else {


### PR DESCRIPTION
amber: `0..2`

from: `$(seq 0 $(echo 2 '-' 1 | bc -l | sed '/\./ s/\.\{0,1\}0\{1,\}$//'))`

to: `$(seq 0 1)`

(when the `to` is a number literal, if its a variable it will generate as before)