### PR TITLE
fix(build): nix CI

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -31,4 +31,4 @@ jobs:
           ./result/bin/amber --version
 
           # Ensure that the `bc` command is correctly provided
-          echo "import { exit } from \"std/env\" \$which bc && bc --version\$ failed { echo \"Failed to run basic calculator\" exit(1) }" | ./result/bin/amber -
+          echo "\$which bc && bc --version\$ failed { echo \"Failed to run basic calculator\" exit(1) }" | ./result/bin/amber -


### PR DESCRIPTION
Now exit is a builtin and not anymore a stdlib so the Ci needed an update.