### PR TITLE
fix: Do not use absolute paths to the postprocessors

### DIFF
--- a/src/compiler/postprocessor.rs
+++ b/src/compiler/postprocessor.rs
@@ -71,12 +71,12 @@ impl PostProcessor {
     pub fn get_default() -> Vec<Self> {
         let mut postprocessors = Vec::new();
 
-        let shfmt = PostProcessor::new("shfmt", "/usr/bin/shfmt");
+        let shfmt = PostProcessor::new("shfmt", "shfmt");
         shfmt.cmd().borrow_mut().arg("-i").arg("4");
         shfmt.cmd().borrow_mut().arg("-ln").arg("bash");
         postprocessors.push(shfmt);
 
-        let bshchk = PostProcessor::new("bshchk", "/usr/bin/bshchk");
+        let bshchk = PostProcessor::new("bshchk", "bshchk");
         bshchk.cmd().borrow_mut().arg("--ignore-shebang");
         postprocessors.push(bshchk);
 


### PR DESCRIPTION
If any postprocessor is not installed at the exact path(ex: `~/.local/bin/bshchk`), the `cargo test tests::postprocessor::default_ok` fails:

```
running 1 test
test tests::postprocessor::default_ok ... FAILED

failures:

---- tests::postprocessor::default_ok stdout ----
thread 'tests::postprocessor::default_ok' panicked at src/tests/postprocessor.rs:21:5:
These commands have to be in $PATH for this test to pass: bshchk
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::postprocessor::default_ok

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 222 filtered out; finished in 0.00s
```

This PR omits `/usr/bin/`.

> If `program` is not an absolute path, the PATH will be searched in an OS-defined way.
> -- [Struct std::process::Command](https://doc.rust-lang.org/std/process/struct.Command.html#:~:text=If%20program%20is%20not%20an%20absolute%20path%2C%20the%20PATH%20will%20be%20searched%20in%20an%20OS%2Ddefined%20way.)