### PR TITLE
Fix CI for PR breakages due to shfmt

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: bc
+          packages: bc shfmt
           version: 1.0
       - uses: dtolnay/rust-toolchain@stable
       - name: Cache dependencies installed with cargo


### PR DESCRIPTION
The CI constantly breaks for PRs with the following error:
```
---- tests::stdlib::test_stdlib_src_tests_stdlib_abs_ab stdout ----
thread 'tests::stdlib::test_stdlib_src_tests_stdlib_abs_ab' panicked at src/modules/formatter.rs:59:30:
Couldn't spawn shfmt: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

This PR adds the `shfmt` package, so it should fix the issue.