### PR TITLE
Add CLI subcommands and Bash tab completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "build-helper",
  "chrono",
  "clap",
+ "clap_complete",
  "colored",
  "glob",
  "heraclitus-compiler",
@@ -74,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
@@ -205,9 +206,9 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
-version = "4.5.8"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -215,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.8"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -226,10 +227,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_derive"
-version = "4.5.8"
+name = "clap_complete"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "86bc73de94bc81e52f3bebec71bc4463e9748f7a59166663e32044669577b0e2"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2 1.0.86",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ copyright = "GPLv3"
 [dependencies]
 amber-meta = { path = "meta" }
 chrono = "0.4.38"
-clap = { version = "4.4.18", features = ["derive"] }
+clap = { version = "4.5.20", features = ["derive"] }
+clap_complete = "4.5.36"
 colored = "2.0.0"
 glob = "0.3"
 heraclitus-compiler = "1.8.1"

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -102,14 +102,9 @@ impl AmberCompiler {
         }
     }
 
-    pub fn parse(
-        &self,
-        tokens: Vec<Token>,
-        is_docs_gen: bool,
-    ) -> Result<(Block, ParserMetadata), Message> {
+    pub fn parse(&self, tokens: Vec<Token>) -> Result<(Block, ParserMetadata), Message> {
         let code = self.cc.code.as_ref().expect(NO_CODE_PROVIDED).clone();
         let mut meta = ParserMetadata::new(tokens, self.path.clone(), Some(code));
-        meta.is_docs_gen = is_docs_gen;
         if let Err(Failure::Loud(err)) = check_all_blocks(&meta) {
             return Err(err);
         }
@@ -263,7 +258,7 @@ impl AmberCompiler {
 
     pub fn compile(&self) -> Result<(Vec<Message>, String), Message> {
         let tokens = self.tokenize()?;
-        let (block, meta) = self.parse(tokens, false)?;
+        let (block, meta) = self.parse(tokens)?;
         let messages = meta.messages.clone();
         let code = self.translate(block, meta)?;
         Ok((messages, code))
@@ -285,9 +280,10 @@ impl AmberCompiler {
         }
     }
 
-    pub fn generate_docs(&self, output: String) -> Result<(), Message> {
+    pub fn generate_docs(&self, output: String, usage: bool) -> Result<(), Message> {
         let tokens = self.tokenize()?;
-        let (block, meta) = self.parse(tokens, true)?;
+        let (block, mut meta) = self.parse(tokens)?;
+        meta.doc_usage = usage;
         self.document(block, meta, output);
         Ok(())
     }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -31,10 +31,15 @@ pub struct CompilerOptions {
 
 impl Default for CompilerOptions {
     fn default() -> Self {
-        Self {
-            no_proc: vec![String::from("*")],
-            minify: false,
-        }
+        let no_proc = vec![String::from("*")];
+        Self { no_proc, minify: false }
+    }
+}
+
+impl CompilerOptions {
+    pub fn from_args(no_proc: &Vec<String>, minify: bool) -> Self {
+        let no_proc = no_proc.clone();
+        Self { no_proc, minify }
     }
 }
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -269,9 +269,15 @@ impl AmberCompiler {
         Ok((messages, code))
     }
 
-    pub fn execute(code: String, flags: &[String]) -> Result<ExitStatus, std::io::Error> {
+    pub fn execute(mut code: String, args: Vec<String>) -> Result<ExitStatus, std::io::Error> {
         if let Some(mut command) = Self::find_bash() {
-            let code = format!("set -- {};\n{}", flags.join(" "), code);
+            if !args.is_empty() {
+                let args = args.into_iter()
+                    .map(|arg| arg.replace("\"", "\\\""))
+                    .map(|arg| format!("\"{arg}\""))
+                    .collect::<Vec<String>>();
+                code = format!("set -- {}\n{}", args.join(" "), code);
+            }
             command.arg("-c").arg(code).spawn()?.wait()
         } else {
             let error = std::io::Error::new(ErrorKind::NotFound, "Failed to find Bash");

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -37,8 +37,8 @@ impl Default for CompilerOptions {
 }
 
 impl CompilerOptions {
-    pub fn from_args(no_proc: &Vec<String>, minify: bool) -> Self {
-        let no_proc = no_proc.clone();
+    pub fn from_args(no_proc: &[String], minify: bool) -> Self {
+        let no_proc = no_proc.to_owned();
         Self { no_proc, minify }
     }
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -32,12 +32,9 @@ pub struct AmberCompiler {
 
 impl AmberCompiler {
     pub fn new(code: String, path: Option<String>, cli_opts: Cli) -> AmberCompiler {
-        AmberCompiler {
-            cc: Compiler::new("Amber", rules::get_rules()),
-            path,
-            cli_opts,
-        }
-        .load_code(AmberCompiler::comment_shebang(code))
+        let cc = Compiler::new("Amber", rules::get_rules());
+        let compiler = AmberCompiler { cc, path, cli_opts };
+        compiler.load_code(AmberCompiler::comment_shebang(code))
     }
 
     fn comment_shebang(code: String) -> String {
@@ -185,13 +182,10 @@ impl AmberCompiler {
             };
         }
 
+        let now = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
         let header = include_str!("header.sh")
             .replace("{{ version }}", env!("CARGO_PKG_VERSION"))
-            .replace("{{ date }}", Local::now()
-                .format("%Y-%m-%d %H:%M:%S")
-                .to_string()
-                .as_str()
-            );
+            .replace("{{ date }}", now.as_str());
         Ok(format!("{}{}", header, result))
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ enum CommandKind {
     /// Generate Amber script documentation
     Docs(DocsCommand),
     /// Generate Bash completion script
-    Comp,
+    Completion,
 }
 
 #[derive(Args, Clone, Debug)]
@@ -143,8 +143,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             CommandKind::Docs(command) => {
                 handle_docs(command)?;
             }
-            CommandKind::Comp => {
-                handle_complete();
+            CommandKind::Completion => {
+                handle_completion();
             }
         }
     } else if let Some(input) = cli.input {
@@ -256,7 +256,7 @@ fn handle_docs(command: DocsCommand) -> Result<(), Box<dyn Error>> {
     }
 }
 
-fn handle_complete() {
+fn handle_completion() {
     let mut command = Cli::command();
     let name = command.get_name().to_string();
     clap_complete::generate(Shell::Bash, &mut command, name, &mut io::stdout());

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ enum CommandKind {
     Check(CheckCommand),
     /// Compile Amber script to Bash
     Build(BuildCommand),
-    /// Generate documentation for Amber script
+    /// Generate Amber script documentation
     Doc(DocCommand),
     /// Generate Bash completion script
     Comp,

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ enum CommandKind {
     /// Compile Amber script to Bash
     Build(BuildCommand),
     /// Generate Amber script documentation
-    Doc(DocCommand),
+    Docs(DocsCommand),
     /// Generate Bash completion script
     Comp,
 }
@@ -100,7 +100,7 @@ struct BuildCommand {
 }
 
 #[derive(Args, Clone, Debug)]
-struct DocCommand {
+struct DocsCommand {
     /// Input filename ('-' to read from stdin)
     input: PathBuf,
 
@@ -140,8 +140,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                 let (code, _) = compile_input(command.input, options);
                 write_output(output, code);
             }
-            CommandKind::Doc(command) => {
-                handle_doc(command)?;
+            CommandKind::Docs(command) => {
+                handle_docs(command)?;
             }
             CommandKind::Comp => {
                 handle_complete();
@@ -234,7 +234,7 @@ fn handle_eval(command: EvalCommand) -> Result<(), Box<dyn Error>> {
     }
 }
 
-fn handle_doc(command: DocCommand) -> Result<(), Box<dyn Error>> {
+fn handle_docs(command: DocsCommand) -> Result<(), Box<dyn Error>> {
     let input = command.input.to_string_lossy().to_string();
     let code = match fs::read_to_string(&input) {
         Ok(code) => code,

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,9 +69,9 @@ fn handle_compile(cli: Cli) -> Result<(), Box<dyn Error>> {
     };
 
     let code = if input == "-" {
-        let mut buf = String::new();
-        match stdin().read_to_string(&mut buf) {
-            Ok(_) => buf,
+        let mut code = String::new();
+        match stdin().read_to_string(&mut code) {
+            Ok(_) => code,
             Err(err) => handle_err(err),
         }
     } else {
@@ -81,7 +81,8 @@ fn handle_compile(cli: Cli) -> Result<(), Box<dyn Error>> {
         }
     };
 
-    let (messages, code) = match AmberCompiler::new(code, Some(input), cli.clone()).compile() {
+    let compiler = AmberCompiler::new(code, Some(input), cli.clone());
+    let (messages, code) = match compiler.compile() {
         Ok(result) => result,
         Err(err) => {
             err.show();
@@ -123,7 +124,8 @@ fn handle_compile(cli: Cli) -> Result<(), Box<dyn Error>> {
 }
 
 fn handle_eval(code: String, cli: Cli) -> Result<(), Box<dyn Error>> {
-    match AmberCompiler::new(code, None, cli).compile() {
+    let compiler = AmberCompiler::new(code, None, cli);
+    match compiler.compile() {
         Ok((messages, code)) => {
             messages.iter().for_each(|m| m.show());
             (!messages.is_empty()).then(render_dash);
@@ -161,7 +163,7 @@ fn handle_docs(cli: Cli) -> Result<(), Box<dyn Error>> {
         String::from(out.to_string_lossy())
     };
 
-    let code: String = match fs::read_to_string(&input) {
+    let code = match fs::read_to_string(&input) {
         Ok(code) => code,
         Err(err) => {
             Message::new_err_msg(err.to_string()).show();
@@ -169,7 +171,8 @@ fn handle_docs(cli: Cli) -> Result<(), Box<dyn Error>> {
         }
     };
 
-    match AmberCompiler::new(code, Some(input), cli).generate_docs(output) {
+    let compiler = AmberCompiler::new(code, Some(input), cli);
+    match compiler.generate_docs(output) {
         Ok(_) => Ok(()),
         Err(err) => {
             err.show();

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,10 @@ struct DocCommand {
 
     /// Output directory (relative to input file, default 'docs')
     output: Option<PathBuf>,
+
+    /// Show standard library usage in documentation
+    #[arg(long)]
+    usage: bool,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -235,7 +239,7 @@ fn handle_doc(command: DocCommand) -> Result<(), Box<dyn Error>> {
     let compiler = AmberCompiler::new(code, Some(input), options);
     let output = command.output.unwrap_or_else(|| PathBuf::from("docs"));
     let output = output.to_string_lossy().to_string();
-    match compiler.generate_docs(output) {
+    match compiler.generate_docs(output, command.usage) {
         Ok(_) => Ok(()),
         Err(err) => {
             err.show();

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,14 +10,15 @@ mod utils;
 pub mod tests;
 
 use crate::compiler::{AmberCompiler, CompilerOptions};
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap_complete::Shell;
 use colored::Colorize;
 use heraclitus_compiler::prelude::*;
 use std::error::Error;
-use std::fs;
 use std::io::{prelude::*, stdin};
 use std::path::PathBuf;
 use std::process::Command;
+use std::{fs, io};
 
 #[derive(Parser, Clone, Debug)]
 #[command(version, arg_required_else_help(true))]
@@ -45,6 +46,8 @@ enum CommandKind {
     Build(BuildCommand),
     /// Generate documentation for Amber script
     Doc(DocCommand),
+    /// Generate Bash completion script
+    Comp,
 }
 
 #[derive(Args, Clone, Debug)]
@@ -139,6 +142,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
             CommandKind::Doc(command) => {
                 handle_doc(command)?;
+            }
+            CommandKind::Comp => {
+                handle_complete();
             }
         }
     } else if let Some(input) = cli.input {
@@ -246,6 +252,12 @@ fn handle_doc(command: DocCommand) -> Result<(), Box<dyn Error>> {
             std::process::exit(1);
         }
     }
+}
+
+fn handle_complete() {
+    let mut command = Cli::command();
+    let name = command.get_name().to_string();
+    clap_complete::generate(Shell::Bash, &mut command, name, &mut io::stdout());
 }
 
 #[cfg(windows)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 fn create_output(command: &BuildCommand) -> PathBuf {
     if let Some(output) = &command.output {
         output.clone()
+    } else if command.input.as_os_str() == "-" {
+        command.input.clone()
     } else {
         command.input.with_extension("sh")
     }

--- a/src/modules/function/declaration.rs
+++ b/src/modules/function/declaration.rs
@@ -275,7 +275,7 @@ impl DocumentationModule for FunctionDeclaration {
     fn document(&self, meta: &ParserMetadata) -> String {
         let mut result = vec![];
         result.push(format!("## `{}`\n", self.name));
-        let references = self.create_reference(meta, &mut result);
+        let references = self.create_test_references(meta, &mut result);
         result.push("```ab".to_string());
         result.push(self.doc_signature.to_owned().unwrap());
         result.push("```\n".to_string());
@@ -293,7 +293,7 @@ impl DocumentationModule for FunctionDeclaration {
 }
 
 impl FunctionDeclaration {
-    fn create_reference(&self, meta: &ParserMetadata, result: &mut Vec<String>) -> Option<Vec<String>> {
+    fn create_test_references(&self, meta: &ParserMetadata, result: &mut Vec<String>) -> Option<Vec<String>> {
         if meta.doc_usage {
             let mut references = Vec::new();
             let exe_path = env::current_exe()

--- a/src/modules/function/declaration.rs
+++ b/src/modules/function/declaration.rs
@@ -1,9 +1,6 @@
 use std::collections::HashSet;
-#[cfg(debug_assertions)]
 use std::{env, fs};
-#[cfg(debug_assertions)]
 use std::ffi::OsStr;
-#[cfg(debug_assertions)]
 use std::path::Path;
 
 use heraclitus_compiler::prelude::*;
@@ -278,74 +275,65 @@ impl DocumentationModule for FunctionDeclaration {
     fn document(&self, meta: &ParserMetadata) -> String {
         let mut result = vec![];
         result.push(format!("## `{}`\n", self.name));
-
         let references = self.create_reference(meta, &mut result);
-
         result.push("```ab".to_string());
         result.push(self.doc_signature.to_owned().unwrap());
         result.push("```\n".to_string());
         if let Some(comment) = &self.comment {
             result.push(comment.document(meta));
         }
-
         if let Some(references) = references {
             for reference in references {
                 result.push(reference);
             }
             result.push("\n".to_string());
         }
-
         result.join("\n")
     }
 }
 
 impl FunctionDeclaration {
-    #[cfg(debug_assertions)]
     fn create_reference(&self, meta: &ParserMetadata, result: &mut Vec<String>) -> Option<Vec<String>> {
-        let mut references = Vec::new();
-        let exe_path = env::current_exe()
-            .expect("Executable path not found");
-        let root_path = exe_path.parent()
-            .and_then(Path::parent)
-            .and_then(Path::parent)
-            .expect("Root path not found");
-        let test_path = root_path.join("src")
-            .join("tests")
-            .join("stdlib");
-        let lib_name = meta.context.path.as_ref()
-            .map(Path::new)
-            .and_then(Path::file_name)
-            .and_then(OsStr::to_str)
-            .map(String::from)
-            .unwrap_or_default();
-        result.push(String::from("```ab"));
-        result.push(format!("import {{ {} }} from \"std/{}\"", self.name, lib_name));
-        result.push(String::from("```\n"));
-        if test_path.exists() && test_path.is_dir() {
-            if let Ok(entries) = fs::read_dir(test_path) {
-                let pattern = format!("{}*.ab", self.name);
-                let pattern = glob::Pattern::new(&pattern).unwrap();
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    if let Some(file_name) = path.file_name().and_then(OsStr::to_str) {
-                        if pattern.matches(file_name) {
-                            references.push(format!("* [{}](https://github.com/amber-lang/amber/blob/master/src/tests/stdlib/{})", file_name, file_name));
+        if meta.doc_usage {
+            let mut references = Vec::new();
+            let exe_path = env::current_exe()
+                .expect("Executable path not found");
+            let root_path = exe_path.parent()
+                .and_then(Path::parent)
+                .and_then(Path::parent)
+                .expect("Root path not found");
+            let test_path = root_path.join("src")
+                .join("tests")
+                .join("stdlib");
+            let lib_name = meta.context.path.as_ref()
+                .map(Path::new)
+                .and_then(Path::file_name)
+                .and_then(OsStr::to_str)
+                .map(String::from)
+                .unwrap_or_default();
+            result.push(String::from("```ab"));
+            result.push(format!("import {{ {} }} from \"std/{}\"", self.name, lib_name));
+            result.push(String::from("```\n"));
+            if test_path.exists() && test_path.is_dir() {
+                if let Ok(entries) = fs::read_dir(test_path) {
+                    let pattern = format!("{}*.ab", self.name);
+                    let pattern = glob::Pattern::new(&pattern).unwrap();
+                    for entry in entries.flatten() {
+                        let path = entry.path();
+                        if let Some(file_name) = path.file_name().and_then(OsStr::to_str) {
+                            if pattern.matches(file_name) {
+                                references.push(format!("* [{}](https://github.com/amber-lang/amber/blob/master/src/tests/stdlib/{})", file_name, file_name));
+                            }
                         }
                     }
                 }
             }
+            if !references.is_empty() {
+                references.sort();
+                references.insert(0, String::from("You can check the original tests for code examples:"));
+                return Some(references);
+            }
         }
-        if !references.is_empty() {
-            references.sort();
-            references.insert(0, String::from("You can check the original tests for code examples:"));
-            Some(references)
-        } else {
-            None
-        }
-    }
-
-    #[cfg(not(debug_assertions))]
-    fn create_reference(&self, _meta: &ParserMetadata, _result: &mut Vec<String>) -> Option<Vec<String>> {
         None
     }
 }

--- a/src/modules/imports/import.rs
+++ b/src/modules/imports/import.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use heraclitus_compiler::prelude::*;
-use crate::compiler::AmberCompiler;
+use crate::compiler::{AmberCompiler, CompilerOptions};
 use crate::docs::module::DocumentationModule;
 use crate::modules::block::Block;
 use crate::modules::variable::variable_name_extensions;
@@ -8,7 +8,6 @@ use crate::stdlib;
 use crate::utils::context::{Context, FunctionDecl};
 use crate::utils::{ParserMetadata, TranslateMetadata};
 use crate::translate::module::TranslateModule;
-use crate::Cli;
 use super::import_string::ImportString;
 
 #[derive(Debug, Clone)]
@@ -97,7 +96,8 @@ impl Import {
     }
 
     fn handle_compile_code(&mut self, meta: &mut ParserMetadata, code: String) -> SyntaxResult {
-        let compiler = AmberCompiler::new(code, Some(self.path.value.clone()), Cli::default());
+        let options = CompilerOptions::default();
+        let compiler = AmberCompiler::new(code, Some(self.path.value.clone()), options);
         match compiler.tokenize() {
             Ok(tokens) => {
                 let mut block = Block::new();

--- a/src/modules/imports/import.rs
+++ b/src/modules/imports/import.rs
@@ -88,16 +88,17 @@ impl Import {
         }
     }
 
-    fn handle_import(&mut self, meta: &mut ParserMetadata, imported_code: String) -> SyntaxResult {
+    fn handle_import(&mut self, meta: &mut ParserMetadata, code: String) -> SyntaxResult {
         // If the import was already cached, we don't need to recompile it
         match meta.import_cache.get_import_pub_funs(Some(self.path.value.clone())) {
             Some(pub_funs) => self.handle_export(meta, pub_funs),
-            None => self.handle_compile_code(meta, imported_code)
+            None => self.handle_compile_code(meta, code)
         }
     }
 
-    fn handle_compile_code(&mut self, meta: &mut ParserMetadata, imported_code: String) -> SyntaxResult {
-        match AmberCompiler::new(imported_code.clone(), Some(self.path.value.clone()), Cli::default()).tokenize() {
+    fn handle_compile_code(&mut self, meta: &mut ParserMetadata, code: String) -> SyntaxResult {
+        let compiler = AmberCompiler::new(code, Some(self.path.value.clone()), Cli::default());
+        match compiler.tokenize() {
             Ok(tokens) => {
                 let mut block = Block::new();
                 // Save snapshot of current file
@@ -167,9 +168,8 @@ impl SyntaxModule<ParserMetadata> for Import {
         syntax(meta, &mut self.path)?;
         // Import code from file or standard library
         self.add_import(meta, &self.path.value.clone())?;
-        let imported_code = self.resolve_import(meta)?;
-
-        self.handle_import(meta, imported_code)?;
+        let code = self.resolve_import(meta)?;
+        self.handle_import(meta, code)?;
         Ok(())
     }
 }

--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -26,6 +26,8 @@ fn bash_error_exit_code() -> Result<(), Box<dyn std::error::Error>> {
     // Changes locale to default to prevent locale-specific error messages.
     cmd.env("LC_ALL", "C")
         .arg("run")
+        .arg("--no-proc")
+        .arg("*")
         .arg(file.path());
 
     cmd.assert()

--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -31,9 +31,7 @@ fn bash_error_exit_code() -> Result<(), Box<dyn std::error::Error>> {
 
     cmd.assert()
         .failure()
-        .stderr(predicate::str::contains(
-            "notexistingcommand: command not found",
-        ))
+        .stderr(predicate::str::contains("notexistingcommand: command not found"))
         .code(127);
 
     Ok(())

--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -25,8 +25,7 @@ fn bash_error_exit_code() -> Result<(), Box<dyn std::error::Error>> {
 
     // Changes locale to default to prevent locale-specific error messages.
     cmd.env("LC_ALL", "C")
-        .arg("--no-proc")
-        .arg("*")
+        .arg("run")
         .arg(file.path());
 
     cmd.assert()

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -15,25 +15,21 @@ mod validity;
 
 /// compare the output of the given code with the expected output
 pub fn test_amber(code: impl Into<String>, result: impl AsRef<str>) {
-    match AmberCompiler::new(code.into(), None, Cli::default()).test_eval() {
+    let mut compiler = AmberCompiler::new(code.into(), None, Cli::default());
+    match compiler.test_eval() {
         Ok(eval_result) => assert_eq!(
             eval_result.trim_end_matches('\n'),
-            result.as_ref().trim_end_matches('\n')
+            result.as_ref().trim_end_matches('\n'),
         ),
         Err(err) => panic!("ERROR: {}", err.message.unwrap()),
     }
 }
 
 pub fn compile_code<T: Into<String>>(code: T) -> String {
-    let cli = Cli {
-        no_proc: vec!["*".into()],
-        ..Cli::default()
-    };
-    
-    AmberCompiler::new(code.into(), None, cli)
-        .compile()
-        .unwrap()
-        .1
+    let cli = Cli { no_proc: vec!["*".into()], ..Cli::default() };
+    let compiler = AmberCompiler::new(code.into(), None, cli);
+    let (_, code) = compiler.compile().unwrap();
+    code
 }
 
 pub fn eval_bash<T: Into<String>>(code: T) -> (String, String) {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,4 @@
-use crate::compiler::AmberCompiler;
-use crate::Cli;
+use crate::compiler::{AmberCompiler, CompilerOptions};
 extern crate test_generator;
 use itertools::Itertools;
 use std::fs;
@@ -15,7 +14,8 @@ mod validity;
 
 /// compare the output of the given code with the expected output
 pub fn test_amber(code: impl Into<String>, result: impl AsRef<str>) {
-    let mut compiler = AmberCompiler::new(code.into(), None, Cli::default());
+    let options = CompilerOptions::default();
+    let mut compiler = AmberCompiler::new(code.into(), None, options);
     match compiler.test_eval() {
         Ok(eval_result) => assert_eq!(
             eval_result.trim_end_matches('\n'),
@@ -26,8 +26,8 @@ pub fn test_amber(code: impl Into<String>, result: impl AsRef<str>) {
 }
 
 pub fn compile_code<T: Into<String>>(code: T) -> String {
-    let cli = Cli { no_proc: vec!["*".into()], ..Cli::default() };
-    let compiler = AmberCompiler::new(code.into(), None, cli);
+    let options = CompilerOptions::default();
+    let compiler = AmberCompiler::new(code.into(), None, options);
     let (_, code) = compiler.compile().unwrap();
     code
 }

--- a/src/utils/metadata/parser.rs
+++ b/src/utils/metadata/parser.rs
@@ -28,8 +28,8 @@ pub struct ParserMetadata {
     pub context: Context,
     /// List of all failure messages
     pub messages: Vec<Message>,
-    /// Determines if we are generating documentation
-    pub is_docs_gen: bool
+    /// Show standard library usage in documentation
+    pub doc_usage: bool,
 }
 
 impl ParserMetadata {
@@ -170,7 +170,7 @@ impl Metadata for ParserMetadata {
             var_id: 0,
             context: Context::new(path, tokens),
             messages: Vec::new(),
-            is_docs_gen: false
+            doc_usage: false,
         }
     }
 

--- a/src/utils/metadata/translate.rs
+++ b/src/utils/metadata/translate.rs
@@ -42,7 +42,7 @@ impl TranslateMetadata {
             eval_ctx: false,
             silenced: false,
             indent: -1,
-            minify: cli.minify
+            minify: cli.minify,
         }
     }
 

--- a/src/utils/metadata/translate.rs
+++ b/src/utils/metadata/translate.rs
@@ -1,7 +1,8 @@
 use std::collections::VecDeque;
 
-use crate::{translate::compute::ArithType, utils::function_cache::FunctionCache};
 use crate::compiler::CompilerOptions;
+use crate::translate::compute::ArithType;
+use crate::utils::function_cache::FunctionCache;
 use crate::utils::function_metadata::FunctionMetadata;
 use super::ParserMetadata;
 

--- a/src/utils/metadata/translate.rs
+++ b/src/utils/metadata/translate.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 
-use crate::{translate::compute::ArithType, utils::function_cache::FunctionCache, Cli};
+use crate::{translate::compute::ArithType, utils::function_cache::FunctionCache};
+use crate::compiler::CompilerOptions;
 use crate::utils::function_metadata::FunctionMetadata;
 use super::ParserMetadata;
 
@@ -31,7 +32,7 @@ pub struct TranslateMetadata {
 }
 
 impl TranslateMetadata {
-    pub fn new(meta: ParserMetadata, cli: &Cli) -> Self {
+    pub fn new(meta: ParserMetadata, options: &CompilerOptions) -> Self {
         TranslateMetadata {
             arith_module: ArithType::BcSed,
             fun_cache: meta.fun_cache,
@@ -42,7 +43,7 @@ impl TranslateMetadata {
             eval_ctx: false,
             silenced: false,
             indent: -1,
-            minify: cli.minify,
+            minify: options.minify,
         }
     }
 


### PR DESCRIPTION
Fixes #411 and #558.

Now specifies functionality via subcommands, with command-specific options:

* Use `amber eval` to execute Amber code fragment.
* Use `amber run` to execute Amber script.
* Use `amber check` to check Amber script for errors.
* Use `amber build` to compile Amber script to Bash.
* Use `amber docs` to generate Amber script documentation.
* Use `amber comp` to generate Bash completion script.

Now passes command line arguments to `main` block in Amber script.