### PR TITLE
Use the bash native capitalizing method if available, and fallback to other functions

### DIFF
--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -142,8 +142,26 @@ pub fun char_at(text: Text, index: Num): Text {
 }
 
 /// Capitalize the first letter of the given `text`.
+#[allow_absurd_cast]
 pub fun capitalize(text: Text): Text {
-    return trust $ echo "{text}" | sed "s/^\(.\)/\U\1/" $
+    trust {
+        if len(text) == 0: return text
+        const bash_version = $ echo \"\$\{BASH_VERSINFO[0]}\" $ as Num
+        if {
+            bash_version >= 4 {
+                return $ echo \"\$\{text^}\" $
+            } else {
+                // GNU sed supports \U
+                $ re='\bCopyright\b.+\bFree Software Foundation\b'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
+                if status == 0:
+                    return trust $ echo "{text}" | sed "s/^\(.\)/\U\1/" $
+                else {
+                    let first_letter = upper(char_at(text, 0)) 
+                    return first_letter + slice(text, 1)
+                }
+            }
+        }
+    }
 }
 
 /// Pads `text` with the specified `pad` character on left until it reaches the desired `length`.
@@ -165,4 +183,8 @@ pub fun rpad(text: Text, pad: Text, length: Num): Text {
 /// Pads `text` with zeros on the left until it reaches the desired `length`.
 pub fun zfill(text: Text, length: Num): Text {
     return lpad(text, "0", length)
+}
+
+main(args) {
+    echo capitalize("aaa")
 }

--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -184,7 +184,3 @@ pub fun rpad(text: Text, pad: Text, length: Num): Text {
 pub fun zfill(text: Text, length: Num): Text {
     return lpad(text, "0", length)
 }
-
-main(args) {
-    echo capitalize("aaa")
-}

--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -145,22 +145,20 @@ pub fun char_at(text: Text, index: Num): Text {
 #[allow_absurd_cast]
 pub fun capitalize(text: Text): Text {
     trust {
-        if len(text) == 0: return text
-        const bash_version = $ echo \"\$\{BASH_VERSINFO[0]}\" $ as Num
-        if {
-            bash_version >= 4 {
-                return $ echo \"\$\{text^}\" $
-            } else {
-                // GNU sed supports \U
-                $ re='\bCopyright\b.+\bFree Software Foundation\b'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
-                if status == 0:
-                    return $ echo "{text}" | sed "s/^\(.\)/\U\1/" $
-                else {
-                    let first_letter = upper(char_at(text, 0)) 
-                    return first_letter + slice(text, 1)
-                }
-            }
+        if len(text) == 0 {
+            return text
         }
+        const bash_version = $ echo \"\$\{BASH_VERSINFO[0]}\" $ as Num
+        if bash_version >= 4 {
+            return $ echo \"\$\{text^}\" $
+        }
+        // GNU sed supports \U
+        $ re='\bCopyright\b.+\bFree Software Foundation\b'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
+        if status == 0 {
+            return $ echo "{text}" | sed "s/^\(.\)/\U\1/" $
+        }
+        const first_letter = upper(char_at(text, 0)) 
+        return first_letter + slice(text, 1)
     }
 }
 

--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -154,7 +154,7 @@ pub fun capitalize(text: Text): Text {
                 // GNU sed supports \U
                 $ re='\bCopyright\b.+\bFree Software Foundation\b'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
                 if status == 0:
-                    return trust $ echo "{text}" | sed "s/^\(.\)/\U\1/" $
+                    return $ echo "{text}" | sed "s/^\(.\)/\U\1/" $
                 else {
                     let first_letter = upper(char_at(text, 0)) 
                     return first_letter + slice(text, 1)


### PR DESCRIPTION
1. Since bash 4.0[^1], There is a native method to capitalize a variable. So use it.
2. The previous method, using `\U` in sed is not supported BusyBox sed, maybe. (I've searched on https://github.com/brgl/busybox/blob/master/editors/sed.c) So add a check to GNU sed. (This fixes one test of three failed busybox tests #617)
3. If the all above options are not available, use the text functions to implement capitalizing.

I've run this for several envs and the result:
![image](https://github.com/user-attachments/assets/51e9540a-23d7-40ce-b453-bd12482ffa5e)
(You can see the test workflow at https://github.com/lens0021/amber/pull/1)

[^1]: `docker run --rm bash:4.0 bash -c 'foo="aaa"; echo "${foo^}"'` -> `Aaa`, `docker run --rm bash:3.2 bash -c 'foo="aaa"; echo "${foo^}"'` -> `bash: ${foo^}: bad substitution`