### PR TITLE
ci: Build nightly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Amber Release
 on:
   release:
     types: [published]
+  schedule:
+    - cron: '0 0 * * *'
 
 env:
   BIN_NAME: amber
@@ -164,11 +166,33 @@ jobs:
       - name: Show collected files
         run: ls -al dist
 
+      - name: Decide tag
+        id: tag_name
+        run: |
+          if [ '${{ github.event_name }}' = 'schedule' ]; then
+            # Check if any nightly release already exists for this SHA
+            EXISTING=$(gh release list --limit 100 \
+              | grep "^nightly-" \
+              | grep -- "-${{ github.sha }}" \
+              || true)
+
+            if [ -n "$EXISTING" ]; then
+              echo "tag_name=skip" >> $GITHUB_OUTPUT
+              echo "Nightly release already exists for SHA ${{ github.sha }}"
+            else
+              NIGHTLY_TAG="nightly-$(date --iso-8601)-${{ github.sha }}"
+              echo "tag_name=$NIGHTLY_TAG" >> $GITHUB_OUTPUT
+            fi
+          else
+             echo 'tag_name=${{ github.event.release.tag_name }}' >> $GITHUB_OUTPUT
+          fi
+
       - name: Upload to GitHub Release
+        if: steps.tag_name.outputs.tag_name != 'skip'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.RELEASE_PAT }}
           file: dist/*
           file_glob: true
-          tag: ${{ github.event.release.tag_name }}
+          tag: ${{ steps.tag_name.outputs.tag_name }}
           overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,16 +171,19 @@ jobs:
         run: |
           if [ '${{ github.event_name }}' = 'schedule' ]; then
             # Check if any nightly release already exists for this SHA
+            SHORT_SHA="${{ github.sha }}"
+            SHORT_SHA="${SHORT_SHA:0:7}"
+
             EXISTING=$(gh release list --limit 100 \
               | grep "^nightly-" \
-              | grep -- "-${{ github.sha }}" \
+              | grep -- "-${SHORT_SHA}" \
               || true)
 
             if [ -n "$EXISTING" ]; then
               echo "tag_name=skip" >> $GITHUB_OUTPUT
-              echo "Nightly release already exists for SHA ${{ github.sha }}"
+              echo "Nightly release already exists for SHA ${SHORT_SHA}"
             else
-              NIGHTLY_TAG="nightly-$(date --iso-8601)-${{ github.sha }}"
+              NIGHTLY_TAG="nightly-$(date --iso-8601)-${SHORT_SHA}"
               echo "tag_name=$NIGHTLY_TAG" >> $GITHUB_OUTPUT
               echo "prerelease=true" >> $GITHUB_OUTPUT
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,9 +182,11 @@ jobs:
             else
               NIGHTLY_TAG="nightly-$(date --iso-8601)-${{ github.sha }}"
               echo "tag_name=$NIGHTLY_TAG" >> $GITHUB_OUTPUT
+              echo "prerelease=true" >> $GITHUB_OUTPUT
             fi
           else
              echo 'tag_name=${{ github.event.release.tag_name }}' >> $GITHUB_OUTPUT
+             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Upload to GitHub Release
@@ -196,3 +198,4 @@ jobs:
           file_glob: true
           tag: ${{ steps.tag_name.outputs.tag_name }}
           overwrite: true
+          prerelease: ${{ steps.tag_name.outputs.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,10 +168,12 @@ jobs:
 
       - name: Decide tag
         id: tag_name
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          SHORT_SHA: ${{ github.sha }}
         run: |
           if [ '${{ github.event_name }}' = 'schedule' ]; then
             # Check if any nightly release already exists for this SHA
-            SHORT_SHA="${{ github.sha }}"
             SHORT_SHA="${SHORT_SHA:0:7}"
 
             EXISTING=$(gh release list --limit 100 \
@@ -188,7 +190,7 @@ jobs:
               echo "prerelease=true" >> $GITHUB_OUTPUT
             fi
           else
-             echo 'tag_name=${{ github.event.release.tag_name }}' >> $GITHUB_OUTPUT
+             echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
              echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
Builds daily, at midnight UTC
Skips if the commit already built.

- a test run https://github.com/lens0021/amber/actions/runs/19932671056
- the results on my fork `nightly-2025-12-04-c01548e` (https://github.com/lens0021/amber/releases/tag/nightly-2025-12-04-c01548e )

todo

- [x] waiting for the next scheduled run to check the next changes https://github.com/lens0021/amber/actions/workflows/release.yml
  - Mark as pre-release
  - Shorten release name

Closes #695