### PR TITLE
chore(text.ab): Rename the parameters of text_contain*() functions to source and search

### DIFF
--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -144,8 +144,8 @@ pub fun split_chars(text: Text): [Text] {
 }
 
 /// Checks if some text contains a value.
-pub fun text_contains(text: Text, phrase: Text): Bool {
-  let result = trust $ if [[ "{text}" == *"{phrase}"* ]]; then
+pub fun text_contains(source: Text, search: Text): Bool {
+  let result = trust $ if [[ "{source}" == *"{search}"* ]]; then
     echo 1
   fi $
 
@@ -153,9 +153,9 @@ pub fun text_contains(text: Text, phrase: Text): Bool {
 }
 
 /// Checks if an array value is in the text.
-pub fun text_contains_any(text: Text, terms: [Text]): Bool {
-    for term in terms {
-        if text_contains(text, term) {
+pub fun text_contains_any(source: Text, searches: [Text]): Bool {
+    for search in searches {
+        if text_contains(source, search) {
             return true
         }
     }
@@ -164,9 +164,9 @@ pub fun text_contains_any(text: Text, terms: [Text]): Bool {
 }
 
 /// Checks if all the arrays values are in the string
-pub fun text_contains_all(text: Text, terms: [Text]): Bool {
-    for term in terms {
-        if not text_contains(text, term) {
+pub fun text_contains_all(source: Text, searches: [Text]): Bool {
+    for search in searches {
+        if not text_contains(source, search) {
             return false
         }
     }


### PR DESCRIPTION
## Motivation
When reading the following documentation,
(see the tooltip with the black background)
<img width="542" height="147" alt="image" src="https://github.com/user-attachments/assets/501c7fc1-d78d-4984-bc17-58a2a4b9c483" />

I am confused which one is the text where to find and which one is to find.

## Other languages

Not very helpful, because most of the languages have OOP class.

* [Rust](https://doc.rust-lang.org/std/string/struct.String.html#method.contains): `pub fn contains<P>(&self, pat: P) -> bool` ('pat' stands for a pattern)
* [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes): `includes(searchString)`
* Python: *(No function, syntax)*
* [Ruby](https://ruby-doc.org/core-2.6.9/String.html#method-i-include-3F): `include? other_str → true or false`
* [PHP](https://www.php.net/manual/en/function.str-contains.php): `str_contains(string $haystack, string $needle): bool`
* [Lua](https://www.codecademy.com/resources/docs/lua/strings/find): `string.find(fullString, searchString, init, pattern)`

I think `search_string` is not good for Amber because the name of the type we use is `Text`, not `String`.
`haystack` and `needle` are good for me, but do not seem to be used broadly.
So I choose `source` and `search`.