### PR TITLE
Fix clippy::uninlined_format_args

### DIFF
--- a/meta/src/helper.rs
+++ b/meta/src/helper.rs
@@ -18,7 +18,7 @@ impl HelperVisitor {
     }
 
     fn make_function(name: &Ident, segment: &PathSegment) -> TokenStream2 {
-        let concat = format!("set_{}", name);
+        let concat = format!("set_{name}");
         let concat = Ident::new(&concat, name.span());
         quote! {
             /// Sets the field value and returns the previous value.

--- a/meta/src/manager.rs
+++ b/meta/src/manager.rs
@@ -18,7 +18,7 @@ impl ManagerVisitor {
     }
 
     fn make_with(name: &Ident, segment: &PathSegment) -> TokenStream2 {
-        let concat = format!("with_{}", name);
+        let concat = format!("with_{name}");
         let concat = Ident::new(&concat, name.span());
         quote! {
             /// Sets the field value (which must implement the `Copy` and
@@ -39,7 +39,7 @@ impl ManagerVisitor {
     }
 
     fn make_with_ref(name: &Ident, segment: &PathSegment) -> TokenStream2 {
-        let concat = format!("with_{}_ref", name);
+        let concat = format!("with_{name}_ref");
         let concat = Ident::new(&concat, name.span());
         quote! {
             /// Sets the field value by swapping the references, and
@@ -59,7 +59,7 @@ impl ManagerVisitor {
     }
 
     fn make_with_fn(name: &Ident, segment: &PathSegment) -> TokenStream2 {
-        let concat = format!("with_{}_fn", name);
+        let concat = format!("with_{name}_fn");
         let concat = Ident::new(&concat, name.span());
         quote! {
             /// Sets the field value on the encapsulated struct using

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -211,7 +211,7 @@ impl AmberCompiler {
         let header = include_str!("header.sh")
             .replace("{{ version }}", built_info::GIT_VERSION.unwrap_or(built_info::PKG_VERSION))
             .replace("{{ date }}", now.as_str());
-        Ok(format!("{}{}", header, result))
+        Ok(format!("{header}{result}"))
     }
 
     pub fn document(&self, block: Block, meta: ParserMetadata, output: Option<String>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,7 +219,7 @@ fn write_output(output: PathBuf, code: String) {
     } else {
         match fs::File::create(&output) {
             Ok(mut file) => {
-                write!(file, "{}", code).unwrap();
+                write!(file, "{code}").unwrap();
                 set_file_permission(&file, output);
             }
             Err(err) => {

--- a/src/modules/function/invocation_utils.rs
+++ b/src/modules/function/invocation_utils.rs
@@ -29,7 +29,7 @@ fn run_function_with_args(meta: &mut ParserMetadata, mut fun: FunctionDecl, args
     if fun.arg_names.len() != args.len() {
         let max_args = fun.arg_names.len();
         let min_args = fun.arg_names.len() - fun.arg_optionals.len();
-        let opt_argument = if max_args > min_args {&format!(" ({} optional)",max_args)} else {""};
+        let opt_argument = if max_args > min_args {&format!(" ({max_args} optional)")} else {""};
         // Determine the correct grammar
         let txt_arguments = pluralize(min_args, "argument", "arguments");
         let txt_given = pluralize(args.len(), "was given", "were given");
@@ -79,7 +79,7 @@ pub fn handle_function_reference(meta: &ParserMetadata, tok: Option<Token>, name
     match meta.get_fun_declaration(name) {
         Some(fun_decl) => Ok(fun_decl.id),
         None => {
-            let message = format!("Function '{}' does not exist", name);
+            let message = format!("Function '{name}' does not exist");
             // Find other similar variable if exists
             if let Some(comment) = handle_similar_function(meta, name) {
                 error!(meta, tok, message, comment)

--- a/src/modules/types.rs
+++ b/src/modules/types.rs
@@ -64,7 +64,7 @@ impl Display for Type {
             Type::Array(t) => if **t == Type::Generic {
                     write!(f, "[]")
                 } else {
-                    write!(f, "[{}]", t)
+                    write!(f, "[{t}]")
                 },
             Type::Generic => write!(f, "Generic")
         }

--- a/src/modules/variable/mod.rs
+++ b/src/modules/variable/mod.rs
@@ -44,7 +44,7 @@ pub fn handle_variable_reference(meta: &mut ParserMetadata, tok: &Option<Token>,
     match meta.get_var(name) {
         Some(variable_unit) => Ok(variable_unit.clone()),
         None => {
-            let message = format!("Variable '{}' does not exist", name);
+            let message = format!("Variable '{name}' does not exist");
             // Find other similar variable if exists
             if let Some(comment) = handle_similar_variable(meta, name) {
                 error!(meta, tok.clone(), message, comment)
@@ -119,7 +119,7 @@ pub fn handle_index_accessor(meta: &mut ParserMetadata, range: bool) -> Result<O
         if !allow_index_accessor(&index, range) {
             let expected = if range { "number or range" } else { "number (and not a range)" };
             let side = if range { "right" } else { "left" };
-            let message = format!("Index accessor must be a {} for {} side of operation", expected, side);
+            let message = format!("Index accessor must be a {expected} for {side} side of operation");
             let comment = format!("The index accessor must be a {} not a {}", expected, index.get_type());
             return error!(meta, tok => { message: message, comment: comment });
         }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -47,7 +47,7 @@ pub fn test_amber(code: &str, result: &str, target: TestOutcomeTarget) {
         }
         TestOutcomeTarget::Failure => match evaluated {
             Ok(stdout) => {
-                panic!("Expected error, got: {}", stdout)
+                panic!("Expected error, got: {stdout}")
             }
             Err(err) => {
                 let message = err.message.expect("Error message expected");

--- a/src/translate/fragments/var_stmt.rs
+++ b/src/translate/fragments/var_stmt.rs
@@ -76,7 +76,7 @@ impl VarStmtFragment {
         let variable = self.get_name();
 
         if self.is_ref {
-            format!("${{{}}}", variable)
+            format!("${{{variable}}}")
         } else {
             variable.to_string()
         }


### PR DESCRIPTION
For some reason, this is caught as error suddenly.

![image](https://github.com/user-attachments/assets/0e0cb75c-c288-4c8b-baaa-3adda2c95692)

Used `cargo clippy --fix`.
See https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args for details