### PR TITLE
docs: Fix the comment of UnOp group macro

### DIFF
--- a/src/modules/expression/macros.rs
+++ b/src/modules/expression/macros.rs
@@ -89,7 +89,7 @@ macro_rules! parse_expr_group {
         Ok(node)
     }};
 
-    // Group type that handles Literals. Use this group as the last one in the precedence order
+    // Group type that handles Unary Operators.
     (@internal ({$cur:ident, $prev:ident}, $meta:expr, UnOp => [$($cur_modules:ident),+])) => {{
         let start_index = $meta.get_index();
         $({


### PR DESCRIPTION
There are BinOp, TypeOp, TernOp, UnOp and Literal rules, but there are two comments for literal rule.