### PR TITLE
Builtin lines function part I - Refactoring

### DIFF
--- a/src/modules/expression/binop/add.rs
+++ b/src/modules/expression/binop/add.rs
@@ -62,12 +62,13 @@ impl TranslateModule for Add {
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
         let left = self.left.translate_eval(meta, false);
         let right = self.right.translate_eval(meta, false);
-        let quote = meta.gen_quote();
         match self.kind {
             Type::Array(_) => {
+                let quote = meta.gen_quote();
                 let id = meta.gen_array_id();
-                meta.stmt_queue.push_back(format!("__AMBER_ARRAY_ADD_{id}=({left} {right})"));
-                format!("{quote}${{__AMBER_ARRAY_ADD_{id}[@]}}{quote}")
+                let name = format!("__AMBER_ARRAY_ADD_{id}");
+                meta.stmt_queue.push_back(format!("{name}=({left} {right})"));
+                format!("{quote}${{{name}[@]}}{quote}")
             },
             Type::Text => format!("{}{}", left, right),
             _ => translate_computation(meta, ArithOp::Add, Some(left), Some(right))

--- a/src/modules/shorthand/div.rs
+++ b/src/modules/shorthand/div.rs
@@ -48,21 +48,25 @@ impl SyntaxModule<ParserMetadata> for ShorthandDiv {
 }
 
 impl TranslateModule for ShorthandDiv {
+    //noinspection DuplicatedCode
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
-        let expr = self.is_ref
-            .then(|| self.expr.translate_eval(meta, true))
-            .unwrap_or_else(|| self.expr.translate(meta));
-        let name = match self.global_id {
-            Some(id) => format!("__{id}_{}", self.var),
-            None => if self.is_ref { format!("${{{}}}", self.var) } else { self.var.clone() }
-        };
-        let var = if self.is_ref { format!("\\${{{name}}}") } else { format!("${{{name}}}") };
-        if self.is_ref {
-            let eval = translate_computation_eval(meta, ArithOp::Div, Some(var), Some(expr));
-            format!("eval \"{}={}\"", name, eval)
+        let name = if let Some(id) = self.global_id {
+            format!("__{id}_{}", self.var)
+        } else if self.is_ref {
+            format!("${{{}}}", self.var)
         } else {
-            let eval = translate_computation(meta, ArithOp::Div, Some(var), Some(expr));
-            format!("{}={}", name, eval)
+            self.var.clone()
+        };
+        if self.is_ref {
+            let var = format!("\\${{{name}}}");
+            let expr = self.expr.translate_eval(meta, true);
+            let expr = translate_computation_eval(meta, ArithOp::Div, Some(var), Some(expr));
+            format!("eval \"{name}={expr}\"")
+        } else {
+            let var = format!("${{{name}}}");
+            let expr = self.expr.translate(meta);
+            let expr = translate_computation(meta, ArithOp::Div, Some(var), Some(expr));
+            format!("{name}={expr}")
         }
     }
 }

--- a/src/modules/shorthand/mul.rs
+++ b/src/modules/shorthand/mul.rs
@@ -48,21 +48,25 @@ impl SyntaxModule<ParserMetadata> for ShorthandMul {
 }
 
 impl TranslateModule for ShorthandMul {
+    //noinspection DuplicatedCode
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
-        let expr = self.is_ref
-            .then(|| self.expr.translate_eval(meta, true))
-            .unwrap_or_else(|| self.expr.translate(meta));
-        let name = match self.global_id {
-            Some(id) => format!("__{id}_{}", self.var),
-            None => if self.is_ref { format!("${{{}}}", self.var) } else { self.var.clone() }
-        };
-        let var = if self.is_ref { format!("\\${{{name}}}") } else { format!("${{{name}}}") };
-        if self.is_ref {
-            let expr = translate_computation_eval(meta, ArithOp::Mul, Some(var), Some(expr));
-            format!("eval \"{}={}\"", name, expr)
+        let name = if let Some(id) = self.global_id {
+            format!("__{id}_{}", self.var)
+        } else if self.is_ref {
+            format!("${{{}}}", self.var)
         } else {
+            self.var.clone()
+        };
+        if self.is_ref {
+            let var = format!("\\${{{name}}}");
+            let expr = self.expr.translate_eval(meta, true);
+            let expr = translate_computation_eval(meta, ArithOp::Mul, Some(var), Some(expr));
+            format!("eval \"{name}={expr}\"")
+        } else {
+            let var = format!("${{{name}}}");
+            let expr = self.expr.translate(meta);
             let expr = translate_computation(meta, ArithOp::Mul, Some(var), Some(expr));
-            format!("{}={}", name, expr)
+            format!("{name}={expr}")
         }
     }
 }

--- a/src/modules/shorthand/sub.rs
+++ b/src/modules/shorthand/sub.rs
@@ -48,21 +48,25 @@ impl SyntaxModule<ParserMetadata> for ShorthandSub {
 }
 
 impl TranslateModule for ShorthandSub {
+    //noinspection DuplicatedCode
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
-        let expr = self.is_ref
-            .then(|| self.expr.translate_eval(meta, true))
-            .unwrap_or_else(|| self.expr.translate(meta));
-        let name = match self.global_id {
-            Some(id) => format!("__{id}_{}", self.var),
-            None => if self.is_ref { format!("${{{}}}", self.var) } else { self.var.clone() }
-        };
-        let var = if self.is_ref { format!("\\${{{name}}}") } else { format!("${{{name}}}") };
-        if self.is_ref {
-            let expr = translate_computation_eval(meta, ArithOp::Sub, Some(var), Some(expr));
-            format!("eval \"{}={}\"", name, expr)
+        let name = if let Some(id) = self.global_id {
+            format!("__{id}_{}", self.var)
+        } else if self.is_ref {
+            format!("${{{}}}", self.var)
         } else {
+            self.var.clone()
+        };
+        if self.is_ref {
+            let var = format!("\\${{{name}}}");
+            let expr = self.expr.translate_eval(meta, true);
+            let expr = translate_computation_eval(meta, ArithOp::Sub, Some(var), Some(expr));
+            format!("eval \"{name}={expr}\"")
+        } else {
+            let var = format!("${{{name}}}");
+            let expr = self.expr.translate(meta);
             let expr = translate_computation(meta, ArithOp::Sub, Some(var), Some(expr));
-            format!("{}={}", name, expr)
+            format!("{name}={expr}")
         }
     }
 }

--- a/src/modules/variable/init.rs
+++ b/src/modules/variable/init.rs
@@ -55,14 +55,16 @@ impl SyntaxModule<ParserMetadata> for VariableInit {
 impl TranslateModule for VariableInit {
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
         let name = self.name.clone();
-        let mut  expr = self.expr.translate(meta);
+        let mut expr = self.expr.translate(meta);
         if let Type::Array(_) = self.expr.get_type() {
             expr = format!("({expr})");
         }
-        let local = if self.is_fun_ctx { "local " } else { "" };
-        match self.global_id {
-            Some(id) => format!("__{id}_{name}={expr}"),
-            None => format!("{local}{name}={expr}")
+        if let Some(id) = self.global_id {
+            format!("__{id}_{name}={expr}")
+        } else if self.is_fun_ctx {
+            format!("local {name}={expr}")
+        } else {
+            format!("{name}={expr}")
         }
     }
 }

--- a/src/modules/variable/set.rs
+++ b/src/modules/variable/set.rs
@@ -8,10 +8,20 @@ use crate::modules::types::{Typed, Type};
 #[derive(Debug, Clone)]
 pub struct VariableSet {
     name: String,
-    value: Box<Expr>,
+    expr: Box<Expr>,
     global_id: Option<usize>,
     index: Option<Expr>,
     is_ref: bool
+}
+
+impl VariableSet {
+    fn translate_eval_if_ref(&self, expr: &Expr, meta: &mut TranslateMetadata) -> String {
+        if self.is_ref {
+            expr.translate_eval(meta, true)
+        } else {
+            expr.translate(meta)
+        }
+    }
 }
 
 impl SyntaxModule<ParserMetadata> for VariableSet {
@@ -20,7 +30,7 @@ impl SyntaxModule<ParserMetadata> for VariableSet {
     fn new() -> Self {
         VariableSet {
             name: String::new(),
-            value: Box::new(Expr::new()),
+            expr: Box::new(Expr::new()),
             global_id: None,
             index: None,
             is_ref: false
@@ -32,13 +42,13 @@ impl SyntaxModule<ParserMetadata> for VariableSet {
         self.name = variable(meta, variable_name_extensions())?;
         self.index = handle_index_accessor(meta)?;
         token(meta, "=")?;
-        syntax(meta, &mut *self.value)?;
+        syntax(meta, &mut *self.expr)?;
         let variable = handle_variable_reference(meta, tok.clone(), &self.name)?;
         self.global_id = variable.global_id;
         self.is_ref = variable.is_ref;
         // Typecheck the variable
         let left_type = variable.kind.clone();
-        let right_type = self.value.get_type();
+        let right_type = self.expr.get_type();
         // Check if the variable can be indexed
         if self.index.is_some() && !matches!(variable.kind, Type::Array(_)) {
             return error!(meta, tok, format!("Cannot assign a value to an index of a non-array variable of type '{left_type}'"));
@@ -47,14 +57,14 @@ impl SyntaxModule<ParserMetadata> for VariableSet {
         if self.index.is_some() {
             // Check if the assigned value is compatible with the array
             if let Type::Array(kind) = variable.kind.clone() {
-                if *kind != self.value.get_type() {
-                    let right_type = self.value.get_type();
+                if *kind != self.expr.get_type() {
+                    let right_type = self.expr.get_type();
                     return error!(meta, tok, format!("Cannot assign value of type '{right_type}' to an array of '{kind}'"));
                 }
             }
         }
         // Check if the variable is compatible with the assigned value
-        else if variable.kind != self.value.get_type() {
+        else if variable.kind != self.expr.get_type() {
             return error!(meta, tok, format!("Cannot assign value of type '{right_type}' to a variable of type '{left_type}'"));
         }
         Ok(())
@@ -65,23 +75,19 @@ impl TranslateModule for VariableSet {
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
         let name = self.name.clone();
         let index = self.index.as_ref()
-            .map(|index| format!("[{}]", self.is_ref
-                .then(|| index.translate_eval(meta, true))
-                .unwrap_or_else(|| index.translate(meta))))
+            .map(|index| self.translate_eval_if_ref(index, meta))
+            .map(|index| format!("[{index}]"))
             .unwrap_or_default();
-        let mut expr = self.is_ref
-            .then(|| self.value.translate_eval(meta, true))
-            .unwrap_or_else(|| self.value.translate(meta));
-        if let Type::Array(_) = self.value.get_type() {
-            expr = format!("({})", expr);
+        let mut expr = self.translate_eval_if_ref(self.expr.as_ref(), meta);
+        if let Type::Array(_) = self.expr.get_type() {
+            expr = format!("({expr})");
         }
-        if self.is_ref {
+        if let Some(id) = self.global_id {
+            format!("__{id}_{name}{index}={expr}")
+        } else if self.is_ref {
             format!("eval \"${{{name}}}{index}={expr}\"")
         } else {
-            match self.global_id {
-                Some(id) => format!("__{id}_{name}{index}={expr}"),
-                None => format!("{name}{index}={expr}")
-            }
+            format!("{name}{index}={expr}")
         }
     }
 }


### PR DESCRIPTION
Refactor the `+=` shorthand add operator, by consolidating the various `self.is_ref` tests for text, array and numeric addition.  This is necessary because in a subsequent PR, we will append functionality for array addition only, and this is not possible with the current implementation.  Make corresponding changes to other shorthand operators, initialisation and setter statements.