### PR TITLE
Trailing comma in imports

### DIFF
--- a/src/modules/imports/import.rs
+++ b/src/modules/imports/import.rs
@@ -157,8 +157,13 @@ impl SyntaxModule<ParserMetadata> for Import {
                         if token(meta, "}").is_ok() {
                             break;
                         }
-                        if token(meta, ",").is_err() {
-                            return error!(meta, meta.get_current_token(), "Expected ',' or '}' after import");
+                        match token(meta, ",") {
+                            Ok(_) => {
+                                if token(meta, "}").is_ok() {
+                                    break
+                                }
+                            },
+                            Err(_) => return error!(meta, meta.get_current_token(), "Expected ',' or '}' after import"),
                         }
                     }
                 }

--- a/src/modules/imports/import.rs
+++ b/src/modules/imports/import.rs
@@ -162,8 +162,10 @@ impl SyntaxModule<ParserMetadata> for Import {
                                 if token(meta, "}").is_ok() {
                                     break
                                 }
-                            },
-                            Err(_) => return error!(meta, meta.get_current_token(), "Expected ',' or '}' after import"),
+                            }
+                            Err(_) => {
+                                return error!(meta, meta.get_current_token(), "Expected ',' or '}' after import");
+                            }
                         }
                     }
                 }

--- a/src/modules/imports/import.rs
+++ b/src/modules/imports/import.rs
@@ -144,7 +144,7 @@ impl SyntaxModule<ParserMetadata> for Import {
             Ok(_) => self.is_all = true,
             Err(_) => {
                 token(meta, "{")?;
-                let mut exports = Vec::new();
+                let mut exports = vec![];
                 if token(meta, "}").is_err() {
                     loop {
                         let tok = meta.get_current_token();

--- a/src/modules/imports/import.rs
+++ b/src/modules/imports/import.rs
@@ -168,6 +168,10 @@ impl SyntaxModule<ParserMetadata> for Import {
                             }
                         }
                     }
+                } else {
+                    let message = Message::new_warn_at_token(meta, self.token_import.clone())
+                        .message("Empty import statement");
+                    meta.add_message(message);
                 }
                 self.export_defs = exports;
             }

--- a/src/modules/imports/import.rs
+++ b/src/modules/imports/import.rs
@@ -144,23 +144,22 @@ impl SyntaxModule<ParserMetadata> for Import {
             Ok(_) => self.is_all = true,
             Err(_) => {
                 token(meta, "{")?;
-                let mut exports = vec![];
-                loop {
-                    if token(meta, "}").is_ok() {
-                        break;
-                    }
-                    let tok = meta.get_current_token();
-                    let name = variable(meta, variable_name_extensions())?;
-                    let alias = match token(meta, "as") {
-                        Ok(_) => Some(variable(meta, variable_name_extensions())?),
-                        Err(_) => None
-                    };
-                    exports.push((name, alias, tok));
-                    if token(meta, "}").is_ok() {
-                        break;
-                    }
-                    if token(meta, ",").is_err() {
-                        return error!(meta, meta.get_current_token(), "Expected ',' or '}' after import");
+                let mut exports = Vec::new();
+                if token(meta, "}").is_err() {
+                    loop {
+                        let tok = meta.get_current_token();
+                        let name = variable(meta, variable_name_extensions())?;
+                        let alias = match token(meta, "as") {
+                            Ok(_) => Some(variable(meta, variable_name_extensions())?),
+                            Err(_) => None
+                        };
+                        exports.push((name, alias, tok));
+                        if token(meta, "}").is_ok() {
+                            break;
+                        }
+                        if token(meta, ",").is_err() {
+                            return error!(meta, meta.get_current_token(), "Expected ',' or '}' after import");
+                        }
                     }
                 }
                 self.export_defs = exports;

--- a/src/modules/imports/import.rs
+++ b/src/modules/imports/import.rs
@@ -146,6 +146,9 @@ impl SyntaxModule<ParserMetadata> for Import {
                 token(meta, "{")?;
                 let mut exports = vec![];
                 loop {
+                    if token(meta, "}").is_ok() {
+                        break;
+                    }
                     let tok = meta.get_current_token();
                     let name = variable(meta, variable_name_extensions())?;
                     let alias = match token(meta, "as") {
@@ -153,13 +156,14 @@ impl SyntaxModule<ParserMetadata> for Import {
                         Err(_) => None
                     };
                     exports.push((name, alias, tok));
-                    match token(meta, ",") {
-                        Ok(_) => {},
-                        Err(_) => break
+                    if token(meta, "}").is_ok() {
+                        break;
+                    }
+                    if token(meta, ",").is_err() {
+                        return error!(meta, meta.get_current_token(), "Expected ',' or '}' after import");
                     }
                 }
                 self.export_defs = exports;
-                token(meta, "}")?;
             }
         }
         token(meta, "from")?;

--- a/src/tests/validity/import_with_trailing_comma.ab
+++ b/src/tests/validity/import_with_trailing_comma.ab
@@ -3,7 +3,7 @@ import {
     replace_regex,
 } from "std/text"
 import { sum, abs } from "std/math"
-import {} from "std/env"
+import { } from "std/env"
 
 // Output
 // c

--- a/src/tests/validity/import_with_trailing_comma.ab
+++ b/src/tests/validity/import_with_trailing_comma.ab
@@ -1,0 +1,13 @@
+import {
+    replace,
+    replace_regex,
+} from "std/text"
+import { sum, abs } from "std/math"
+import {} from "std/env"
+
+// Output
+// c
+// 3
+
+echo replace_regex(replace("aa", "a", "b"), "b+", "c", true)
+echo sum([abs(-2), 1])

--- a/src/tests/validity/import_with_trailing_comma.ab
+++ b/src/tests/validity/import_with_trailing_comma.ab
@@ -3,7 +3,6 @@ import {
     replace_regex,
 } from "std/text"
 import { sum, abs } from "std/math"
-import { } from "std/env"
 
 // Output
 // c


### PR DESCRIPTION
Ignore trailing commas in imports.

I've used GH-123 as a reference and given ChatGPT's advice.
