### PR TITLE
fix: Disable some GNU Sed only features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -76,10 +76,9 @@ jobs:
           - "bash:3.2"
         sed:
           - GNU_sed
-        # Uncomment the next matrix when https://github.com/amber-lang/amber/issues/617 is resolved
-        # include:
-        #   - sed: BusyBox_sed
-        #     bash_version: "bash:latest"
+        include:
+          - sed: BusyBox_sed
+            bash_docker_image: "bash:latest"
     steps:
       - uses: actions/checkout@v4
       - uses: awalsh128/cache-apt-pkgs-action@latest

--- a/src/std/fs.ab
+++ b/src/std/fs.ab
@@ -116,9 +116,9 @@ pub fun file_glob(path: Text): [Text]? {
 pub fun file_extract(path: Text, target: Text): Null? {
     if file_exists(path) {
         if {
-            match_regex(path, "\.\(tar\.bz2\|tbz\|tbz2\)$"): $ tar xvjf "{path}" -C "{target}" $?
-            match_regex(path, "\.\(tar\.gz\|tgz\)$"): $ tar xzf "{path}" -C "{target}" $?
-            match_regex(path, "\.\(tar\.xz\|txz\)$"): $ tar xJf "{path}" -C "{target}" $?
+            match_regex(path, "\.(tar\.bz2|tbz|tbz2)$", true): $ tar xvjf "{path}" -C "{target}" $?
+            match_regex(path, "\.(tar\.gz|tgz)$", true): $ tar xzf "{path}" -C "{target}" $?
+            match_regex(path, "\.(tar\.xz|txz)$", true): $ tar xJf "{path}" -C "{target}" $?
             match_regex(path, "\.bz2$"): $ bunzip2 "{path}" $?
             match_regex(path, "\.deb$"): $ dpkg-deb -xv "{path}" "{target}" $?
             match_regex(path, "\.gz$"): $ gunzip "{path}" $?

--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -32,21 +32,36 @@ pub fun replace_one(source, search, replace) {
     return result
 }
 
-/// Replaces all occurrences of a regex pattern in the content with the provided replace text.
+fun is_gnu_sed(): Bool {
+    trust $ re='\bCopyright\b.+\bFree Software Foundation\b'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
+    // We currently ignore the possibility that this can be alpine (busybox) sed
+    // which contains "This is not GNU sed version"
+    return status == 0
+}
+
+/// Replaces all occurences of a regex pattern in the content with the provided replace text.
 ///
 /// Function uses `sed`
 pub fun replace_regex(source: Text, search: Text, replace: Text, extended: Bool = false): Text {
     trust {
+        const is_gnu_sed = is_gnu_sed()
         search = replace(search, "/", "\/")
         replace = replace(replace, "/", "\/")
         if extended {
             // GNU sed versions 4.0 through 4.2 support extended regex syntax,
-            // but only via the "-r" option; use that if the version information
-            // contains "GNU sed".
-            $ re='Copyright.+Free Software Foundation'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
-            let flag = status == 0 then "-r" else "-E"
-            return $ echo "{source}" | sed "{flag}" -e "s/{search}/{replace}/g" $
+            // but only via the "-r" option
+            if is_gnu_sed {
+                // '\b' is not in POSIX standards. Disable it
+                search = replace(search, "\\b", "\\\b")
+                return $ echo "{source}" | sed -r -e "s/{search}/{replace}/g" $
+            } else {
+                return $ echo "{source}" | sed -E -e "s/{search}/{replace}/g" $
+            }
         } else {
+            if is_gnu_sed {
+                // GNU Sed BRE handle \| as a metacharacter, but it is not POSIX standands. Disable it
+                search = replace(search, "\|", "|")
+            }
             return $ echo "{source}" | sed -e "s/{search}/{replace}/g" $
         }
     }
@@ -151,16 +166,24 @@ pub fun text_contains_all(text: Text, terms: [Text]): Bool {
 /// Function uses `sed`
 pub fun match_regex(source: Text, search: Text, extended: Bool = false): Bool {
     trust {
+        const is_gnu_sed = is_gnu_sed()
         search = replace(search, "/", "\/")
         let output = ""
         if extended {
             // GNU sed versions 4.0 through 4.2 support extended regex syntax,
-            // but only via the "-r" option; use that if the version information
-            // contains "GNU sed".
-            $ re='\bCopyright\b.+\bFree Software Foundation\b'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
-            let flag = status == 0 then "-r" else "-E"
-            output = $ echo "{source}" | sed "{flag}" -ne "/{search}/p" $
+            // but only via the "-r" option
+            if is_gnu_sed {
+                // '\b' is not in POSIX standards. Disable it
+                search = replace(search, "\b", "\\b")
+                output = $ echo "{source}" | sed -r -ne "/{search}/p" $
+            } else {
+                output = $ echo "{source}" | sed -E -ne "/{search}/p" $
+            }
         } else {
+            if is_gnu_sed {
+                // GNU Sed BRE handle \| as a metacharacter, but it is not POSIX standands. Disable it
+                search = replace(search, "\|", "|")
+            }
             output = $ echo "{source}" | sed -ne "/{search}/p" $
         }
         if output != "" {

--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -34,8 +34,8 @@ pub fun replace_one(source, search, replace) {
 
 fun is_gnu_sed(): Bool {
     trust $ re='\bCopyright\b.+\bFree Software Foundation\b'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
-    // We currently ignore the possibility that this can be alpine (busybox) sed
-    // which contains "This is not GNU sed version"
+    // We can't match agains a word "GNU" because
+    // alpine's busybox sed returns "This is not GNU sed version"
     return status == 0
 }
 

--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -32,11 +32,23 @@ pub fun replace_one(source, search, replace) {
     return result
 }
 
-fun is_gnu_sed(): Bool {
-    trust $ re='\bCopyright\b.+\bFree Software Foundation\b'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
+const SED_VERSION_UNKNOWN = 0
+const SED_VERSION_GNU = 1
+const SED_VERSION_BUSYBOX = 2
+const SED_VERSION_BSD = 3
+
+fun sed_version(): Num {
     // We can't match agains a word "GNU" because
     // alpine's busybox sed returns "This is not GNU sed version"
-    return status == 0
+    trust $ re='\bCopyright\b.+\bFree Software Foundation\b'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
+    if status == 0 {
+        return SED_VERSION_GNU
+    }
+    trust $ re='\bBusyBox\b'; [[ \$(sed 2>&1) =~ \$re ]] $
+    if status == 0 {
+        return SED_VERSION_BUSYBOX
+    }
+    return SED_VERSION_UNKNOWN
 }
 
 /// Replaces all occurences of a regex pattern in the content with the provided replace text.
@@ -44,21 +56,23 @@ fun is_gnu_sed(): Bool {
 /// Function uses `sed`
 pub fun replace_regex(source: Text, search: Text, replace: Text, extended: Bool = false): Text {
     trust {
-        const is_gnu_sed = is_gnu_sed()
+        const sed_version = sed_version()
         search = replace(search, "/", "\/")
         replace = replace(replace, "/", "\/")
+        if sed_version == SED_VERSION_GNU or sed_version == SED_VERSION_BUSYBOX {
+            // '\b' is supported but not in POSIX standards. Disable it
+            search = replace(search, "\\b", "\\\b")
+        }
         if extended {
             // GNU sed versions 4.0 through 4.2 support extended regex syntax,
             // but only via the "-r" option
-            if is_gnu_sed {
-                // '\b' is not in POSIX standards. Disable it
-                search = replace(search, "\\b", "\\\b")
+            if sed_version == SED_VERSION_GNU {
                 return $ echo "{source}" | sed -r -e "s/{search}/{replace}/g" $
             } else {
                 return $ echo "{source}" | sed -E -e "s/{search}/{replace}/g" $
             }
         } else {
-            if is_gnu_sed {
+            if sed_version == SED_VERSION_GNU or sed_version == SED_VERSION_BUSYBOX {
                 // GNU Sed BRE handle \| as a metacharacter, but it is not POSIX standands. Disable it
                 search = replace(search, "\|", "|")
             }
@@ -166,13 +180,17 @@ pub fun text_contains_all(text: Text, terms: [Text]): Bool {
 /// Function uses `sed`
 pub fun match_regex(source: Text, search: Text, extended: Bool = false): Bool {
     trust {
-        const is_gnu_sed = is_gnu_sed()
+        const sed_version = sed_version()
         search = replace(search, "/", "\/")
         let output = ""
+        if sed_version == SED_VERSION_GNU or sed_version == SED_VERSION_BUSYBOX {
+            // '\b' is supported but not in POSIX standards. Disable it
+            search = replace(search, "\\b", "\\\b")
+        }
         if extended {
             // GNU sed versions 4.0 through 4.2 support extended regex syntax,
             // but only via the "-r" option
-            if is_gnu_sed {
+            if sed_version == SED_VERSION_GNU {
                 // '\b' is not in POSIX standards. Disable it
                 search = replace(search, "\b", "\\b")
                 output = $ echo "{source}" | sed -r -ne "/{search}/p" $
@@ -180,7 +198,7 @@ pub fun match_regex(source: Text, search: Text, extended: Bool = false): Bool {
                 output = $ echo "{source}" | sed -E -ne "/{search}/p" $
             }
         } else {
-            if is_gnu_sed {
+            if sed_version == SED_VERSION_GNU or sed_version == SED_VERSION_BUSYBOX {
                 // GNU Sed BRE handle \| as a metacharacter, but it is not POSIX standands. Disable it
                 search = replace(search, "\|", "|")
             }
@@ -252,13 +270,11 @@ pub fun capitalized(text: Text): Text {
         if len(text) == 0 {
             return text
         }
-        const bash_version = $ echo \"\$\{BASH_VERSINFO[0]}\" $ as Num
-        if bash_version >= 4 {
+        if bash_version() >= [4] {
             return $ echo \"\$\{text^}\" $
         }
-        // GNU sed supports \U
-        $ re='\bCopyright\b.+\bFree Software Foundation\b'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
-        if status == 0 {
+        if sed_version() == SED_VERSION_GNU {
+            // GNU sed supports \U
             return $ echo "{text}" | sed "s/^\(.\)/\U\1/" $
         }
         const first_letter = uppercase(char_at(text, 0))

--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -35,10 +35,9 @@ pub fun replace_one(source, search, replace) {
 const SED_VERSION_UNKNOWN = 0
 const SED_VERSION_GNU = 1
 const SED_VERSION_BUSYBOX = 2
-const SED_VERSION_BSD = 3
 
 fun sed_version(): Num {
-    // We can't match agains a word "GNU" because
+    // We can't match against a word "GNU" because
     // alpine's busybox sed returns "This is not GNU sed version"
     trust $ re='\bCopyright\b.+\bFree Software Foundation\b'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
     if status == 0 {

--- a/src/tests/stdlib/text_match_regex.ab
+++ b/src/tests/stdlib/text_match_regex.ab
@@ -5,7 +5,7 @@ main {
         echo "\$ match failed"
     }
     if match_regex("to be", "to be|not to be") {
-        echo "A pipe (|) should be treated as a literal character in POSIX Standards BRE. Actually not."
+        echo "A pipe (|) should be treated as a literal character in POSIX Standards BRE."
     }
 
     echo "Succeeded"

--- a/src/tests/stdlib/text_match_regex.ab
+++ b/src/tests/stdlib/text_match_regex.ab
@@ -1,12 +1,12 @@
 import { match_regex } from "std/text"
 
-main {
-    if not match_regex("Hello World", "World$") {
-        echo "\$ match failed"
-    }
-    if match_regex("to be", "to be|not to be") {
-        echo "A pipe (|) should be treated as a literal character in POSIX Standards BRE."
-    }
+// Output
+// Succeeded
+// Succeeded
 
-    echo "Succeeded"
+main {
+    // $ end of string
+    echo match_regex("Hello World", " World$") then "Succeeded" else ""
+    // A pipe (|) should be treated as a literal character in POSIX Standards BRE.
+    echo match_regex("to be", "to be|not to be") then "" else "Succeeded"
 }

--- a/src/tests/stdlib/text_match_regex.ab
+++ b/src/tests/stdlib/text_match_regex.ab
@@ -1,7 +1,12 @@
 import { match_regex } from "std/text"
 
 main {
-    if match_regex("Hello World", "World$") {
-        echo "Succeeded"
+    if not match_regex("Hello World", "World$") {
+        echo "\$ match failed"
     }
+    if match_regex("to be", "to be|not to be") {
+        echo "A pipe (|) should be treated as a literal character in POSIX Standards BRE. Actually not."
+    }
+
+    echo "Succeeded"
 }

--- a/src/tests/stdlib/text_replace_regex_basic.ab
+++ b/src/tests/stdlib/text_replace_regex_basic.ab
@@ -14,7 +14,7 @@ main {
     // Ending position of the string
     echo replace_regex("foo", "foo$", "###")
     // A pipe (|) should be treated as a literal character in POSIX Standards BRE.
-    echo replace_regex(".tar.gz", "\.\(tar\.gz\|tgz\)$", "Succeeded")
+    echo replace_regex(".tar.gz", "\.\(tar\.gz\|tgz\)$", "Failed")
     // Replacing forward slash failed
     echo replace_regex("/path/to/file.txt", "/", "#")
 }

--- a/src/tests/stdlib/text_replace_regex_basic.ab
+++ b/src/tests/stdlib/text_replace_regex_basic.ab
@@ -1,22 +1,20 @@
 import * from "std/text"
 
-main {
-    if replace_regex("aeon aeons eon eons", " eon ", " ### ") != "aeon aeons ### eons" {
-        echo "expected: aeon aeons ### eons"
-        echo "actual: {replace_regex("aeon aeons eon eons", " eon ", "###")}"
-    }
-    if replace_regex("abc123def", "\([0-9][0-9]*\)", "[\1]") != "abc[123]def" {
-        echo "Combination of bracket exp and one or more failed"
-    }
-    if replace_regex("foo", "foo$", "###") != "###" {
-        echo "Ending position of the string failed"
-    }
-    if replace_regex(".tar.gz", "\.\(tar\.gz\|tgz\)$", "") == "" {
-        echo "A pipe (|) should be treated as a literal character in POSIX Standards BRE. Actually not."
-    }
-    if replace_regex("/path/to/file.txt", "/", "#") != "#path#to#file.txt" {
-        echo "Replacing forward slash failed"
-    }
+// Output
+// aeon aeons ### eons
+// abc[123]def
+// ###
+// .tar.gz
+// #path#to#file.txt
 
-    echo "Succeeded"
+main {
+    echo replace_regex("aeon aeons eon eons", " eon ", " ### ")
+    // Combination of bracket exp and one or more
+    echo replace_regex("abc123def", "\([0-9][0-9]*\)", "[\1]")
+    // Ending position of the string
+    echo replace_regex("foo", "foo$", "###")
+    // A pipe (|) should be treated as a literal character in POSIX Standards BRE.
+    echo replace_regex(".tar.gz", "\.\(tar\.gz\|tgz\)$", "Succeeded")
+    // Replacing forward slash failed
+    echo replace_regex("/path/to/file.txt", "/", "#")
 }

--- a/src/tests/stdlib/text_replace_regex_basic.ab
+++ b/src/tests/stdlib/text_replace_regex_basic.ab
@@ -1,12 +1,22 @@
 import * from "std/text"
 
-// Output
-// abc[123]def
-// aeon aeons ### eons
-// #path#to#file.txt
-
 main {
-    echo replace_regex("abc123def", "\([0-9][0-9]*\)", "[\1]")
-    echo replace_regex("aeon aeons eon eons", " eon ", " ### ")
-    echo replace_regex("/path/to/file.txt", "/", "#")
+    if replace_regex("aeon aeons eon eons", " eon ", " ### ") != "aeon aeons ### eons" {
+        echo "expected: aeon aeons ### eons"
+        echo "actual: {replace_regex("aeon aeons eon eons", " eon ", "###")}"
+    }
+    if replace_regex("abc123def", "\([0-9][0-9]*\)", "[\1]") != "abc[123]def" {
+        echo "Combination of bracket exp and one or more failed"
+    }
+    if replace_regex("foo", "foo$", "###") != "###" {
+        echo "Ending position of the string failed"
+    }
+    if replace_regex(".tar.gz", "\.\(tar\.gz\|tgz\)$", "") == "" {
+        echo "A pipe (|) should be treated as a literal character in POSIX Standards BRE. Actually not."
+    }
+    if replace_regex("/path/to/file.txt", "/", "#") != "#path#to#file.txt" {
+        echo "Replacing forward slash failed"
+    }
+
+    echo "Succeeded"
 }

--- a/src/tests/stdlib/text_replace_regex_ext.ab
+++ b/src/tests/stdlib/text_replace_regex_ext.ab
@@ -1,29 +1,27 @@
 import * from "std/text"
 
-main {
-    // This will fail on any system where sed does not support extended
-    // regex syntax, via "-r" on GNU sed and "-E" on all other versions.
-    if replace_regex("aaa", "a+", "", true) != "" {
-        echo "One or more matching failed"
-    }
-    if replace_regex("abc", "[ab]", "c", true) != "ccc" {
-        echo "Single character bracket expression failed"
-    }
-    if replace_regex("E", "[A-Z]", "E", true) != "E" {
-        echo "Range bracket expression failed"
-    }
-    if replace_regex("abc123def", "([0-9]+)", "[\1]", true) != "abc[123]def" {
-        echo "Combination of bracket exp and one or more failed"
-    }
-    if replace_regex("aeon aeons eon eons", "\beon\b", "###", true) == "aeon aeons ### eons" {
-        echo "Word boundary is handled, but it should not because it is not POSIX standard"
-    }
-    if replace_regex("/path/to/file.txt", "/", "#", true) != "#path#to#file.txt" {
-        echo "Replacing forward slash failed"
-    }
-    if replace_regex(".tar.gz", "\.(tar\.gz|tgz)$", "", true) != "" {
-        echo "A pipe (|) should be treated as OR in POSIX Standards ERE. Actually not."
-    }
+// Output
+// z
+// ccc
+// E
+// abc[123]def
+// aeon aeons eon eons
+// #path#to#file.txt
+// Succeeded
 
-    echo "Succeeded"
+main {
+    // One or more matching
+    echo replace_regex("aaa", "a+", "z", true)
+    // Single character bracket expression
+    echo replace_regex("abc", "[ab]", "c", true)
+    // Range bracket expression
+    echo replace_regex("E", "[A-Z]", "E", true)
+    // Combination of bracket exp, caupturing group and one or more
+    echo replace_regex("abc123def", "([0-9]+)", "[\1]", true)
+    // Word boundary should not be handled, because it is not POSIX standard
+    echo replace_regex("aeon aeons eon eons", "\beon\b", "###", true)
+    // Replacing forward slash
+    echo replace_regex("/path/to/file.txt", "/", "#", true)
+    // A pipe (|) should be treated as OR in POSIX Standards ERE.
+    echo replace_regex(".tar.gz", "\.(tar\.gz|tgz)$", "Succeeded", true)
 }

--- a/src/tests/stdlib/text_replace_regex_ext.ab
+++ b/src/tests/stdlib/text_replace_regex_ext.ab
@@ -1,17 +1,29 @@
 import * from "std/text"
 
-// Output
-// abc[123]def
-// aeon aeons ### eons
-// #path#to#file.txt
-
 main {
-    $ re='Copyright.+Free Software Foundation'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $ failed {
-        echo "Succeeded"
-    }
     // This will fail on any system where sed does not support extended
     // regex syntax, via "-r" on GNU sed and "-E" on all other versions.
-    echo replace_regex("abc123def", "([0-9]+)", "[\1]", true)
-    echo replace_regex("aeon aeons eon eons", "\beon\b", "###", true)
-    echo replace_regex("/path/to/file.txt", "/", "#", true)
+    if replace_regex("aaa", "a+", "", true) != "" {
+        echo "One or more matching failed"
+    }
+    if replace_regex("abc", "[ab]", "c", true) != "ccc" {
+        echo "Single character bracket expression failed"
+    }
+    if replace_regex("E", "[A-Z]", "E", true) != "E" {
+        echo "Range bracket expression failed"
+    }
+    if replace_regex("abc123def", "([0-9]+)", "[\1]", true) != "abc[123]def" {
+        echo "Combination of bracket exp and one or more failed"
+    }
+    if replace_regex("aeon aeons eon eons", "\beon\b", "###", true) == "aeon aeons ### eons" {
+        echo "Word boundary is handled, but it should not because it is not POSIX standard"
+    }
+    if replace_regex("/path/to/file.txt", "/", "#", true) != "#path#to#file.txt" {
+        echo "Replacing forward slash failed"
+    }
+    if replace_regex(".tar.gz", "\.(tar\.gz|tgz)$", "", true) != "" {
+        echo "A pipe (|) should be treated as OR in POSIX Standards ERE. Actually not."
+    }
+
+    echo "Succeeded"
 }


### PR DESCRIPTION
Disclaimer: I am not a REGEX expert and cannot be.

Today, I have just known GNU Sed provides a lot of features that are not included in POSIX Standards.
For compatibility to Mac OS X, this PR disables the features by escaping some character sequences.
This is the first referred solution at https://github.com/amber-lang/amber/discussions/716.

## Breaking changes

`match_regex()` and `replace_regex()` do not handle the followings anymore:

- `\b` in ERE and BRE
  - ["The GNU extensions to POSIX regular expressions add support for the \b and \B word boundaries"](https://www.regular-expressions.info/wordboundaries.html#:~:text=The%20GNU%20extensions%20to%20POSIX%20regular%20expressions%20add%20support%20for%20the%20%5Cb%20and%20%5CB%20word%20boundaries)
- `|` in BRE
  - ["Obsolete (“basic”) regular expressions differ in several respects. ‘|’ is an ordinary character"](https://stackoverflow.com/questions/73732299/sed-is-failing-when-regex-pattern-is-a-group#:~:text=Obsolete%20(%E2%80%9Cbasic%E2%80%9D)%20regular%20expressions%20differ%20in%20several%20respects.%20%E2%80%98%7C%E2%80%99%20is%20an%20ordinary%20character)
  - ["ERE only: `|`"](https://en.wikibooks.org/wiki/Regular_Expressions/POSIX-Extended_Regular_Expressions#:~:text=or%20%22ab%22.-,ERE%20only%3A%20%7C,-Matches%20the%20preceding)
  
  ---
  Closes #617 