### PR TITLE
Improve escaping

### DIFF
--- a/src/modules/expression/literal/text.rs
+++ b/src/modules/expression/literal/text.rs
@@ -1,5 +1,6 @@
 use heraclitus_compiler::prelude::*;
 use crate::docs::module::DocumentationModule;
+use crate::modules::expression::literal::validate_text_escape_sequences;
 use crate::modules::prelude::*;
 use crate::modules::types::{Type, Typed};
 use crate::translate::module::TranslateModule;
@@ -30,7 +31,11 @@ impl SyntaxModule<ParserMetadata> for Text {
     }
 
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
+        let start_pos = meta.get_index();
         (self.strings, self.interps) = parse_interpolated_region(meta, '"')?;
+        for string in self.strings.iter() {
+            validate_text_escape_sequences(meta, string, start_pos, meta.get_index());
+        }
         Ok(())
     }
 }

--- a/src/translate/fragments/interpolable.rs
+++ b/src/translate/fragments/interpolable.rs
@@ -71,8 +71,8 @@ impl InterpolableFragment {
                     InterpolableRenderType::GlobalContext => result += r"\$",
                 }
                 '`' => match self.render_type {
-                    InterpolableRenderType::StringLiteral => result += r"`",
-                    InterpolableRenderType::GlobalContext => result += r"\`",
+                    InterpolableRenderType::StringLiteral => result += r"\`",
+                    InterpolableRenderType::GlobalContext => result += r"`",
                 }
                 '!' => match self.render_type {
                     InterpolableRenderType::StringLiteral => result += r#""'!'""#,


### PR DESCRIPTION
Removes warning for escape characters for commands and fixes the correct interpolation of backtick in `Text`.