### PR TITLE
Sort functions by name in documentation

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -128,10 +128,7 @@ impl AmberCompiler {
         meta: &ParserMetadata,
     ) -> Vec<(String, Block)> {
         let imports_sorted = meta.import_cache.topological_sort();
-        let imports_blocks = meta
-            .import_cache
-            .files
-            .iter()
+        let imports_blocks = meta.import_cache.files.iter()
             .map(|file| {
                 file.metadata
                     .as_ref()
@@ -186,32 +183,29 @@ impl AmberCompiler {
     }
 
     pub fn document(&self, block: Block, meta: ParserMetadata, output: String) {
-        let base_path = PathBuf::from(
-            meta.get_path()
-                .expect("Input file must exist in docs generation"),
-        );
+        let base_path = meta.get_path()
+            .map(PathBuf::from)
+            .expect("Input file must exist in docs generation");
         let base_dir = fs::canonicalize(base_path).map(|val| {
             val.parent()
                 .expect("Parent dir must exist in docs generation")
                 .to_owned()
                 .clone()
         });
-        if let Err(err) = base_dir {
+        let base_dir = base_dir.unwrap_or_else(|err| {
             Message::new_err_msg("Couldn't get the absolute path to the provided input file")
                 .comment(err.to_string())
                 .show();
             std::process::exit(1);
-        }
-        let base_dir = base_dir.unwrap();
+        });
         let ast_forest = self.get_sorted_ast_forest(block, &meta);
         let mut paths = vec![];
         for (path, block) in ast_forest {
             let dep_path = {
-                let dep_path = fs::canonicalize(PathBuf::from(path.clone()));
-                if dep_path.is_err() {
-                    continue;
-                }
-                let dep_path = dep_path.unwrap();
+                let dep_path = match fs::canonicalize(PathBuf::from(path)) {
+                    Ok(path) => path,
+                    Err(_) => continue,
+                };
 
                 if !dep_path.starts_with(&base_dir) {
                     continue;

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -214,15 +214,16 @@ impl AmberCompiler {
                 dep_path
             };
             let document = block.document(&meta);
-            // Save to file
+            // Save to file; replace the base directory if the output
+            // path is absolute, otherwise append the output path.
             let dir_path = {
-                let file_dir = dep_path.strip_prefix(&base_dir).unwrap();
-                let parent = file_dir.parent().unwrap().display();
-                format!("{}/{output}/{}", base_dir.to_string_lossy(), parent)
+                let file_path = dep_path.strip_prefix(&base_dir).unwrap();
+                let file_dir = file_path.parent().unwrap();
+                base_dir.join(&output).join(file_dir)
             };
             if let Err(err) = fs::create_dir_all(dir_path.clone()) {
                 Message::new_err_msg(format!(
-                    "Couldn't create directory `{dir_path}`. Do you have sufficient permissions?"
+                    "Couldn't create directory `{}`. Do you have sufficient permissions?", dir_path.display()
                 ))
                 .comment(err.to_string())
                 .show();

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -230,7 +230,7 @@ impl AmberCompiler {
                 std::process::exit(1);
             }
             let filename = dep_path.file_stem().unwrap().to_string_lossy();
-            let path = PathBuf::from(dir_path).join(format!("{filename}.md"));
+            let path = dir_path.join(format!("{filename}.md"));
             let mut file = File::create(path.clone()).unwrap();
             file.write_all(document.as_bytes()).unwrap();
             paths.push(String::from(path.to_string_lossy()));

--- a/src/modules/block.rs
+++ b/src/modules/block.rs
@@ -86,7 +86,7 @@ impl DocumentationModule for Block {
     fn document(&self, meta: &ParserMetadata) -> String {
         let indices = self.statements.iter()
             .enumerate()
-            .map(|(index, statement)| (index, statement.name()))
+            .map(|(index, statement)| (index, statement.get_docs_item_name()))
             .filter_map(|(index, name)| name.map(|n| (n, index)))
             .sorted()
             .collect::<Vec<_>>();

--- a/src/modules/block.rs
+++ b/src/modules/block.rs
@@ -1,6 +1,8 @@
 use std::collections::VecDeque;
+use std::ops::Index;
 
 use heraclitus_compiler::prelude::*;
+use itertools::Itertools;
 use crate::docs::module::DocumentationModule;
 use crate::utils::{metadata::ParserMetadata, TranslateMetadata};
 use crate::translate::module::TranslateModule;
@@ -82,8 +84,16 @@ impl TranslateModule for Block {
 
 impl DocumentationModule for Block {
     fn document(&self, meta: &ParserMetadata) -> String {
-        self.statements.iter()
+        let indices = self.statements.iter()
+            .enumerate()
+            .map(|(index, statement)| (index, statement.name()))
+            .filter_map(|(index, name)| name.map(|n| (n, index)))
+            .sorted()
+            .collect::<Vec<_>>();
+        indices.iter()
+            .map(|(_, index)| self.statements.index(*index))
             .map(|statement| statement.document(meta))
-            .collect::<Vec<_>>().join("")
+            .collect::<Vec<_>>()
+            .join("")
     }
 }

--- a/src/modules/statement/stmt.rs
+++ b/src/modules/statement/stmt.rs
@@ -71,6 +71,15 @@ pub enum StatementType {
     CommentDoc(CommentDoc)
 }
 
+impl StatementType {
+    pub fn name(&self) -> Option<String> {
+        match self {
+            StatementType::FunctionDeclaration(inner) => Some(inner.name.clone()),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Statement {
     pub value: Option<StatementType>
@@ -112,6 +121,14 @@ impl Statement {
                 Ok(())
             }
             Err(details) => Err(details)
+        }
+    }
+
+    pub fn name(&self) -> Option<String> {
+        if let Some(value) = &self.value {
+            value.name()
+        } else {
+            None
         }
     }
 }

--- a/src/modules/statement/stmt.rs
+++ b/src/modules/statement/stmt.rs
@@ -71,15 +71,6 @@ pub enum StatementType {
     CommentDoc(CommentDoc)
 }
 
-impl StatementType {
-    pub fn name(&self) -> Option<String> {
-        match self {
-            StatementType::FunctionDeclaration(inner) => Some(inner.name.clone()),
-            _ => None,
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct Statement {
     pub value: Option<StatementType>
@@ -124,11 +115,10 @@ impl Statement {
         }
     }
 
-    pub fn name(&self) -> Option<String> {
-        if let Some(value) = &self.value {
-            value.name()
-        } else {
-            None
+    pub fn get_docs_item_name(&self) -> Option<String> {
+        match &self.value {
+            Some(StatementType::FunctionDeclaration(inner)) => Some(inner.name.clone()),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
Fixes #460.  Sorts function declarations (we expect these to be the only top level elements in the abstract syntax tree) by name.  Also uses path concatenation to ensure the base directory is overwritten by an absolute output directory.