### PR TITLE
feat(doc): append after function description the link for the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ test*.ab
 test*.sh
 test*.md
 /docs/
+src/std/docs/
 
 # Flamegraph files
 flamegraph.svg
@@ -15,3 +16,4 @@ flamegraph.svg
 # Nixos
 .direnv
 /result
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "glob",
  "heraclitus-compiler",
  "include_dir",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ include_dir = "0.7.4"
 itertools = "0.13.0"
 similar-string = "1.4.2"
 test-generator = "0.3.1"
+glob = "0.3"
 
 # test dependencies
 [dev-dependencies]

--- a/src/modules/function/declaration.rs
+++ b/src/modules/function/declaration.rs
@@ -323,7 +323,8 @@ impl FunctionDeclaration {
         result.push(String::from("```\n"));
         if test_path.exists() && test_path.is_dir() {
             if let Ok(entries) = fs::read_dir(test_path) {
-                let pattern = glob::Pattern::new(&format!("{}*.ab", self.name)).unwrap();
+                let pattern = format!("{}*.ab", self.name);
+                let pattern = glob::Pattern::new(&pattern).unwrap();
                 for entry in entries.flatten() {
                     let path = entry.path();
                     if let Some(file_name) = path.file_name().and_then(OsStr::to_str) {


### PR DESCRIPTION
Ref: https://github.com/amber-lang/amber/issues/500

The markdown generated:

```
## `includes`

pub fun includes(array, value) 


Checks if a value is in the array.



You can check the original tests for code examples: [includes_empty_text_array.ab](https://github.com/amber-lang/amber/blob/master/src/tests/stdlib/includes_empty_text_array.ab), [includes_empty_num_array.ab](https://github.com/amber-lang/amber/blob/master/src/tests/stdlib/includes_empty_num_array.ab), [includes_exact_match.ab](https://github.com/amber-lang/amber/blob/master/src/tests/stdlib/includes_exact_match.ab), [includes_partial_match_with_expanded_element.ab](https://github.com/amber-lang/amber/blob/master/src/tests/stdlib/includes_partial_match_with_expanded_element.ab), [includes_text_array.ab](https://github.com/amber-lang/amber/blob/master/src/tests/stdlib/includes_text_array.ab), [includes_prefix_match.ab](https://github.com/amber-lang/amber/blob/master/src/tests/stdlib/includes_prefix_match.ab).
```

The code basically check if we are using the amber dev version, in this way can get the tests and generate the list.

My rust code will be horrible for sure.