### PR TITLE
Implement standard library glob function

### DIFF
--- a/src/std/fs.ab
+++ b/src/std/fs.ab
@@ -1,3 +1,5 @@
+import { join, len, replace_regex, split } from "std/text"
+
 /// Checks if a directory exists.
 pub fun dir_exist(path) {
     $[ -d "{path}" ]$ failed {
@@ -40,7 +42,6 @@ pub fun create_symbolic_link(origin: Text, destination: Text): Bool {
         trust $ln -s "{origin}" "{destination}"$
         return true
     }
-
     echo "The file {origin} doesn't exist!"
     return false
 }
@@ -60,7 +61,6 @@ pub fun make_executable(path: Text): Bool {
         trust $chmod +x "{path}"$
         return true
     }
-
     echo "The file {path} doesn't exist!"
     return false
 }
@@ -73,6 +73,35 @@ pub fun change_owner(user: Text, path: Text): Bool {
         trust $chown -R "{user}" "{path}"$
         return true
     }
-
     return false
+}
+
+/// Escapes all characters in the passed-in glob except "*", "?" and "/",
+/// to prevent injection attacks.
+fun escape_non_glob_chars(path: Text): Text {
+    return replace_regex(path, "\([^*?/]\)", "\\\\\1")
+}
+
+/// Finds all files or directories matching multiple file globs. When
+/// we have union types, this functionality can be merged into the main
+/// `glob` function.
+pub fun glob_multiple(paths: [Text]): [Text]? {
+    let combined = ""
+    if len(paths) == 1 {
+        combined = escape_non_glob_chars(paths[0])
+    } else {
+        let items = [Text]
+        loop item in paths {
+            item = escape_non_glob_chars(item)
+            items += [item]
+        }
+        combined = join(items, " ")
+    }
+    let files = $eval "for file in {combined}; do [ -e \\\"\\\$file\\\" ] && echo \\\"\\\$file\\\"; done"$?
+    return split(files, "\n")
+}
+
+/// Finds all files or directories matching a file glob.
+pub fun glob(path: Text): [Text]? {
+    return glob_multiple([path])?
 }

--- a/src/std/fs.ab
+++ b/src/std/fs.ab
@@ -42,6 +42,7 @@ pub fun create_symbolic_link(origin: Text, destination: Text): Bool {
         trust $ln -s "{origin}" "{destination}"$
         return true
     }
+
     echo "The file {origin} doesn't exist!"
     return false
 }
@@ -61,6 +62,7 @@ pub fun make_executable(path: Text): Bool {
         trust $chmod +x "{path}"$
         return true
     }
+
     echo "The file {path} doesn't exist!"
     return false
 }
@@ -73,6 +75,7 @@ pub fun change_owner(user: Text, path: Text): Bool {
         trust $chown -R "{user}" "{path}"$
         return true
     }
+
     return false
 }
 

--- a/src/tests/stdlib/create_symbolic_link.ab
+++ b/src/tests/stdlib/create_symbolic_link.ab
@@ -7,5 +7,5 @@ main {
     } else {
         echo "failed"
     }
-    trust $rm {tmpdir}$
+    trust $rm -fr {tmpdir}$
 } 

--- a/src/tests/stdlib/glob_absolute_missing_file.ab
+++ b/src/tests/stdlib/glob_absolute_missing_file.ab
@@ -1,0 +1,26 @@
+import * from "std/fs"
+
+// Output
+// FAILED
+
+main {
+    let tmpdir = trust $ mktemp -d $
+    trust {
+        $ touch {tmpdir}/1st\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/2nd\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/file.txt $
+        $ touch {tmpdir}/file1.txt $
+        $ touch {tmpdir}/file2.txt $
+        $ touch {tmpdir}/file99.txt $
+        $ touch {tmpdir}/other.csv $
+    }
+
+    let files = glob("{tmpdir}/missing*") failed {
+        echo "FAILED"
+    }
+    loop file in files {
+        echo "[{file}]"
+    }
+
+    trust $ rm -rf {tmpdir} $
+}

--- a/src/tests/stdlib/glob_absolute_multiple_globs.ab
+++ b/src/tests/stdlib/glob_absolute_multiple_globs.ab
@@ -26,7 +26,13 @@ main {
         $ touch {tmpdir}/other.csv $
     }
 
-    let expected = ["{tmpdir}/file.txt", "{tmpdir}/file1.txt", "{tmpdir}/file2.txt", "{tmpdir}/file99.txt", "{tmpdir}/other.csv"]
+    let expected = [
+        "{tmpdir}/file.txt",
+        "{tmpdir}/file1.txt",
+        "{tmpdir}/file2.txt",
+        "{tmpdir}/file99.txt",
+        "{tmpdir}/other.csv",
+    ]
     let actual = glob_multiple(["{tmpdir}/missing*", "{tmpdir}/file*.txt", "{tmpdir}/other*.csv"]) failed {
         echo "FAILED"
     }

--- a/src/tests/stdlib/glob_absolute_multiple_globs.ab
+++ b/src/tests/stdlib/glob_absolute_multiple_globs.ab
@@ -1,0 +1,41 @@
+import * from "std/array"
+import * from "std/fs"
+import * from "std/text"
+
+fun compare(actual: [Text], expected: [Text]): Bool {
+    if len(actual) != len(expected) {
+        return false
+    }
+    loop file in expected {
+        if not includes(actual, file) {
+            return false
+        }
+    }
+    return true
+}
+
+main {
+    let tmpdir = trust $ mktemp -d $
+    trust {
+        $ touch {tmpdir}/1st\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/2nd\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/file.txt $
+        $ touch {tmpdir}/file1.txt $
+        $ touch {tmpdir}/file2.txt $
+        $ touch {tmpdir}/file99.txt $
+        $ touch {tmpdir}/other.csv $
+    }
+
+    let expected = ["{tmpdir}/file.txt", "{tmpdir}/file1.txt", "{tmpdir}/file2.txt", "{tmpdir}/file99.txt", "{tmpdir}/other.csv"]
+    let actual = glob_multiple(["{tmpdir}/missing*", "{tmpdir}/file*.txt", "{tmpdir}/other*.csv"]) failed {
+        echo "FAILED"
+    }
+    if compare(actual, expected) {
+        echo "Succeded"
+    } else {
+        echo "Expected: {expected}"
+        echo "Actual: {actual}"
+    }
+
+    trust $ rm -rf {tmpdir} $
+}

--- a/src/tests/stdlib/glob_absolute_wild_char.ab
+++ b/src/tests/stdlib/glob_absolute_wild_char.ab
@@ -1,0 +1,41 @@
+import * from "std/array"
+import * from "std/fs"
+import * from "std/text"
+
+fun compare(actual: [Text], expected: [Text]): Bool {
+    if len(actual) != len(expected) {
+        return false
+    }
+    loop file in expected {
+        if not includes(actual, file) {
+            return false
+        }
+    }
+    return true
+}
+
+main {
+    let tmpdir = trust $ mktemp -d $
+    trust {
+        $ touch {tmpdir}/1st\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/2nd\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/file.txt $
+        $ touch {tmpdir}/file1.txt $
+        $ touch {tmpdir}/file2.txt $
+        $ touch {tmpdir}/file99.txt $
+        $ touch {tmpdir}/other.csv $
+    }
+
+    let expected = ["{tmpdir}/file1.txt", "{tmpdir}/file2.txt"]
+    let actual = glob("{tmpdir}/file?.txt") failed {
+        echo "FAILED"
+    }
+    if compare(actual, expected) {
+        echo "Succeded"
+    } else {
+        echo "Expected: {expected}"
+        echo "Actual: {actual}"
+    }
+
+    trust $ rm -rf {tmpdir} $
+}

--- a/src/tests/stdlib/glob_absolute_wild_char.ab
+++ b/src/tests/stdlib/glob_absolute_wild_char.ab
@@ -26,7 +26,10 @@ main {
         $ touch {tmpdir}/other.csv $
     }
 
-    let expected = ["{tmpdir}/file1.txt", "{tmpdir}/file2.txt"]
+    let expected = [
+        "{tmpdir}/file1.txt",
+        "{tmpdir}/file2.txt",
+    ]
     let actual = glob("{tmpdir}/file?.txt") failed {
         echo "FAILED"
     }

--- a/src/tests/stdlib/glob_absolute_wild_star.ab
+++ b/src/tests/stdlib/glob_absolute_wild_star.ab
@@ -1,0 +1,41 @@
+import * from "std/array"
+import * from "std/fs"
+import * from "std/text"
+
+fun compare(actual: [Text], expected: [Text]): Bool {
+    if len(actual) != len(expected) {
+        return false
+    }
+    loop file in expected {
+        if not includes(actual, file) {
+            return false
+        }
+    }
+    return true
+}
+
+main {
+    let tmpdir = trust $ mktemp -d $
+    trust {
+        $ touch {tmpdir}/1st\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/2nd\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/file.txt $
+        $ touch {tmpdir}/file1.txt $
+        $ touch {tmpdir}/file2.txt $
+        $ touch {tmpdir}/file99.txt $
+        $ touch {tmpdir}/other.csv $
+    }
+
+    let expected = ["{tmpdir}/file.txt", "{tmpdir}/file1.txt", "{tmpdir}/file2.txt", "{tmpdir}/file99.txt"]
+    let actual = glob("{tmpdir}/file*.txt") failed {
+        echo "FAILED"
+    }
+    if compare(actual, expected) {
+        echo "Succeded"
+    } else {
+        echo "Expected: {expected}"
+        echo "Actual: {actual}"
+    }
+
+    trust $ rm -rf {tmpdir} $
+}

--- a/src/tests/stdlib/glob_absolute_wild_star.ab
+++ b/src/tests/stdlib/glob_absolute_wild_star.ab
@@ -26,7 +26,12 @@ main {
         $ touch {tmpdir}/other.csv $
     }
 
-    let expected = ["{tmpdir}/file.txt", "{tmpdir}/file1.txt", "{tmpdir}/file2.txt", "{tmpdir}/file99.txt"]
+    let expected = [
+        "{tmpdir}/file.txt",
+        "{tmpdir}/file1.txt",
+        "{tmpdir}/file2.txt",
+        "{tmpdir}/file99.txt",
+    ]
     let actual = glob("{tmpdir}/file*.txt") failed {
         echo "FAILED"
     }

--- a/src/tests/stdlib/glob_absolute_with_spaces.ab
+++ b/src/tests/stdlib/glob_absolute_with_spaces.ab
@@ -1,0 +1,41 @@
+import * from "std/array"
+import * from "std/fs"
+import * from "std/text"
+
+fun compare(actual: [Text], expected: [Text]): Bool {
+    if len(actual) != len(expected) {
+        return false
+    }
+    loop file in expected {
+        if not includes(actual, file) {
+            return false
+        }
+    }
+    return true
+}
+
+main {
+    let tmpdir = trust $ mktemp -d $
+    trust {
+        $ touch {tmpdir}/1st\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/2nd\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/file.txt $
+        $ touch {tmpdir}/file1.txt $
+        $ touch {tmpdir}/file2.txt $
+        $ touch {tmpdir}/file99.txt $
+        $ touch {tmpdir}/other.csv $
+    }
+
+    let expected = ["{tmpdir}/1st file with spaces.txt", "{tmpdir}/2nd file with spaces.txt"]
+    let actual = glob("{tmpdir}/*with spaces*") failed {
+        echo "FAILED"
+    }
+    if compare(actual, expected) {
+        echo "Succeded"
+    } else {
+        echo "Expected: {expected}"
+        echo "Actual: {actual}"
+    }
+
+    trust $ rm -rf {tmpdir} $
+}

--- a/src/tests/stdlib/glob_absolute_with_spaces.ab
+++ b/src/tests/stdlib/glob_absolute_with_spaces.ab
@@ -26,7 +26,10 @@ main {
         $ touch {tmpdir}/other.csv $
     }
 
-    let expected = ["{tmpdir}/1st file with spaces.txt", "{tmpdir}/2nd file with spaces.txt"]
+    let expected = [
+        "{tmpdir}/1st file with spaces.txt",
+        "{tmpdir}/2nd file with spaces.txt",
+    ]
     let actual = glob("{tmpdir}/*with spaces*") failed {
         echo "FAILED"
     }

--- a/src/tests/stdlib/glob_injection_attack.ab
+++ b/src/tests/stdlib/glob_injection_attack.ab
@@ -1,0 +1,25 @@
+import * from "std/fs"
+
+// Output
+// [xxx; do echo HACKED; done; for file in]
+
+main {
+    let tmpdir = trust $ mktemp -d $
+    trust {
+        $ touch "{tmpdir}/xxx; do echo HACKED; done; for file in" $
+    }
+    cd tmpdir
+
+    // The glob function escapes all characters in the passed-in glob
+    // apart from "*", "?" and "/", to prevent injection attacks.  If we
+    // didn't do this, the following code would output "[HACKED]" instead
+    // of the filename.
+    let files = glob("xxx; do echo HACKED; done; for file in") failed {
+        echo "FAILED"
+    }
+    loop file in files {
+        echo "[{file}]"
+    }
+
+    trust $ rm -rf {tmpdir} $
+}

--- a/src/tests/stdlib/glob_relative_missing_file.ab
+++ b/src/tests/stdlib/glob_relative_missing_file.ab
@@ -1,0 +1,27 @@
+import * from "std/fs"
+
+// Output
+// FAILED
+
+main {
+    let tmpdir = trust $ mktemp -d $
+    trust {
+        $ touch {tmpdir}/1st\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/2nd\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/file.txt $
+        $ touch {tmpdir}/file1.txt $
+        $ touch {tmpdir}/file2.txt $
+        $ touch {tmpdir}/file99.txt $
+        $ touch {tmpdir}/other.csv $
+    }
+    cd tmpdir
+
+    let files = glob("missing*") failed {
+        echo "FAILED"
+    }
+    loop file in files {
+        echo "[{file}]"
+    }
+
+    trust $ rm -rf {tmpdir} $
+}

--- a/src/tests/stdlib/glob_relative_multiple_globs.ab
+++ b/src/tests/stdlib/glob_relative_multiple_globs.ab
@@ -27,7 +27,13 @@ main {
     }
     cd tmpdir
 
-    let expected = ["file.txt", "file1.txt", "file2.txt", "file99.txt", "other.csv"]
+    let expected = [
+        "file.txt",
+        "file1.txt",
+        "file2.txt",
+        "file99.txt",
+        "other.csv",
+    ]
     let actual = glob_multiple(["missing*", "file*.txt", "other*.csv"]) failed {
         echo "FAILED"
     }

--- a/src/tests/stdlib/glob_relative_multiple_globs.ab
+++ b/src/tests/stdlib/glob_relative_multiple_globs.ab
@@ -1,0 +1,42 @@
+import * from "std/array"
+import * from "std/fs"
+import * from "std/text"
+
+fun compare(actual: [Text], expected: [Text]): Bool {
+    if len(actual) != len(expected) {
+        return false
+    }
+    loop file in expected {
+        if not includes(actual, file) {
+            return false
+        }
+    }
+    return true
+}
+
+main {
+    let tmpdir = trust $ mktemp -d $
+    trust {
+        $ touch {tmpdir}/1st\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/2nd\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/file.txt $
+        $ touch {tmpdir}/file1.txt $
+        $ touch {tmpdir}/file2.txt $
+        $ touch {tmpdir}/file99.txt $
+        $ touch {tmpdir}/other.csv $
+    }
+    cd tmpdir
+
+    let expected = ["file.txt", "file1.txt", "file2.txt", "file99.txt", "other.csv"]
+    let actual = glob_multiple(["missing*", "file*.txt", "other*.csv"]) failed {
+        echo "FAILED"
+    }
+    if compare(actual, expected) {
+        echo "Succeded"
+    } else {
+        echo "Expected: {expected}"
+        echo "Actual: {actual}"
+    }
+
+    trust $ rm -rf {tmpdir} $
+}

--- a/src/tests/stdlib/glob_relative_wild_char.ab
+++ b/src/tests/stdlib/glob_relative_wild_char.ab
@@ -27,7 +27,10 @@ main {
     }
     cd tmpdir
 
-    let expected = ["file1.txt", "file2.txt"]
+    let expected = [
+        "file1.txt",
+        "file2.txt",
+    ]
     let actual = glob("file?.txt") failed {
         echo "FAILED"
     }

--- a/src/tests/stdlib/glob_relative_wild_char.ab
+++ b/src/tests/stdlib/glob_relative_wild_char.ab
@@ -1,0 +1,42 @@
+import * from "std/array"
+import * from "std/fs"
+import * from "std/text"
+
+fun compare(actual: [Text], expected: [Text]): Bool {
+    if len(actual) != len(expected) {
+        return false
+    }
+    loop file in expected {
+        if not includes(actual, file) {
+            return false
+        }
+    }
+    return true
+}
+
+main {
+    let tmpdir = trust $ mktemp -d $
+    trust {
+        $ touch {tmpdir}/1st\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/2nd\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/file.txt $
+        $ touch {tmpdir}/file1.txt $
+        $ touch {tmpdir}/file2.txt $
+        $ touch {tmpdir}/file99.txt $
+        $ touch {tmpdir}/other.csv $
+    }
+    cd tmpdir
+
+    let expected = ["file1.txt", "file2.txt"]
+    let actual = glob("file?.txt") failed {
+        echo "FAILED"
+    }
+    if compare(actual, expected) {
+        echo "Succeded"
+    } else {
+        echo "Expected: {expected}"
+        echo "Actual: {actual}"
+    }
+
+    trust $ rm -rf {tmpdir} $
+}

--- a/src/tests/stdlib/glob_relative_wild_star.ab
+++ b/src/tests/stdlib/glob_relative_wild_star.ab
@@ -1,0 +1,42 @@
+import * from "std/array"
+import * from "std/fs"
+import * from "std/text"
+
+fun compare(actual: [Text], expected: [Text]): Bool {
+    if len(actual) != len(expected) {
+        return false
+    }
+    loop file in expected {
+        if not includes(actual, file) {
+            return false
+        }
+    }
+    return true
+}
+
+main {
+    let tmpdir = trust $ mktemp -d $
+    trust {
+        $ touch {tmpdir}/1st\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/2nd\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/file.txt $
+        $ touch {tmpdir}/file1.txt $
+        $ touch {tmpdir}/file2.txt $
+        $ touch {tmpdir}/file99.txt $
+        $ touch {tmpdir}/other.csv $
+    }
+    cd tmpdir
+
+    let expected = ["file.txt", "file1.txt", "file2.txt", "file99.txt"]
+    let actual = glob("file*.txt") failed {
+        echo "FAILED"
+    }
+    if compare(actual, expected) {
+        echo "Succeded"
+    } else {
+        echo "Expected: {expected}"
+        echo "Actual: {actual}"
+    }
+
+    trust $ rm -rf {tmpdir} $
+}

--- a/src/tests/stdlib/glob_relative_wild_star.ab
+++ b/src/tests/stdlib/glob_relative_wild_star.ab
@@ -27,7 +27,12 @@ main {
     }
     cd tmpdir
 
-    let expected = ["file.txt", "file1.txt", "file2.txt", "file99.txt"]
+    let expected = [
+        "file.txt",
+        "file1.txt",
+        "file2.txt",
+        "file99.txt",
+    ]
     let actual = glob("file*.txt") failed {
         echo "FAILED"
     }

--- a/src/tests/stdlib/glob_relative_with_spaces.ab
+++ b/src/tests/stdlib/glob_relative_with_spaces.ab
@@ -27,7 +27,10 @@ main {
     }
     cd tmpdir
 
-    let expected = ["1st file with spaces.txt", "2nd file with spaces.txt"]
+    let expected = [
+        "1st file with spaces.txt",
+        "2nd file with spaces.txt",
+    ]
     let actual = glob("*with spaces*") failed {
         echo "FAILED"
     }

--- a/src/tests/stdlib/glob_relative_with_spaces.ab
+++ b/src/tests/stdlib/glob_relative_with_spaces.ab
@@ -1,0 +1,42 @@
+import * from "std/array"
+import * from "std/fs"
+import * from "std/text"
+
+fun compare(actual: [Text], expected: [Text]): Bool {
+    if len(actual) != len(expected) {
+        return false
+    }
+    loop file in expected {
+        if not includes(actual, file) {
+            return false
+        }
+    }
+    return true
+}
+
+main {
+    let tmpdir = trust $ mktemp -d $
+    trust {
+        $ touch {tmpdir}/1st\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/2nd\ file\ with\ spaces.txt $
+        $ touch {tmpdir}/file.txt $
+        $ touch {tmpdir}/file1.txt $
+        $ touch {tmpdir}/file2.txt $
+        $ touch {tmpdir}/file99.txt $
+        $ touch {tmpdir}/other.csv $
+    }
+    cd tmpdir
+
+    let expected = ["1st file with spaces.txt", "2nd file with spaces.txt"]
+    let actual = glob("*with spaces*") failed {
+        echo "FAILED"
+    }
+    if compare(actual, expected) {
+        echo "Succeded"
+    } else {
+        echo "Expected: {expected}"
+        echo "Actual: {actual}"
+    }
+
+    trust $ rm -rf {tmpdir} $
+}


### PR DESCRIPTION
Fixes #463, by implementing `glob` as a standard library function.  I also fixed a bug where failing functions would return the previous array value with the first item blanked out, because the default return value was Bash string `''` not Bash array `()`.