### PR TITLE
fix: Update condition to filter Bash 4.4 or later

### DIFF
--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -24,7 +24,7 @@ pub fun replace(source, search, replace) {
 pub fun replace_one(source, search, replace) {
     // Here we use a command to avoid #646
     let result = ""
-    if bash_version() > [4,3] {
+    if bash_version() >= [4,3] {
         trust $ {nameof result}="\$\{{nameof source}/\"\$\{{nameof search}}\"/\"\$\{{nameof replace}}\"}" $
     } else {
         trust $ {nameof result}="\$\{{nameof source}/\"\$\{{nameof search}}\"/\$\{{nameof replace}}}" $

--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -12,7 +12,7 @@ fun bash_version(): [Num] {
 pub fun replace(source, search, replace) {
     // Here we use a command to avoid #646
     let result = ""
-    if bash_version() > [4,2] {
+    if bash_version() > [4,3] {
         trust $ {nameof result}="\$\{{nameof source}//\"\$\{{nameof search}}\"/\"\$\{{nameof replace}}\"}" $
     } else {
         trust $ {nameof result}="\$\{{nameof source}//\"\$\{{nameof search}}\"/\$\{{nameof replace}}}" $
@@ -24,7 +24,7 @@ pub fun replace(source, search, replace) {
 pub fun replace_one(source, search, replace) {
     // Here we use a command to avoid #646
     let result = ""
-    if bash_version() > [4,2] {
+    if bash_version() > [4,3] {
         trust $ {nameof result}="\$\{{nameof source}/\"\$\{{nameof search}}\"/\"\$\{{nameof replace}}\"}" $
     } else {
         trust $ {nameof result}="\$\{{nameof source}/\"\$\{{nameof search}}\"/\$\{{nameof replace}}}" $

--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -12,7 +12,7 @@ fun bash_version(): [Num] {
 pub fun replace(source, search, replace) {
     // Here we use a command to avoid #646
     let result = ""
-    if bash_version() > [4,3] {
+    if bash_version() >= [4,3] {
         trust $ {nameof result}="\$\{{nameof source}//\"\$\{{nameof search}}\"/\"\$\{{nameof replace}}\"}" $
     } else {
         trust $ {nameof result}="\$\{{nameof source}//\"\$\{{nameof search}}\"/\$\{{nameof replace}}}" $


### PR DESCRIPTION
I have not done a deep research, but this change fixes the broken tests.

(The title of this PR can be improved, but my English is broken now. I will fix maybe soon...)