### PR TITLE
fix: remove extra spaces in echo helpers

### DIFF
--- a/src/std/env.ab
+++ b/src/std/env.ab
@@ -136,21 +136,21 @@ pub fun color_echo(message: Text, color: Num): Null {
 
 /// Prints a text as a info message.
 pub fun echo_info(message: Text): Null {
-    printf("\x1b[1;3;97;44m %s \x1b[0m\n", [message])
+    printf("\x1b[1;3;97;44m%s\x1b[0m\n", [message])
 }
 
 /// Prints a text as a success message.
 pub fun echo_success(message: Text): Null {
-    printf("\x1b[1;3;97;42m %s \x1b[0m\n", [message])
+    printf("\x1b[1;3;97;42m%s\x1b[0m\n", [message])
 }
 
 /// Prints a text as a warning message.
 pub fun echo_warning(message: Text): Null {
-    printf("\x1b[1;3;97;43m %s \x1b[0m\n", [message])
+    printf("\x1b[1;3;97;43m%s\x1b[0m\n", [message])
 }
 
 /// Prints a text as a error and exits if the status code is greater than 0.
 pub fun error(message: Text, exit_code: Num = 1): Null {
-    printf("\x1b[1;3;97;41m %s \x1b[0m\n", [message])
+    printf("\x1b[1;3;97;41m%s\x1b[0m\n", [message])
     if exit_code > 0 : exit(exit_code)
 }

--- a/src/tests/stdlib/echo_info.ab
+++ b/src/tests/stdlib/echo_info.ab
@@ -1,7 +1,7 @@
 import * from "std/env"
 
 // Output
-// [1;3;97;44m Hello Amber! [0m
+// [1;3;97;44mHello Amber![0m
 
 main {
     echo_info("Hello Amber!")

--- a/src/tests/stdlib/echo_success.ab
+++ b/src/tests/stdlib/echo_success.ab
@@ -1,7 +1,7 @@
 import * from "std/env"
 
 // Output
-// [1;3;97;42m Hello Amber! [0m
+// [1;3;97;42mHello Amber![0m
 
 main {
     echo_success("Hello Amber!")

--- a/src/tests/stdlib/echo_warning.ab
+++ b/src/tests/stdlib/echo_warning.ab
@@ -1,7 +1,7 @@
 import * from "std/env"
 
 // Output
-// [1;3;97;43m Hello Amber! [0m
+// [1;3;97;43mHello Amber![0m
 
 main {
     echo_warning("Hello Amber!")

--- a/src/tests/stdlib/error.ab
+++ b/src/tests/stdlib/error.ab
@@ -1,7 +1,7 @@
 import * from "std/env"
 
 // Output
-// [1;3;97;41m Hello Amber! [0m
+// [1;3;97;41mHello Amber![0m
 
 main {
     error("Hello Amber!", 0)


### PR DESCRIPTION
The echo helper functions in std/env prepend and append extra spaces around the given text.
This leads to weird shifts of input text like this:

![image](https://github.com/user-attachments/assets/1cebd5d3-bd6c-4a27-9b41-d8986d1a2329)
