### PR TITLE
Revert context changes on error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,11 @@ dependencies = [
 [[package]]
 name = "amber-meta"
 version = "0.1.0"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.68",
+]
 
 [[package]]
 name = "android-tzdata"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
 name = "amber"
 version = "0.3.5-alpha"
 dependencies = [
+ "amber-meta",
  "assert_cmd",
  "build-helper",
  "chrono",
@@ -29,6 +30,10 @@ dependencies = [
  "test-generator",
  "tiny_http",
 ]
+
+[[package]]
+name = "amber-meta"
+version = "0.1.0"
 
 [[package]]
 name = "android-tzdata"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,21 +8,22 @@ rust-version = "1.79"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-heraclitus-compiler = "1.8.0"
-similar-string = "1.4.2"
-colored = "2.0.0"
-itertools = "0.13.0"
-clap = { version = "4.4.18", features = ["derive"] }
+amber-meta = { path = "meta" }
 chrono = "0.4.38"
-test-generator = "0.3.1"
+clap = { version = "4.4.18", features = ["derive"] }
+colored = "2.0.0"
+heraclitus-compiler = "1.8.0"
 include_dir = "0.7.4"
+itertools = "0.13.0"
+similar-string = "1.4.2"
+test-generator = "0.3.1"
 
 # test dependencies
 [dev-dependencies]
-tiny_http = "0.12.0"
 assert_cmd = "2.0.14"
 predicates = "3.1.0"
 tempfile = "3.10.1"
+tiny_http = "0.12.0"
 
 [profile.release]
 strip = true
@@ -36,6 +37,9 @@ lto = "thin"
 
 [profile.test]
 opt-level = 3
+
+[workspace]
+members = ["meta"]
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
+proc-macro2 = "1.0.86"
+quote = "1.0.36"
+syn = { version = "2.0.68", features = ["visit"] }

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "amber-meta"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]

--- a/meta/src/helper.rs
+++ b/meta/src/helper.rs
@@ -21,6 +21,7 @@ impl HelperVisitor {
         let concat = format!("set_{}", name);
         let concat = Ident::new(&concat, name.span());
         quote! {
+            /// Sets the field value and returns the previous value.
             pub fn #concat(&mut self, mut #name: #segment) -> #segment {
                 use std::mem::swap;
                 swap(&mut self.#name, &mut #name);

--- a/meta/src/helper.rs
+++ b/meta/src/helper.rs
@@ -1,0 +1,47 @@
+use crate::utils;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::visit::Visit;
+use syn::{Field, Ident, PathSegment};
+
+pub struct HelperVisitor {
+    name: Ident,
+    functions: Vec<TokenStream2>,
+}
+
+impl HelperVisitor {
+    pub fn new(name: &Ident) -> Self {
+        Self {
+            name: name.clone(),
+            functions: Vec::new(),
+        }
+    }
+
+    fn make_function(name: &Ident, segment: &PathSegment) -> TokenStream2 {
+        let concat = format!("set_{}", name);
+        let concat = Ident::new(&concat, name.span());
+        quote! {
+            pub fn #concat(&mut self, mut #name: #segment) -> #segment {
+                use std::mem::swap;
+                swap(&mut self.#name, &mut #name);
+                #name
+            }
+        }
+    }
+
+    pub fn make_block(&self) -> TokenStream2 {
+        utils::make_block(&self.name, &self.functions)
+    }
+}
+
+impl<'a> Visit<'a> for HelperVisitor {
+    fn visit_field(&mut self, field: &'a Field) {
+        if field.attrs.iter().any(utils::is_context) {
+            if let Some(name) = &field.ident {
+                if let Some(segment) = utils::get_type(field) {
+                    self.functions.push(Self::make_function(name, segment));
+                }
+            }
+        }
+    }
+}

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -1,0 +1,27 @@
+mod helper;
+mod manager;
+mod utils;
+
+use crate::helper::HelperVisitor;
+use crate::manager::ManagerVisitor;
+use proc_macro::TokenStream;
+use syn::visit::Visit;
+use syn::*;
+
+#[proc_macro_derive(ContextManager, attributes(context))]
+pub fn context_manager(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemStruct);
+    let mut visitor = ManagerVisitor::new(&input.ident);
+    visitor.visit_item_struct(&input);
+    let output = visitor.make_block();
+    TokenStream::from(output)
+}
+
+#[proc_macro_derive(ContextHelper, attributes(context))]
+pub fn context_helper(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemStruct);
+    let mut visitor = HelperVisitor::new(&input.ident);
+    visitor.visit_item_struct(&input);
+    let output = visitor.make_block();
+    TokenStream::from(output)
+}

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -8,10 +8,80 @@ use proc_macro::TokenStream;
 use syn::visit::Visit;
 use syn::*;
 
-/// To add context manager functions to a struct, annotate the struct
-/// itself with `#[derive(ContextManager)`, and required fields with
-/// `#[context]`.  Creates three functions `with_foo()`, `with_foo_ref()`
-/// and `with_foo_fn()`.
+/// Derive macro `ContextManager` allows changes to be made to annotated
+/// fields on a struct, with automatic reset on early error return.
+///
+/// In this example, we change some settings on an object, and rely on
+/// the context manager to reset those settings when it fails.  The macro
+/// creates three functions for each annotated field in the `Amplifier`
+/// struct, and we call the following ones here:
+///
+/// * Function `Amplifier::with_panel_ref()` swaps the existing `panel`
+///   field on the `Amplifier` object, passes the `Amplifier` object to
+///   the lambda by mutable reference, swaps the old `panel` field on
+///   exit, and returns the result.
+///
+/// * Function `Amplifier::with_power()` sets the `power` field on the
+///   `Amplifier` object, and resets the old value on exit.  Requires
+///   the field being modified to implement the `Copy` and `Clone` traits.
+///
+/// * Function `Amplifier::with_panel_fn()` sets the `volume` field on
+///   the encapsulated `Panel` object, by calling its setter function
+///   `Panel::set_volume()`, and resets the old value on exit.  Note,
+///   the setter function is created by derive macro `ContextHelper`.
+///
+/// ```rust
+/// use amber_meta::{ContextHelper, ContextManager};
+///
+/// #[derive(ContextManager)]
+/// struct Amplifier {
+///     #[context]
+///     power: bool,
+///     #[context]
+///     panel: Panel,
+/// }
+///
+/// #[derive(ContextHelper)]
+/// struct Panel {
+///     #[context]
+///     started: bool,
+///     #[context]
+///     volume: u8,
+///     display: Option<String>,
+/// }
+///
+/// impl Panel {
+///     fn new() -> Panel {
+///         Panel { started: false, volume: 0, display: None }
+///     }
+/// }
+///
+/// fn demo_amplifier(amp: &mut Amplifier) -> Result<(), String> {
+///     // Install a new control panel.
+///     let mut panel = Panel::new();
+///     amp.with_panel_ref(&mut panel, |amp| {
+///         // Turn the power on.
+///         amp.with_power(true, |amp| {
+///             // Set the volume to 11.
+///             amp.with_panel_fn(Panel::set_volume, 11, |amp| {
+///                 // Strum a guitar chord.
+///                 play_guitar(amp)?;
+///                 Ok(())
+///             })?;
+///             // Reset the volume on exit.
+///             Ok(())
+///         })?;
+///         // Turn the power off on exit.
+///         Ok(())
+///     })?;
+///     // Reinstall the old control panel on exit.
+///     Ok(())
+/// }
+///
+/// fn play_guitar(amp: &Amplifier) -> Result<(), String> {
+///     Err(String::from("Blown fuse"))
+/// }
+/// ```
 #[proc_macro_derive(ContextManager, attributes(context))]
 pub fn context_manager(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
@@ -21,9 +91,9 @@ pub fn context_manager(input: TokenStream) -> TokenStream {
     TokenStream::from(output)
 }
 
-/// To add setter functions designed to work with `with_foo_fn()` (see
-/// above), annotate the struct itself with `#[derive(ContextHelper)`,
-/// and required fields with `#[context]`.
+/// Derive macro `ContextHelper` provides support functions for use with
+/// context functions created by `ContextManager`; for more information,
+/// see documentation for that macro.
 #[proc_macro_derive(ContextHelper, attributes(context))]
 pub fn context_helper(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -8,6 +8,10 @@ use proc_macro::TokenStream;
 use syn::visit::Visit;
 use syn::*;
 
+/// To add context manager functions to a struct, annotate the struct
+/// itself with `#[derive(ContextManager)`, and required fields with
+/// `#[context]`.  Creates three functions `with_foo()`, `with_foo_ref()`
+/// and `with_foo_fn()`.
 #[proc_macro_derive(ContextManager, attributes(context))]
 pub fn context_manager(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
@@ -17,6 +21,9 @@ pub fn context_manager(input: TokenStream) -> TokenStream {
     TokenStream::from(output)
 }
 
+/// To add setter functions designed to work with `with_foo_fn()` (see
+/// above), annotate the struct itself with `#[derive(ContextHelper)`,
+/// and required fields with `#[context]`.
 #[proc_macro_derive(ContextHelper, attributes(context))]
 pub fn context_helper(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -37,6 +37,8 @@ use syn::*;
 /// struct Amplifier {
 ///     #[context]
 ///     power: bool,
+///     input: f64,
+///     output: f64,
 ///     #[context]
 ///     panel: Panel,
 /// }
@@ -44,15 +46,13 @@ use syn::*;
 /// #[derive(ContextHelper)]
 /// struct Panel {
 ///     #[context]
-///     started: bool,
-///     #[context]
 ///     volume: u8,
 ///     display: Option<String>,
 /// }
 ///
 /// impl Panel {
 ///     fn new() -> Panel {
-///         Panel { started: false, volume: 0, display: None }
+///         Panel { volume: 0, display: None }
 ///     }
 /// }
 ///

--- a/meta/src/manager.rs
+++ b/meta/src/manager.rs
@@ -21,8 +21,8 @@ impl ManagerVisitor {
         let concat = format!("with_{}", name);
         let concat = Ident::new(&concat, name.span());
         quote! {
-            /// Sets the field value (which must implement the Copy and
-            /// Clone traits) and restores the previous value after the
+            /// Sets the field value (which must implement the `Copy` and
+            /// `Clone` traits) and restores the previous value after the
             /// body function has returned.
             pub fn #concat<T, E, B>(&mut self, #name: #segment, mut body: B) -> Result<T, E>
             where

--- a/meta/src/manager.rs
+++ b/meta/src/manager.rs
@@ -65,6 +65,11 @@ impl ManagerVisitor {
             /// Sets the field value on the encapsulated struct using
             /// its member function, and restores the previous value
             /// after the body function has returned.
+            ///
+            /// Additionally, to add setter functions designed to work
+            /// with `with_foo_fn()`, annotate the encapsulated struct
+            /// with `#[derive(ContextHelper)`, and required fields with
+            /// `#[context]`.
             pub fn #concat<V, S, B>(&mut self, mut setter: S, value: V, mut body: B) -> SyntaxResult
             where
                 S: FnMut(&mut #segment, V) -> V,

--- a/meta/src/manager.rs
+++ b/meta/src/manager.rs
@@ -1,0 +1,89 @@
+use crate::utils;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::visit::Visit;
+use syn::{Field, Ident, PathSegment};
+
+pub struct ManagerVisitor {
+    name: Ident,
+    functions: Vec<TokenStream2>,
+}
+
+impl ManagerVisitor {
+    pub fn new(name: &Ident) -> Self {
+        Self {
+            name: name.clone(),
+            functions: Vec::new(),
+        }
+    }
+
+    fn make_with(name: &Ident, segment: &PathSegment) -> TokenStream2 {
+        let concat = format!("with_{}", name);
+        let concat = Ident::new(&concat, name.span());
+        quote! {
+            pub fn #concat<B>(&mut self, #name: #segment, mut body: B) -> SyntaxResult
+            where
+                B: FnMut(&mut Self) -> SyntaxResult,
+            {
+                // Native types are implicitly copied on clone.
+                let prev = self.#name.clone();
+                self.#name = #name;
+                let result = body(self);
+                self.#name = prev;
+                result
+            }
+        }
+    }
+
+    fn make_with_ref(name: &Ident, segment: &PathSegment) -> TokenStream2 {
+        let concat = format!("with_{}_ref", name);
+        let concat = Ident::new(&concat, name.span());
+        quote! {
+            pub fn #concat<B>(&mut self, #name: &mut #segment, mut body: B) -> SyntaxResult
+            where
+                B: FnMut(&mut Self) -> SyntaxResult,
+            {
+                use std::mem::swap;
+                swap(&mut self.#name, #name);
+                let result = body(self);
+                swap(&mut self.#name, #name);
+                result
+            }
+        }
+    }
+
+    fn make_with_fn(name: &Ident, segment: &PathSegment) -> TokenStream2 {
+        let concat = format!("with_{}_fn", name);
+        let concat = Ident::new(&concat, name.span());
+        quote! {
+            pub fn #concat<V, S, B>(&mut self, mut setter: S, value: V, mut body: B) -> SyntaxResult
+            where
+                S: FnMut(&mut #segment, V) -> V,
+                B: FnMut(&mut Self) -> SyntaxResult,
+            {
+                let prev = setter(&mut self.#name, value);
+                let result = body(self);
+                setter(&mut self.#name, prev);
+                result
+            }
+        }
+    }
+
+    pub fn make_block(&self) -> TokenStream2 {
+        utils::make_block(&self.name, &self.functions)
+    }
+}
+
+impl<'a> Visit<'a> for ManagerVisitor {
+    fn visit_field(&mut self, field: &'a Field) {
+        if field.attrs.iter().any(utils::is_context) {
+            if let Some(name) = &field.ident {
+                if let Some(segment) = utils::get_type(field) {
+                    self.functions.push(Self::make_with(name, segment));
+                    self.functions.push(Self::make_with_ref(name, segment));
+                    self.functions.push(Self::make_with_fn(name, segment));
+                }
+            }
+        }
+    }
+}

--- a/meta/src/manager.rs
+++ b/meta/src/manager.rs
@@ -21,6 +21,9 @@ impl ManagerVisitor {
         let concat = format!("with_{}", name);
         let concat = Ident::new(&concat, name.span());
         quote! {
+            /// Sets the field value (which must implement the Copy and
+            /// Clone traits) and restores the previous value after the
+            /// body function has returned.
             pub fn #concat<B>(&mut self, #name: #segment, mut body: B) -> SyntaxResult
             where
                 B: FnMut(&mut Self) -> SyntaxResult,
@@ -39,6 +42,9 @@ impl ManagerVisitor {
         let concat = format!("with_{}_ref", name);
         let concat = Ident::new(&concat, name.span());
         quote! {
+            /// Sets the field value by swapping the references, and
+            /// restores the previous value after the body function has
+            /// returned.
             pub fn #concat<B>(&mut self, #name: &mut #segment, mut body: B) -> SyntaxResult
             where
                 B: FnMut(&mut Self) -> SyntaxResult,
@@ -56,6 +62,9 @@ impl ManagerVisitor {
         let concat = format!("with_{}_fn", name);
         let concat = Ident::new(&concat, name.span());
         quote! {
+            /// Sets the field value on the encapsulated struct using
+            /// its member function, and restores the previous value
+            /// after the body function has returned.
             pub fn #concat<V, S, B>(&mut self, mut setter: S, value: V, mut body: B) -> SyntaxResult
             where
                 S: FnMut(&mut #segment, V) -> V,

--- a/meta/src/manager.rs
+++ b/meta/src/manager.rs
@@ -24,9 +24,9 @@ impl ManagerVisitor {
             /// Sets the field value (which must implement the Copy and
             /// Clone traits) and restores the previous value after the
             /// body function has returned.
-            pub fn #concat<B>(&mut self, #name: #segment, mut body: B) -> SyntaxResult
+            pub fn #concat<T, E, B>(&mut self, #name: #segment, mut body: B) -> Result<T, E>
             where
-                B: FnMut(&mut Self) -> SyntaxResult,
+                B: FnMut(&mut Self) -> Result<T, E>,
             {
                 // Native types are implicitly copied on clone.
                 let prev = self.#name.clone();
@@ -45,9 +45,9 @@ impl ManagerVisitor {
             /// Sets the field value by swapping the references, and
             /// restores the previous value after the body function has
             /// returned.
-            pub fn #concat<B>(&mut self, #name: &mut #segment, mut body: B) -> SyntaxResult
+            pub fn #concat<T, E, B>(&mut self, #name: &mut #segment, mut body: B) -> Result<T, E>
             where
-                B: FnMut(&mut Self) -> SyntaxResult,
+                B: FnMut(&mut Self) -> Result<T, E>,
             {
                 use std::mem::swap;
                 swap(&mut self.#name, #name);
@@ -70,10 +70,10 @@ impl ManagerVisitor {
             /// with `with_foo_fn()`, annotate the encapsulated struct
             /// with `#[derive(ContextHelper)`, and required fields with
             /// `#[context]`.
-            pub fn #concat<V, S, B>(&mut self, mut setter: S, value: V, mut body: B) -> SyntaxResult
+            pub fn #concat<V, S, T, E, B>(&mut self, mut setter: S, value: V, mut body: B) -> Result<T, E>
             where
                 S: FnMut(&mut #segment, V) -> V,
-                B: FnMut(&mut Self) -> SyntaxResult,
+                B: FnMut(&mut Self) -> Result<T, E>,
             {
                 let prev = setter(&mut self.#name, value);
                 let result = body(self);

--- a/meta/src/utils.rs
+++ b/meta/src/utils.rs
@@ -18,8 +18,7 @@ pub fn make_block(name: &Ident, functions: &Vec<TokenStream2>) -> TokenStream2 {
 pub fn is_context(attr: &Attribute) -> bool {
     if let Meta::Path(path) = &attr.meta {
         if let Some(segment) = path.segments.last() {
-            let ident = segment.ident.to_string();
-            if ident == "context" {
+            if segment.ident == "context" {
                 return true;
             }
         }

--- a/meta/src/utils.rs
+++ b/meta/src/utils.rs
@@ -1,0 +1,32 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{Attribute, Field, Ident, Meta, PathSegment, Type};
+
+// https://users.rust-lang.org/t/how-to-use-a-vector-of-tokenstreams-created-with-quote-within-quote/81092
+pub fn make_block(name: &Ident, functions: &Vec<TokenStream2>) -> TokenStream2 {
+    quote! {
+        impl #name {
+            #(#functions)*
+        }
+    }
+}
+
+pub fn is_context(attr: &Attribute) -> bool {
+    if let Meta::Path(path) = &attr.meta {
+        if let Some(segment) = path.segments.last() {
+            let ident = segment.ident.to_string();
+            if ident == "context" {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+pub fn get_type(field: &Field) -> Option<&PathSegment> {
+    if let Type::Path(path) = &field.ty {
+        path.path.segments.last()
+    } else {
+        None
+    }
+}

--- a/meta/src/utils.rs
+++ b/meta/src/utils.rs
@@ -2,8 +2,9 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{Attribute, Field, Ident, Meta, PathSegment, Type};
 
-// https://users.rust-lang.org/t/how-to-use-a-vector-of-tokenstreams-created-with-quote-within-quote/81092
+/// Implements multiple functions for a struct implementation block.
 pub fn make_block(name: &Ident, functions: &Vec<TokenStream2>) -> TokenStream2 {
+    // See [https://users.rust-lang.org/t/how-to-use-a-vector-of-tokenstreams-created-with-quote-within-quote/81092].
     quote! {
         impl #name {
             #(#functions)*
@@ -11,6 +12,9 @@ pub fn make_block(name: &Ident, functions: &Vec<TokenStream2>) -> TokenStream2 {
     }
 }
 
+/// Tests whether a given field attribute is `#[context]`, for both
+/// `#[derive(ContextManager)]` and `#[derive(ContextHelper)]` enhanced
+/// structs.
 pub fn is_context(attr: &Attribute) -> bool {
     if let Meta::Path(path) = &attr.meta {
         if let Some(segment) = path.segments.last() {
@@ -23,6 +27,9 @@ pub fn is_context(attr: &Attribute) -> bool {
     false
 }
 
+/// Gets the type of a given field.  Note, we use the `PathSegment` not
+/// the contained `Ident`, because that supports generic field types
+/// like `Option<String>`.
 pub fn get_type(field: &Field) -> Option<&PathSegment> {
     if let Type::Path(path) = &field.ty {
         path.path.segments.last()

--- a/src/modules/block.rs
+++ b/src/modules/block.rs
@@ -35,7 +35,7 @@ impl SyntaxModule<ParserMetadata> for Block {
     }
 
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
-        meta.push_scope(|meta| {
+        meta.with_push_scope(|meta| {
             while let Some(token) = meta.get_current_token() {
                 // Handle the end of line or command
                 if ["\n", ";"].contains(&token.word.as_str()) {

--- a/src/modules/block.rs
+++ b/src/modules/block.rs
@@ -35,28 +35,28 @@ impl SyntaxModule<ParserMetadata> for Block {
     }
 
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
-        meta.push_scope();
-        while let Some(token) = meta.get_current_token() {
-            // Handle the end of line or command
-            if ["\n", ";"].contains(&token.word.as_str()) {
-                meta.increment_index();
-                continue;
-            }
-            // Handle block end
-            else if token.word == "}" {
-                break;
-            }
-            let mut statement = Statement::new();
-            if let Err(failure) = statement.parse(meta) {
-                return match failure {
-                    Failure::Quiet(pos) => error_pos!(meta, pos, "Unexpected token"),
-                    Failure::Loud(err) => return Err(Failure::Loud(err))
+        meta.push_scope(|meta| {
+            while let Some(token) = meta.get_current_token() {
+                // Handle the end of line or command
+                if ["\n", ";"].contains(&token.word.as_str()) {
+                    meta.increment_index();
+                    continue;
                 }
+                // Handle block end
+                else if token.word == "}" {
+                    break;
+                }
+                let mut statement = Statement::new();
+                if let Err(failure) = statement.parse(meta) {
+                    return match failure {
+                        Failure::Quiet(pos) => error_pos!(meta, pos, "Unexpected token"),
+                        Failure::Loud(err) => return Err(Failure::Loud(err))
+                    }
+                }
+                self.statements.push(statement);
             }
-            self.statements.push(statement);
-        }
-        meta.pop_scope();
-        Ok(())
+            Ok(())
+        })
     }
 }
 

--- a/src/modules/formatter.rs
+++ b/src/modules/formatter.rs
@@ -7,7 +7,7 @@ use std::{io::{BufWriter, Write}, process::{Command, Stdio}};
 #[derive(Debug, Clone, Copy)]
 #[allow(non_camel_case_types)]
 pub enum BashFormatter {
-    /// https://github.com/mvdan/sh
+    /// <https://github.com/mvdan/sh>
     shfmt
 }
 

--- a/src/modules/function/invocation_utils.rs
+++ b/src/modules/function/invocation_utils.rs
@@ -51,7 +51,7 @@ fn run_function_with_args(meta: &mut ParserMetadata, mut fun: FunctionDecl, args
     // Swap the contexts to use the function context
     meta.with_context_ref(&mut context, |meta| {
         // Create a sub context for new variables
-        meta.push_scope(|meta| {
+        meta.with_push_scope(|meta| {
             for (kind, name, is_ref) in izip!(args, &fun.arg_names, &fun.arg_refs) {
                 meta.add_param(name, kind.clone(), *is_ref);
             }

--- a/src/modules/function/invocation_utils.rs
+++ b/src/modules/function/invocation_utils.rs
@@ -49,11 +49,8 @@ fn run_function_with_args(meta: &mut ParserMetadata, mut fun: FunctionDecl, args
     }
     let mut ctx = meta.fun_cache.get_context(fun.id).unwrap().clone();
     let mut block = Block::new();
-    let mut binop_border = None;
     // Swap the contexts to use the function context
     swap(&mut ctx, &mut meta.context);
-    // Swap the binop border to clear it
-    swap(&mut binop_border, &mut meta.binop_border);
     // Create a sub context for new variables
     meta.push_scope();
     for (kind, name, is_ref) in izip!(args, &fun.arg_names, &fun.arg_refs) {
@@ -69,8 +66,6 @@ fn run_function_with_args(meta: &mut ParserMetadata, mut fun: FunctionDecl, args
     meta.pop_scope();
     // Restore old context
     swap(&mut ctx, &mut meta.context);
-    // Restore old binop border
-    swap(&mut binop_border, &mut meta.binop_border);
     // Set the new return type or null if nothing was returned
     if let Type::Generic = fun.returns {
         fun.returns = ctx.fun_ret_type.clone().unwrap_or_else(|| Type::Null);

--- a/src/modules/function/invocation_utils.rs
+++ b/src/modules/function/invocation_utils.rs
@@ -1,10 +1,9 @@
-use std::mem::swap;
 use itertools::izip;
 use heraclitus_compiler::prelude::*;
 use similar_string::find_best_similarity;
+use crate::modules::block::Block;
 use crate::modules::types::Type;
 use crate::utils::ParserMetadata;
-use crate::modules::block::Block;
 use crate::utils::context::FunctionDecl;
 
 // Convert a number to an ordinal number
@@ -47,28 +46,28 @@ fn run_function_with_args(meta: &mut ParserMetadata, mut fun: FunctionDecl, args
             }
         }
     }
-    let mut ctx = meta.fun_cache.get_context(fun.id).unwrap().clone();
+    let mut context = meta.fun_cache.get_context(fun.id).unwrap().clone();
     let mut block = Block::new();
     // Swap the contexts to use the function context
-    swap(&mut ctx, &mut meta.context);
-    // Create a sub context for new variables
-    meta.push_scope();
-    for (kind, name, is_ref) in izip!(args, &fun.arg_names, &fun.arg_refs) {
-        meta.add_param(name, kind.clone(), *is_ref);
-    }
-    // Set the expected return type if specified
-    if fun.returns != Type::Generic {
-        meta.context.fun_ret_type = Some(fun.returns.clone());
-    }
-    // Parse the function body
-    syntax(meta, &mut block)?;
-    // Pop function body
-    meta.pop_scope();
-    // Restore old context
-    swap(&mut ctx, &mut meta.context);
+    meta.with_context_ref(&mut context, |meta| {
+        // Create a sub context for new variables
+        meta.push_scope();
+        for (kind, name, is_ref) in izip!(args, &fun.arg_names, &fun.arg_refs) {
+            meta.add_param(name, kind.clone(), *is_ref);
+        }
+        // Set the expected return type if specified
+        if fun.returns != Type::Generic {
+            meta.context.fun_ret_type = Some(fun.returns.clone());
+        }
+        // Parse the function body
+        syntax(meta, &mut block)?;
+        // Pop function body
+        meta.pop_scope();
+        Ok(())
+    })?;
     // Set the new return type or null if nothing was returned
     if let Type::Generic = fun.returns {
-        fun.returns = ctx.fun_ret_type.clone().unwrap_or_else(|| Type::Null);
+        fun.returns = context.fun_ret_type.clone().unwrap_or_else(|| Type::Null);
     };
     // Set the new argument types
     fun.arg_types = args.to_vec();

--- a/src/modules/function/invocation_utils.rs
+++ b/src/modules/function/invocation_utils.rs
@@ -51,18 +51,18 @@ fn run_function_with_args(meta: &mut ParserMetadata, mut fun: FunctionDecl, args
     // Swap the contexts to use the function context
     meta.with_context_ref(&mut context, |meta| {
         // Create a sub context for new variables
-        meta.push_scope();
-        for (kind, name, is_ref) in izip!(args, &fun.arg_names, &fun.arg_refs) {
-            meta.add_param(name, kind.clone(), *is_ref);
-        }
-        // Set the expected return type if specified
-        if fun.returns != Type::Generic {
-            meta.context.fun_ret_type = Some(fun.returns.clone());
-        }
-        // Parse the function body
-        syntax(meta, &mut block)?;
-        // Pop function body
-        meta.pop_scope();
+        meta.push_scope(|meta| {
+            for (kind, name, is_ref) in izip!(args, &fun.arg_names, &fun.arg_refs) {
+                meta.add_param(name, kind.clone(), *is_ref);
+            }
+            // Set the expected return type if specified
+            if fun.returns != Type::Generic {
+                meta.context.fun_ret_type = Some(fun.returns.clone());
+            }
+            // Parse the function body
+            syntax(meta, &mut block)?;
+            Ok(())
+        })?;
         Ok(())
     })?;
     // Set the new return type or null if nothing was returned

--- a/src/modules/loops/iter_loop.rs
+++ b/src/modules/loops/iter_loop.rs
@@ -1,11 +1,10 @@
-use std::mem::swap;
-
 use heraclitus_compiler::prelude::*;
 use crate::docs::module::DocumentationModule;
 use crate::modules::expression::expr::Expr;
 use crate::modules::types::{Typed, Type};
 use crate::modules::variable::variable_name_extensions;
 use crate::translate::module::TranslateModule;
+use crate::utils::context::Context;
 use crate::utils::metadata::{ParserMetadata, TranslateMetadata};
 use crate::modules::block::Block;
 
@@ -55,13 +54,12 @@ impl SyntaxModule<ParserMetadata> for IterLoop {
                 meta.add_var(index, Type::Num);
             }
             // Save loop context state and set it to true
-            let mut new_is_loop_ctx = true;
-            swap(&mut new_is_loop_ctx, &mut meta.context.is_loop_ctx);
-            // Parse loop
-            syntax(meta, &mut self.block)?;
-            token(meta, "}")?;
-            // Restore loop context state
-            swap(&mut new_is_loop_ctx, &mut meta.context.is_loop_ctx);
+            meta.with_context_fn(Context::set_is_loop_ctx, true, |meta| {
+                // Parse loop
+                syntax(meta, &mut self.block)?;
+                token(meta, "}")?;
+                Ok(())
+            })?;
             meta.pop_scope();
             Ok(())
         }, |pos| {

--- a/src/modules/loops/iter_loop.rs
+++ b/src/modules/loops/iter_loop.rs
@@ -48,7 +48,7 @@ impl SyntaxModule<ParserMetadata> for IterLoop {
             };
             token(meta, "{")?;
             // Create iterator variable
-            meta.push_scope(|meta| {
+            meta.with_push_scope(|meta| {
                 meta.add_var(&self.iter_name, self.iter_type.clone());
                 if let Some(index) = self.iter_index.as_ref() {
                     meta.add_var(index, Type::Num);

--- a/src/modules/loops/iter_loop.rs
+++ b/src/modules/loops/iter_loop.rs
@@ -48,19 +48,20 @@ impl SyntaxModule<ParserMetadata> for IterLoop {
             };
             token(meta, "{")?;
             // Create iterator variable
-            meta.push_scope();
-            meta.add_var(&self.iter_name, self.iter_type.clone());
-            if let Some(index) = self.iter_index.as_ref() {
-                meta.add_var(index, Type::Num);
-            }
-            // Save loop context state and set it to true
-            meta.with_context_fn(Context::set_is_loop_ctx, true, |meta| {
-                // Parse loop
-                syntax(meta, &mut self.block)?;
-                token(meta, "}")?;
+            meta.push_scope(|meta| {
+                meta.add_var(&self.iter_name, self.iter_type.clone());
+                if let Some(index) = self.iter_index.as_ref() {
+                    meta.add_var(index, Type::Num);
+                }
+                // Save loop context state and set it to true
+                meta.with_context_fn(Context::set_is_loop_ctx, true, |meta| {
+                    // Parse loop
+                    syntax(meta, &mut self.block)?;
+                    token(meta, "}")?;
+                    Ok(())
+                })?;
                 Ok(())
             })?;
-            meta.pop_scope();
             Ok(())
         }, |pos| {
             error_pos!(meta, pos, "Syntax error in loop")

--- a/src/modules/main.rs
+++ b/src/modules/main.rs
@@ -44,15 +44,15 @@ impl SyntaxModule<ParserMetadata> for Main {
             }
             token(meta, "{")?;
             // Create a new scope for variables
-            meta.push_scope();
-            // Create variables
-            for arg in self.args.iter() {
-                meta.add_var(arg, Type::Array(Box::new(Type::Text)));
-            }
-            // Parse the block
-            syntax(meta, &mut self.block)?;
-            // Remove the scope made for variables
-            meta.pop_scope();
+            meta.push_scope(|meta| {
+                // Create variables
+                for arg in self.args.iter() {
+                    meta.add_var(arg, Type::Array(Box::new(Type::Text)));
+                }
+                // Parse the block
+                syntax(meta, &mut self.block)?;
+                Ok(())
+            })?;
             token(meta, "}")?;
             meta.context.is_main_ctx = false;
             Ok(())

--- a/src/modules/main.rs
+++ b/src/modules/main.rs
@@ -44,7 +44,7 @@ impl SyntaxModule<ParserMetadata> for Main {
             }
             token(meta, "{")?;
             // Create a new scope for variables
-            meta.push_scope(|meta| {
+            meta.with_push_scope(|meta| {
                 // Create variables
                 for arg in self.args.iter() {
                     meta.add_var(arg, Type::Array(Box::new(Type::Text)));

--- a/src/utils/context.rs
+++ b/src/utils/context.rs
@@ -1,9 +1,9 @@
+use super::{cc_flags::CCFlags, function_interface::FunctionInterface};
 use crate::modules::expression::expr::Expr;
 use crate::modules::types::Type;
+use amber_meta::ContextHelper;
 use heraclitus_compiler::prelude::*;
 use std::collections::{HashMap, HashSet};
-
-use super::{cc_flags::CCFlags, function_interface::FunctionInterface};
 
 #[derive(Clone, Debug)]
 pub struct FunctionDecl {
@@ -94,7 +94,7 @@ impl ScopeUnit {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, ContextHelper)]
 pub struct Context {
     /// The current index in the expression
     pub index: usize,
@@ -109,6 +109,7 @@ pub struct Context {
     /// Determines if the context is in a function
     pub is_fun_ctx: bool,
     /// Determines if the context is in a loop
+    #[context]
     pub is_loop_ctx: bool,
     /// Determines if the context is in the main block
     pub is_main_ctx: bool,
@@ -119,6 +120,7 @@ pub struct Context {
     /// The return type of the currently parsed function
     pub fun_ret_type: Option<Type>,
     /// List of compiler flags
+    #[context]
     pub cc_flags: HashSet<CCFlags>,
 }
 

--- a/src/utils/metadata/parser.rs
+++ b/src/utils/metadata/parser.rs
@@ -12,8 +12,6 @@ use crate::utils::function_cache::FunctionCache;
 pub struct ParserMetadata {
     /// Code if the parser is in eval mode
     pub eval_code: Option<String>,
-    /// Determines where the binary operator should end
-    pub binop_border: Option<usize>,
     /// Used for debugging by Heraclitus
     pub debug: Option<usize>,
     /// Cache of already imported modules
@@ -162,7 +160,6 @@ impl Metadata for ParserMetadata {
     fn new(tokens: Vec<Token>, path: Option<String>, code: Option<String>) -> Self {
         ParserMetadata {
             eval_code: code,
-            binop_border: None,
             debug: None,
             import_cache: ImportCache::new(path.clone()),
             fun_cache: FunctionCache::new(),

--- a/src/utils/metadata/parser.rs
+++ b/src/utils/metadata/parser.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use heraclitus_compiler::prelude::*;
+use amber_meta::ContextManager;
 use crate::modules::block::Block;
 use crate::modules::types::Type;
 use crate::utils::context::{Context, ScopeUnit, VariableDecl, FunctionDecl};
@@ -8,7 +9,7 @@ use crate::utils::function_interface::FunctionInterface;
 use crate::utils::import_cache::ImportCache;
 use crate::utils::function_cache::FunctionCache;
 
-#[derive(Debug)]
+#[derive(Debug, ContextManager)]
 pub struct ParserMetadata {
     /// Code if the parser is in eval mode
     pub eval_code: Option<String>,
@@ -23,6 +24,7 @@ pub struct ParserMetadata {
     /// Global variable id
     pub var_id: usize,
     /// Context of the parser
+    #[context]
     pub context: Context,
     /// List of all failure messages
     pub messages: Vec<Message>,

--- a/src/utils/metadata/parser.rs
+++ b/src/utils/metadata/parser.rs
@@ -48,13 +48,14 @@ impl ParserMetadata {
     }
 
     /// Pushes a new scope to the stack
-    pub fn push_scope(&mut self) {
-        self.context.scopes.push(ScopeUnit::new())
-    }
-
-    /// Pops the last scope from the stack
-    pub fn pop_scope(&mut self) -> Option<ScopeUnit> {
-        self.context.scopes.pop()
+    pub fn push_scope<B>(&mut self, mut body: B) -> SyntaxResult
+    where
+        B: FnMut(&mut Self) -> SyntaxResult
+    {
+        self.context.scopes.push(ScopeUnit::new());
+        let result = body(self);
+        self.context.scopes.pop();
+        result
     }
 
     /* Variables */

--- a/src/utils/metadata/parser.rs
+++ b/src/utils/metadata/parser.rs
@@ -174,8 +174,8 @@ impl Metadata for ParserMetadata {
         }
     }
 
-    fn get_trace(&self) -> Vec<PositionInfo> {
-        self.context.trace.clone()
+    fn get_token_at(&self, index: usize) -> Option<Token> {
+        self.context.expr.get(index).cloned()
     }
 
     fn get_index(&self) -> usize {
@@ -186,10 +186,6 @@ impl Metadata for ParserMetadata {
         self.context.index = index
     }
 
-    fn get_token_at(&self, index: usize) -> Option<Token> {
-        self.context.expr.get(index).cloned()
-    }
-
     fn get_debug(&mut self) -> Option<usize> {
         self.debug
     }
@@ -198,11 +194,15 @@ impl Metadata for ParserMetadata {
         self.debug = Some(indent)
     }
 
+    fn get_path(&self) -> Option<String> {
+        self.context.path.clone()
+    }
+
     fn get_code(&self) -> Option<&String> {
         self.eval_code.as_ref()
     }
 
-    fn get_path(&self) -> Option<String> {
-        self.context.path.clone()
+    fn get_trace(&self) -> Vec<PositionInfo> {
+        self.context.trace.clone()
     }
 }

--- a/src/utils/metadata/parser.rs
+++ b/src/utils/metadata/parser.rs
@@ -48,7 +48,7 @@ impl ParserMetadata {
     }
 
     /// Pushes a new scope to the stack
-    pub fn push_scope<B>(&mut self, mut body: B) -> SyntaxResult
+    pub fn with_push_scope<B>(&mut self, mut body: B) -> SyntaxResult
     where
         B: FnMut(&mut Self) -> SyntaxResult
     {


### PR DESCRIPTION
Fixes bug #489, by using a procedural macro to generate context manager functions, wrapping syntax parser failure.  Also pops scope from the scope stack on syntax parser failure.