### PR TITLE
Install from shell using curl fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ Make sure that the operating system meets the following prerequisites
 
 #### system-wide install
 ```bash
-curl -s "https://raw.githubusercontent.com/Ph0enixKM/AmberNative/master/setup/install.sh" | /bin/bash
+bash <(curl -s "https://raw.githubusercontent.com/amber-lang/amber/master/setup/install.sh")
 ```
 
 #### local-user install
 ```bash
-curl -s "https://raw.githubusercontent.com/Ph0enixKM/AmberNative/master/setup/install.sh" | /bin/bash -s -- --user
+bash -- --user <(curl -s "https://raw.githubusercontent.com/amber-lang/amber/master/setup/install.sh")
 ```
 
 #### Via a package manager


### PR DESCRIPTION
Seems that using the previous command the prompt is not working, with this version instead is executed and waited.

Also I fixed the URL to the actual now so there isn't anymore a redirect.

The new command is
```
bash <(curl -s "https://raw.githubusercontent.com/amber-lang/amber/master/setup/install.sh")
```

Ref: #456 