### PR TITLE
Conditionally wrap command in eval to handle single quotes in interpolated strings

### DIFF
--- a/src/tests/validity/command_interpolation_single_apix.ab
+++ b/src/tests/validity/command_interpolation_single_apix.ab
@@ -1,0 +1,4 @@
+const msg = "Succeede"
+trust $ printf '{msg}' $
+let position = 4
+trust $ echo 'a b c d e' | cut --delimiter=' ' --fields={position} $


### PR DESCRIPTION
This is another attempt to fix #182, based on the approach in closed #724. This time, I tried to solve the issue by using `eval` only when the command string includes single quotes `'`.

My main concern is that we might only know if the quote is there at runtime. If this is the case, the compiler cannot decide whether to use `eval`. (though I could not create a test case that fails at few tries)
Also, if the compiler cannot decide, then this would force us to go back to the old method of my previous PR: using `eval` for every command. However, I know that makes the output Bash code terribly hard to read.

And for the same reason, we cannot show a warning to the user if their command has a single quote, because the compiler just cannot tell.

Anyway, since users can now perform at least a few more actions than before, I'm uploading the PR.