### PR TITLE
Improve errors when no `failed` block used after failable expression

### DIFF
--- a/src/modules/command/cmd.rs
+++ b/src/modules/command/cmd.rs
@@ -40,6 +40,7 @@ impl SyntaxModule<ParserMetadata> for Command {
         self.modifier.use_modifiers(meta, |_this, meta| {
             let tok = meta.get_current_token();
             (self.strings, self.interps) = parse_interpolated_region(meta, '$')?;
+            self.failed.set_position(PositionInfo::from_between_tokens(meta, tok.clone(), meta.get_current_token()));
             match syntax(meta, &mut self.failed) {
                 Ok(_) => Ok(()),
                 Err(Failure::Quiet(_)) => error!(meta, tok => {

--- a/src/modules/condition/failed.rs
+++ b/src/modules/condition/failed.rs
@@ -8,8 +8,20 @@ use crate::modules::types::Type;
 pub struct Failed {
     pub is_parsed: bool,
     is_question_mark: bool,
+    error_position: Option<PositionInfo>,
+    function_name: Option<String>,
     is_main: bool,
     block: Box<Block>
+}
+
+impl Failed {
+    pub fn set_position(&mut self, position: PositionInfo) {
+        self.error_position = Some(position);
+    }
+
+    pub fn set_function_name(&mut self, name: String) {
+        self.function_name = Some(name);
+    }
 }
 
 impl SyntaxModule<ParserMetadata> for Failed {
@@ -20,6 +32,8 @@ impl SyntaxModule<ParserMetadata> for Failed {
             is_parsed: false,
             is_question_mark: false,
             is_main: false,
+            function_name: None,
+            error_position: None,
             block: Box::new(Block::new().with_needs_noop().with_condition())
         }
     }
@@ -49,7 +63,17 @@ impl SyntaxModule<ParserMetadata> for Failed {
                     self.is_parsed = true;
                     return Ok(());
                 } else {
-                    return error!(meta, tok, "Failed expression must be followed by a block or statement")
+                    match (self.function_name.clone(), self.error_position.clone()) {
+                        (Some(fun_name), Some(pos)) => {
+                            return error_pos!(meta, pos, format!("Failed function call '{fun_name}' must be followed by a 'failed' block or statement"))
+                        }
+                        (None, Some(pos)) => {
+                            return error_pos!(meta, pos, format!("Failed command must be followed by a 'failed' block or statement"))
+                        }
+                        _ => {
+                            return error!(meta, tok, format!("Failed expression must be followed by a 'failed' block or statement"))
+                        }
+                    }
                 }
             }
         }

--- a/src/modules/function/invocation.rs
+++ b/src/modules/function/invocation.rs
@@ -67,6 +67,7 @@ impl SyntaxModule<ParserMetadata> for FunctionInvocation {
                 (self.line, self.col) = tok.pos;
             }
             self.name = variable(meta, variable_name_extensions())?;
+            self.failed.set_function_name(self.name.clone());
             // Get the arguments
             token(meta, "(")?;
             self.id = handle_function_reference(meta, tok.clone(), &self.name)?;
@@ -103,6 +104,7 @@ impl SyntaxModule<ParserMetadata> for FunctionInvocation {
             let var_refs = self.args.iter().map(is_ref).collect::<Vec<bool>>();
             self.refs.clone_from(&function_unit.arg_refs);
             (self.kind, self.variant_id) = handle_function_parameters(meta, self.id, function_unit.clone(), &types, &var_refs, tok.clone())?;
+            self.failed.set_position(PositionInfo::from_between_tokens(meta, tok.clone(), meta.get_current_token()));
 
             self.is_failable = function_unit.is_failable;
             if self.is_failable {


### PR DESCRIPTION
Adds clean errors when no `failed` block is used.

Closes #210 