### PR TITLE
New release 0.4.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "amber"
-version = "0.3.5-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "amber-meta",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amber"
-version = "0.3.5-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 repository = "https://github.com/amber-lang/Amber"
 homepage = "https://amber-lang.com/"


### PR DESCRIPTION
Bumps current version from `0.3.5-alpha` to `0.4.0-alpha`. You can see all the changes in the linked issue