### PR TITLE
Make array_first and array_shift fail when the array is empty

### DIFF
--- a/src/std/array.ab
+++ b/src/std/array.ab
@@ -27,9 +27,11 @@ pub fun array_contains(array, value) {
     return result >= 0
 }
 
-/// Returns the first element in the array; if the array is empty, the return
-/// value is undefined.
+/// Returns the first element in the array; if the array is empty, the function
+/// fails.
 pub fun array_first(array) {
+    if len(array) == 0:
+        fail 1
     return array[0]
 }
 
@@ -75,9 +77,11 @@ pub fun array_pop(ref array) {
 }
 
 /// Removes the first element from the array, and returns it; if the array
-/// is empty, the return value is undefined, but the array will be unchanged.
+/// is empty, the function fails, and the array will be unchanged.
 pub fun array_shift(ref array) {
     let length = len(array)
+    if length == 0:
+        fail 1
     let element = array[0]
     array = array[1..length]
     return element

--- a/src/tests/stdlib/array_first.ab
+++ b/src/tests/stdlib/array_first.ab
@@ -2,16 +2,19 @@ import { array_first } from "std/array"
 
 // Output
 // First of numbers: "zero" (4) [zero one two three]
-// First of empty: "" (0) []
+// First of empty array does not exist
 
 fun test_first(label: Text, data: [Text]): Null {
-    let value = array_first(data)
+    let value = array_first(data) failed {
+        echo "First of empty array does not exist"
+        return null
+    }
     echo "First of {label}: \"{value}\" ({len(data)}) [{data}]"
 }
 
 main {
     let numbers = ["zero", "one", "two", "three"]
     let empty = [Text]
-    test_first("numbers", numbers)
-    test_first("empty", empty)
+    test_first("numbers", numbers)?
+    test_first("empty", empty)?
 }

--- a/src/tests/stdlib/array_shift.ab
+++ b/src/tests/stdlib/array_shift.ab
@@ -2,10 +2,13 @@ import { array_shift } from "std/array"
 
 // Output
 // Shifted from numbers: "zero" (3) [one two three]
-// Shifted from empty: "" (0) []
+// First of empty array does not exist
 
 fun test_shift(label: Text, data: [Text]): Null {
-    let value = array_shift(data)
+    let value = array_shift(data) failed {
+        echo "First of empty array does not exist"
+        return null
+    }
     echo "Shifted from {label}: \"{value}\" ({len(data)}) [{data}]"
 }
 


### PR DESCRIPTION
For consistency with other array functions.