### PR TITLE
Implemented AMBER_PATH for import lookup

### DIFF
--- a/src/modules/imports/import.rs
+++ b/src/modules/imports/import.rs
@@ -78,12 +78,19 @@ impl Import {
             }
         } else {
             match fs::read_to_string(self.path.value.clone()) {
-                Ok(content) => Ok(content),
-                Err(err) => error!(meta, self.token_path.clone() => {
-                    message: format!("Could not read file '{}'", self.path.value),
-                    comment: err.to_string()
-                })
+                Ok(content) => return Ok(content),
+                Err(_) => ()
             }
+            for path in meta.context.import_paths.clone() {
+                match fs::read_to_string(path.join(self.path.value.clone())) {
+                    Ok(content) => return Ok(content),
+                    Err(_) => ()
+                }
+            }
+            error!(meta, self.token_path.clone() => {
+                message: format!("Could not find '{}'", self.path.value),
+                comment: format!("Tried lookup paths: {:?}", meta.context.import_paths)
+            })
         }
     }
 

--- a/src/utils/context.rs
+++ b/src/utils/context.rs
@@ -3,7 +3,7 @@ use crate::modules::expression::expr::Expr;
 use crate::modules::types::Type;
 use amber_meta::ContextHelper;
 use heraclitus_compiler::prelude::*;
-use std::collections::{HashMap, HashSet};
+use std::{collections::{HashMap, HashSet}, path::PathBuf, env};
 
 #[derive(Clone, Debug)]
 pub struct FunctionDecl {
@@ -123,6 +123,9 @@ pub struct Context {
     /// List of compiler flags
     #[context]
     pub cc_flags: HashSet<CCFlags>,
+    /// List of lookup paths
+    #[context]
+    pub import_paths: Vec<PathBuf>,
 }
 
 // FIXME: Move the scope related structures to the separate file
@@ -141,6 +144,7 @@ impl Context {
             pub_funs: vec![],
             fun_ret_type: None,
             cc_flags: HashSet::new(),
+            import_paths: env::split_paths(&env::var("AMBER_PATH").unwrap_or("".to_string())).collect(),
         }
     }
 


### PR DESCRIPTION
This fixes #668 and opens up possibilities for simpler package managers, as they could export a set of standard paths.
