### PR TITLE
Include (un)installer into release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,12 @@ jobs:
           pattern: artifacts-*
           path: target/distrib/
           merge-multiple: true
+      - name: Compile installer/uninstaller
+        run: |
+          TARGET_TRIPLE="$(rustc -Vv | awk '/^host/ { print $2 }')"
+          AMBER="$PWD/target/distrib/amber-${TARGET_TRIPLE}/amber"
+          $AMBER ./setup/install.ab ./target/distrib/install.sh
+          $AMBER ./setup/uninstall.ab ./target/distrib/uninstall.sh
       - id: cargo-dist
         shell: bash
         run: |
@@ -183,6 +189,8 @@ jobs:
           # Parse out what we just built and upload it to scratch storage
           echo "paths<<EOF" >> "$GITHUB_OUTPUT"
           jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
+          echo "$PWD/target/distrib/install.sh" >> "$GITHUB_OUTPUT"
+          echo "$PWD/target/distrib/uninstall.sh" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"


### PR DESCRIPTION
Relates: #462

Added artifacts compiled from `setup/install.ab` and `setup/uninstall.ab` to release assets. I didn't remove `setup/install.sh` and `setup/uninstall.ab` to prevent documentation breakage. If you can tell me where I should edit, I'll contribute to updating the document.