### PR TITLE
Fix optional argument type matching

### DIFF
--- a/src/modules/function/declaration.rs
+++ b/src/modules/function/declaration.rs
@@ -191,7 +191,7 @@ impl SyntaxModule<ParserMetadata> for FunctionDeclaration {
                             optional = true;
                             let mut expr = Expr::new();
                             syntax(meta, &mut expr)?;
-                            if !expr.get_type().is_subset_of(&arg_type) {
+                            if !expr.get_type().is_allowed_in(&arg_type) {
                                 return error!(meta, name_token, "Optional argument does not match annotated type");
                             }
                             self.arg_optionals.push(expr);

--- a/src/modules/function/declaration.rs
+++ b/src/modules/function/declaration.rs
@@ -191,7 +191,7 @@ impl SyntaxModule<ParserMetadata> for FunctionDeclaration {
                             optional = true;
                             let mut expr = Expr::new();
                             syntax(meta, &mut expr)?;
-                            if arg_type != Type::Generic && arg_type != expr.get_type() {
+                            if !expr.get_type().is_subset_of(&arg_type) {
                                 return error!(meta, name_token, "Optional argument does not match annotated type");
                             }
                             self.arg_optionals.push(expr);

--- a/src/modules/types.rs
+++ b/src/modules/types.rs
@@ -17,6 +17,7 @@ pub enum Type {
 impl Type {
     pub fn is_subset_of(&self, other: &Type) -> bool {
         match (self, other) {
+            (_, Type::Generic) => true,
             (Type::Array(current), Type::Array(other)) => {
                 **current != Type::Generic && **other == Type::Generic
             }
@@ -28,7 +29,7 @@ impl Type {
     }
 
     pub fn is_allowed_in(&self, other: &Type) -> bool {
-        self == other || self.is_subset_of(other) || other == &Type::Generic
+        self == other || self.is_subset_of(other)
     }
 
     pub fn is_array(&self) -> bool {

--- a/src/modules/types.rs
+++ b/src/modules/types.rs
@@ -28,7 +28,7 @@ impl Type {
     }
 
     pub fn is_allowed_in(&self, other: &Type) -> bool {
-        self == other || self.is_subset_of(other)
+        self == other || self.is_subset_of(other) || other == &Type::Generic
     }
 
     pub fn is_array(&self) -> bool {

--- a/src/tests/validity/function_optional_argument_generic_array.ab
+++ b/src/tests/validity/function_optional_argument_generic_array.ab
@@ -1,0 +1,10 @@
+// Output
+// Hello World
+// 1 2 3
+
+fun echo_var(arg: [] = [1, 2, 3]){
+    echo arg
+}
+
+echo_var(["Hello", "World"])
+echo_var()

--- a/src/tests/validity/function_optional_argument_generic_array.ab
+++ b/src/tests/validity/function_optional_argument_generic_array.ab
@@ -2,7 +2,7 @@
 // Hello World
 // 1 2 3
 
-fun echo_var(arg: [] = [1, 2, 3]){
+fun echo_var(arg: [] = [1, 2, 3]): Null {
     echo arg
 }
 


### PR DESCRIPTION
Currently declaring this function throws an error:

```
fun foo(arg: [] = [1, 2]) {

}
```

Even though this should work completely fine. The optional value is a subset of the argument type.