### PR TITLE
vscode debug profile

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug the Amber compiler",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=amber",
+                    "--package=amber"
+                ],
+                "filter": {
+                    "name": "amber",
+                    "kind": "bin",
+                }
+            },
+            "args": [
+                "build",
+                "test.ab",
+                "test.sh"
+            ],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}


### PR DESCRIPTION
this adds a debug profile for vscode users

i didn't create an issue for this because i don't think there is anything to discuss as i've already been using this profile for some time.

the only reason to close this that i can think of is that there woudn't be enough people in this project that use vscode to justify adding a directory to the root of the repo