### PR TITLE
feat: add input_hidden function

### DIFF
--- a/src/std/env.ab
+++ b/src/std/env.ab
@@ -71,11 +71,7 @@ pub fun input(prompt: Text): Text {
 
 /// Creates a prompt, hides any user input and returns the value.
 pub fun input_hidden(prompt: Text): Text {
-    unsafe $stty -echo$
-    unsafe $printf "\${nameof prompt}"$
-    unsafe $read$
-    unsafe $stty echo$
-    unsafe $printf "\n"$
+    unsafe $read -s -p "\${nameof prompt}"$
     return "\$REPLY"
 }
 

--- a/src/std/env.ab
+++ b/src/std/env.ab
@@ -69,6 +69,16 @@ pub fun input(prompt: Text): Text {
     return "\$REPLY"
 }
 
+/// Creates a prompt, hides any user input and returns the value.
+pub fun input_hidden(prompt: Text): Text {
+    unsafe $stty -echo$
+    unsafe $printf "\${nameof prompt}"$
+    unsafe $read$
+    unsafe $stty echo$
+    unsafe $printf "\n"$
+    return "\$REPLY"
+}
+
 /// Creates a confirm prompt (Yes/No), and returns true if the choice is Yes.
 ///
 /// "No" is the default choice, set default_yes to true for "Yes" as default choice.

--- a/src/std/env.ab
+++ b/src/std/env.ab
@@ -70,7 +70,10 @@ pub fun input(prompt: Text): Text {
 
 /// Creates a prompt, hides any user input and returns the value.
 pub fun input_hidden(prompt: Text): Text {
-    unsafe $read -s -p "\${nameof prompt}"$
+    unsafe {
+        $read -s -p "\${nameof prompt}"$
+        $echo "" >&2$
+    }
     return "\$REPLY"
 }
 

--- a/src/std/env.ab
+++ b/src/std/env.ab
@@ -64,8 +64,7 @@ pub fun is_command(command: Text): Bool {
 
 /// Creates a prompt and returns the value.
 pub fun input(prompt: Text): Text {
-    unsafe $printf "\${nameof prompt}"$
-    unsafe $read$
+    unsafe $read -p "\${nameof prompt}"$
     return "\$REPLY"
 }
 

--- a/src/tests/stdlib/input.ab
+++ b/src/tests/stdlib/input.ab
@@ -1,7 +1,7 @@
 import * from "std/env"
 
 // Output
-// Please enter your name:Hello, Amber
+// Hello, Amber
 
 main {
     unsafe $echo "Amber" >> /tmp/test_input$

--- a/src/tests/stdlib/input_hidden.ab
+++ b/src/tests/stdlib/input_hidden.ab
@@ -1,8 +1,7 @@
 import * from "std/env"
 
 // Output
-// Please enter your name:
-//Hello, Amber
+// Hello, Amber
 
 main {
     unsafe $echo "Amber" >> /tmp/test_input$

--- a/src/tests/stdlib/input_hidden.ab
+++ b/src/tests/stdlib/input_hidden.ab
@@ -1,0 +1,13 @@
+import * from "std/env"
+
+// Output
+// Please enter your name:
+//Hello, Amber
+
+main {
+    unsafe $echo "Amber" >> /tmp/test_input$
+    unsafe $exec 0< /tmp/test_input$
+    let name = input_hidden("Please enter your name:")
+    echo "Hello, " + name
+    unsafe $rm /tmp/test_input$
+}


### PR DESCRIPTION
Adds `input_hidden` function to `std/env`

Prompts for input, but hides the user input (useful for password prompts)