### PR TITLE
replace_regex: remove bash word boundary when detecting gnused

### DIFF
--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -19,7 +19,7 @@ pub fun replace_regex(source: Text, search: Text, replace: Text, extended: Bool 
             // GNU sed versions 4.0 through 4.2 support extended regex syntax,
             // but only via the "-r" option; use that if the version information
             // contains "GNU sed".
-            $ re='\bCopyright\b.+\bFree Software Foundation\b'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
+            $ re='Copyright.+Free Software Foundation'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
             let flag = status == 0 then "-r" else "-E"
             return $ echo "{source}" | sed "{flag}" -e "s/{search}/{replace}/g" $
         } else {


### PR DESCRIPTION
Bash linked against C libraries other than GLibc may not support GNU extensions of POSIX Extended Regular Regex. For example,

```
re='\bx'; [[ 'x' =~ $re ]] && echo "1"
```

does not output the same result on Linux/GLibc and macOS.