### PR TITLE
docs: Remove the .ab extension from import statements for stdlib

### DIFF
--- a/src/modules/function/declaration.rs
+++ b/src/modules/function/declaration.rs
@@ -309,6 +309,7 @@ impl FunctionDeclaration {
                 .map(Path::new)
                 .and_then(Path::file_name)
                 .and_then(OsStr::to_str)
+                .map(|s| s.trim_end_matches(".ab"))
                 .map(String::from)
                 .unwrap_or_default();
             result.push(String::from("```ab"));


### PR DESCRIPTION
| After | Before |
|--------|--------|
| `import { array_first_index } from "std/array.ab"` | `import { array_first_index } from "std/array"` |

I believe the `.ab` must be omitted when importing stdlib:

![image](https://github.com/user-attachments/assets/e717eefa-eb08-454d-8517-579afce1ad6a)
