### PR TITLE
Update standard library to use `Int` data types

### DIFF
--- a/src/std/array.ab
+++ b/src/std/array.ab
@@ -1,7 +1,7 @@
 /// Returns index of the first value found in the specified array.
 ///
 /// If the value is not found, the function returns -1.
-pub fun array_find(array, value): Num {
+pub fun array_find(array, value): Int {
     for index, element in array {
         if value as Text == element as Text {
             return index
@@ -11,8 +11,8 @@ pub fun array_find(array, value): Num {
 }
 
 /// Searches for a value in an array and returns an array with the index of the various items.
-pub fun array_find_all(array, value): [Num] {
-    let result = [Num]
+pub fun array_find_all(array, value): [Int] {
+    let result = [Int]
     for index, element in array {
         if value as Text == element as Text {
             result += [index]
@@ -45,7 +45,7 @@ pub fun array_last(array) {
 /// Removes an element at the index from the array; if the index is negative
 /// or beyond the end, the return value is undefined, but the array will be
 /// unchanged.
-pub fun array_remove_at(ref array: [], index: Num): Null {
+pub fun array_remove_at(ref array: [], index: Int): Null {
     let offset = index + 1
     let length = len(array)
     array = array[0..index] + array[offset..length]

--- a/src/std/date.ab
+++ b/src/std/date.ab
@@ -21,7 +21,7 @@
 /// - `%p` - locale's equivalent of either AM or PM; blank if unknown
 /// - `%T` - time; same as %H:%M:%S
 /// - `%Y` - year
-pub fun date_format_posix(date: Num, format: Text = "%F %T", utc: Bool = false): Text? {
+pub fun date_format_posix(date: Int, format: Text = "%F %T", utc: Bool = false): Text? {
     let utc_flag = utc then "-u" else ""
     // Case if this is a GNU date command
     return $ date {utc_flag} -d "@{date}" +"{format}" 2>/dev/null $ failed {
@@ -34,19 +34,19 @@ pub fun date_format_posix(date: Num, format: Text = "%F %T", utc: Bool = false):
 /// If no format is specified, "%F %T" format is used.
 /// For more info about format type "man date" on your shell or go to <https://www.gnu.org/software/coreutils/date>.
 #[allow_absurd_cast]
-pub fun date_from_posix(date: Text, format: Text = "%F %T", utc: Bool = false): Num? {
+pub fun date_from_posix(date: Text, format: Text = "%F %T", utc: Bool = false): Int? {
     let utc_flag = utc then "-u" else ""
     // Case if this is a GNU date command
     return $ date {utc_flag} -d "\$(date -d "{date}" +"{format}" 2>/dev/null)" +%s 2>/dev/null $ failed {
         // Case if this is a BSD date command
-        return $ date {utc_flag} -j -f "{format}" "{date}" +%s $? as Num
-    } as Num
+        return $ date {utc_flag} -j -f "{format}" "{date}" +%s $? as Int
+    } as Int
 }
 
 /// Returns the current timestamp (seconds since the Epoch (1970-01-01 00:00 UTC)).
 #[allow_absurd_cast]
-pub fun date_now(): Num {
-    return trust $ date +%s $ as Num
+pub fun date_now(): Int {
+    return trust $ date +%s $ as Int
 }
 
 /// Adds a value to a date passed in the unix epoch format in miliseconds.
@@ -59,7 +59,7 @@ pub fun date_now(): Num {
 /// - hours
 /// - minutes
 /// - seconds
-pub fun date_add(date: Num, amount: Num, unit: Text): Num? {
+pub fun date_add(date: Int, amount: Int, unit: Text): Int? {
     if {
         unit == "years": return date + amount * 365 * 24 * 60 * 60
         unit == "months": return date + amount * 30 * 24 * 60 * 60
@@ -81,7 +81,7 @@ pub fun date_add(date: Num, amount: Num, unit: Text): Num? {
 /// - hours
 /// - minutes
 /// - seconds
-pub fun date_sub(date: Num, amount: Num, unit: Text): Num? {
+pub fun date_sub(date: Int, amount: Int, unit: Text): Int? {
     if {
         unit == "years": return date - amount * 365 * 24 * 60 * 60
         unit == "months": return date - amount * 30 * 24 * 60 * 60

--- a/src/std/env.ab
+++ b/src/std/env.ab
@@ -118,7 +118,7 @@ pub fun escaped(text: Text): Text {
 }
 
 /// Prepares a text with formatting options for `printf`.
-pub fun styled(message: Text, style: Num, fg: Num, bg: Num): Text {
+pub fun styled(message: Text, style: Int, fg: Int, bg: Int): Text {
     return "\x1b[{style};{fg};{bg}m{escaped(message)}\x1b[0m"
 }
 
@@ -138,7 +138,7 @@ pub fun underlined(message: Text): Text {
 }
 
 /// Prints a text with a specified color.
-pub fun echo_colored(message: Text, color: Num): Null {
+pub fun echo_colored(message: Text, color: Int): Null {
     printf("\x1b[{color as Text}m%s\x1b[0m\n", [message])
 }
 
@@ -158,7 +158,7 @@ pub fun echo_warning(message: Text): Null {
 }
 
 /// Prints a text as a error and exits if the status code is greater than 0.
-pub fun echo_error(message: Text, exit_code: Num = 1): Null {
+pub fun echo_error(message: Text, exit_code: Int = 1): Null {
     printf("\x1b[1;3;97;41m%s\x1b[0m\n", [message])
     if exit_code > 0 : exit(exit_code)
 }

--- a/src/std/fs.ab
+++ b/src/std/fs.ab
@@ -1,36 +1,32 @@
 import { match_regex, join, replace_regex, split, trim } from "std/text"
 
 /// Checks if a directory exists.
-pub fun dir_exists(path) {
-    $ [ -d "{path}" ] $ failed {
-        return false
-    }
-    return true
+pub fun dir_exists(path: Text): Bool {
+    trust $ [ -d "{path}" ] $
+    return status == 0
 }
 
 /// Checks if a file exists.
-pub fun file_exists(path) {
-    $ [ -f "{path}" ] $ failed {
-        return false
-    }
-    return true
+pub fun file_exists(path: Text): Bool {
+    trust $ [ -f "{path}" ] $
+    return status == 0
 }
 
 /// Gets file contents from a path.
-pub fun file_read(path) {
+pub fun file_read(path: Text): Text? {
     return $ < "{path}" $?
 }
 
 /// Writes content to a file.
 /// Doesn't check if the file exist
-pub fun file_write(path, content) {
+pub fun file_write(path: Text, content: Text): Text? {
     return $ echo "{content}" > "{path}" $?
 }
 
 /// Appends content to a file.
 ///
 /// Doesn't check if the file exists.
-pub fun file_append(path, content) {
+pub fun file_append(path: Text, content: Text): Text? {
     return $ echo "{content}" >> "{path}" $?
 }
 
@@ -66,10 +62,10 @@ fun is_mac_os_mktemp(): Bool {
 /// Create a temporary directory and return the path.
 /// Please note this does not respect _CS_DARWIN_USER_TEMP_DIR environment variable.
 pub fun temp_dir_create(
-        template: Text = "tmp.XXXXXXXXXX",
-        auto_delete: Bool = false,
-        force_delete: Bool = false
-    ): Text? {
+    template: Text = "tmp.XXXXXXXXXX",
+    auto_delete: Bool = false,
+    force_delete: Bool = false
+): Text? {
     if trim(template) == "" {
         echo "The template cannot be an empty string!"
         fail 1

--- a/src/std/math.ab
+++ b/src/std/math.ab
@@ -1,7 +1,9 @@
 /// Sums an array's contents
 #[allow_absurd_cast]
 pub fun math_sum(list: [Num]): Num {
-    return trust $ echo "{list}" | awk '\{s=0; for (i=1; i<=NF; i++) s+=\$i; print s}' $ as Num
+    let sum = 0
+    for item in list: sum += item
+    return sum
 }
 
 /// Returns a number, rounded to the nearest integer

--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -36,7 +36,7 @@ const SED_VERSION_UNKNOWN = 0
 const SED_VERSION_GNU = 1
 const SED_VERSION_BUSYBOX = 2
 
-fun sed_version(): Num {
+fun sed_version(): Int {
     // We can't match against a word "GNU" because
     // alpine's busybox sed returns "This is not GNU sed version"
     trust $ re='\bCopyright\b.+\bFree Software Foundation\b'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
@@ -129,8 +129,18 @@ pub fun uppercase(text: Text): Text {
 
 /// Attempts to parse a given text into a number, returning the parsed number or zero if parsing fails.
 #[allow_absurd_cast]
-pub fun parse_number(text: Text): Num? {
+pub fun parse_int(text: Text): Num? {
     $ [ -n "{text}" ] && [ "{text}" -eq "{text}" ] 2>/dev/null $?
+    return text as Num
+}
+
+/// Attempts to parse a given text into a number, returning the parsed number or zero if parsing fails.
+#[allow_absurd_cast]
+pub fun parse_num(text: Text): Num? {
+    let re_int="^-?[0-9]+$"
+    let re_float="^-?[0-9]*\.[0-9]+$"
+
+    $ [[ {text} =~ {re_int} ]] || [[ {text} =~ {re_float} ]] $?
     return text as Num
 }
 
@@ -170,7 +180,6 @@ pub fun text_contains_all(source: Text, searches: [Text]): Bool {
             return false
         }
     }
-
     return true
 }
 
@@ -249,7 +258,7 @@ pub fun ends_with(text: Text, suffix: Text): Bool {
 /// If `index` is negative, the substring starts from the end of `text` based on the absolute value of `index`.
 /// If `length` is provided, the substring will include `length` characters; otherwise, it slices to the end of `text`.
 /// If `length` is negative, an empty string is returned.
-pub fun slice(text: Text, index: Num, length: Num = 0): Text {
+pub fun slice(text: Text, index: Int, length: Int = 0): Text {
     if length == 0: length = len(text) - index
     if length <= 0: return ""
     return trust $ printf "%.{length}s" "\$\{text:{index}}" $
@@ -258,7 +267,7 @@ pub fun slice(text: Text, index: Num, length: Num = 0): Text {
 /// Returns the character from `text` at the specified `index` (0-based).
 ///
 /// If `index` is negative, the substring starts from the end of `text` based on the absolute value of `index`.
-pub fun char_at(text: Text, index: Num): Text {
+pub fun char_at(text: Text, index: Int): Text {
     return trust $ printf "%.1s" "\$\{text:{index}}" $
 }
 
@@ -282,7 +291,7 @@ pub fun capitalized(text: Text): Text {
 }
 
 /// Pads `text` with the specified `pad` character on left until it reaches the desired `length`.
-pub fun lpad(text: Text, pad: Text, length: Num): Text {
+pub fun lpad(text: Text, pad: Text, length: Int): Text {
     if length <= len(text): return text
     length = len(text) - length
     pad = trust $ printf "%{length}s" "" | tr " " "{pad}" $
@@ -290,7 +299,7 @@ pub fun lpad(text: Text, pad: Text, length: Num): Text {
 }
 
 /// Pads `text` with the specified `pad` character on the right until it reaches the desired `length`.
-pub fun rpad(text: Text, pad: Text, length: Num): Text {
+pub fun rpad(text: Text, pad: Text, length: Int): Text {
     if length <= len(text): return text
     length = len(text) - length
     pad = trust $ printf "%{length}s" "" | tr " " "{pad}" $
@@ -298,6 +307,6 @@ pub fun rpad(text: Text, pad: Text, length: Num): Text {
 }
 
 /// Pads `text` with zeros on the left until it reaches the desired `length`.
-pub fun zfill(text: Text, length: Num): Text {
+pub fun zfill(text: Text, length: Int): Text {
     return lpad(text, "0", length)
 }

--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -127,14 +127,14 @@ pub fun uppercase(text: Text): Text {
     return trust $ echo "{text}" | tr '[:lower:]' '[:upper:]' $
 }
 
-/// Attempts to parse a given text into a number, returning the parsed number or zero if parsing fails.
+/// Attempts to parse a given text into an `Int` number.
 #[allow_absurd_cast]
 pub fun parse_int(text: Text): Num? {
     $ [ -n "{text}" ] && [ "{text}" -eq "{text}" ] 2>/dev/null $?
     return text as Num
 }
 
-/// Attempts to parse a given text into a number, returning the parsed number or zero if parsing fails.
+/// Attempts to parse a given text into a `Num` number.
 #[allow_absurd_cast]
 pub fun parse_num(text: Text): Num? {
     let re_int="^-?[0-9]+$"

--- a/src/tests/stdlib/text_parse_int.ab
+++ b/src/tests/stdlib/text_parse_int.ab
@@ -1,0 +1,12 @@
+import * from "std/text"
+
+// Output
+// 123
+// -12
+// 0
+
+main {
+    echo parse_int("123")?
+    echo parse_int("-12")?
+    echo parse_int("0")?
+}

--- a/src/tests/stdlib/text_parse_num.ab
+++ b/src/tests/stdlib/text_parse_num.ab
@@ -1,0 +1,18 @@
+import * from "std/text"
+
+// Output
+// 123
+// -123
+// 3.14
+// .15
+// -456.789
+// 0
+
+main {
+    echo parse_num("123")?
+    echo parse_num("-123")?
+    echo parse_num("3.14")?
+    echo parse_num(".15")?
+    echo parse_num("-456.789")?
+    echo parse_num("0")?
+}

--- a/src/tests/stdlib/text_parse_number.ab
+++ b/src/tests/stdlib/text_parse_number.ab
@@ -1,8 +1,0 @@
-import * from "std/text"
-
-// Output
-// 123
-
-main {
-    echo parse_number("123")?
-} 


### PR DESCRIPTION
`Int` data types should be used in context of **indexes**, **lengths** and **incremental numbers**.

## Added:
1. `parse_number` -> `parse_num`
2. New `parse_int` function that parses text to an integer
3. `math_sum` now does not use `awk` to improve portability
4. Some updated function definitions with `Int` types