### PR TITLE
fix(failed): show function

### DIFF
--- a/src/modules/condition/failed.rs
+++ b/src/modules/condition/failed.rs
@@ -61,7 +61,7 @@ impl SyntaxModule<ParserMetadata> for Failed {
                     self.is_parsed = true;
                     return Ok(());
                 } else {
-                    return error!(meta, tok, "Failed expression must be followed by a block or statement")
+                    return error!(meta, tok, format!("The function '{}' requires a 'failed' block or statement to handle errors", meta.get_token_at(meta.get_index() - 4).unwrap().word))
                 }
             }
         }


### PR DESCRIPTION
On my daily check if I can resolve some bugs in Amber I tried with https://github.com/amber-lang/amber/issues/210

I am not sure about `meta.get_index() - 4` to get the function with the issue.

Using the amberr code:
```
import * from "std/text"

// Output
// 123

main {
    echo parse("123")
}
```

The `meta` is:
```
Context { index: 15, expr: [Tok[import 1:1], Tok[* 1:8], Tok[from 1:10], Tok["std/text" 1:15], Tok[// Output
 3:1], Tok[<new_line> 3:10], Tok[// 123
 4:1], Tok[<new_line> 4:7], Tok[main 6:1], Tok[<symbol: { > 6:6], Tok[echo 7:5], Tok[parse 7:10], Tok[<symbol: ( > 7:15], Tok["123" 7:16], Tok[<symbol: ) > 7:21], Tok[<symbol: } > 8:1]]

REDACTED
```

So I think that the actual index is always the next symbol where it should be the `failed`, in this case a `}`, followed by the closing parenthesis of the function, the parameters, the open parenthesis and finally the function name.
Right now amber doesn't share in the context what is the function or the line is processing, but in this way with `- 4` we start from the end that it is more easy to be right so we can ignore the `echo` token.

Anyway I am not so skilled in the internals but let me know if needs some changes internally before to be able to close that ticket.