### PR TITLE
Fix trace issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,9 +421,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heraclitus-compiler"
-version = "1.8.3"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817342b2c5aae155ce8b61fec450d7e4c6f11dbd0e27126a104c245066d9c0a0"
+checksum = "e72670042e09178f5cf816dd5d647e85c503882354de9c76eee396256355633e"
 dependencies = [
  "capitalize",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "4.5.20", features = ["derive"] }
 clap_complete = "4.5.36"
 colored = "2.0.0"
 glob = "0.3"
-heraclitus-compiler = "1.8.3"
+heraclitus-compiler = "1.9.0"
 include_dir = "0.7.4"
 insta = "1.43.1"
 itertools = "0.13.0"

--- a/src/modules/builtin/cd.rs
+++ b/src/modules/builtin/cd.rs
@@ -31,7 +31,7 @@ impl TypeCheckModule for Cd {
         // Then check if it's the correct type
         let path_type = self.value.get_type();
         if path_type != Type::Text {
-            let position = self.value.get_position(meta);
+            let position = self.value.get_position();
             return error_pos!(meta, position => {
                 message: "Builtin function `cd` can only be used with values of type Text",
                 comment: format!("Given type: {}, expected type: {}", path_type, Type::Text)

--- a/src/modules/builtin/exit.rs
+++ b/src/modules/builtin/exit.rs
@@ -35,7 +35,7 @@ impl TypeCheckModule for Exit {
 
             let code_type = code_expr.get_type();
             if code_type != Type::Int {
-                let position = code_expr.get_position(meta);
+                let position = code_expr.get_position();
                 return error_pos!(meta, position => {
                     message: "Builtin function `exit` can only be used with values of type Int",
                     comment: format!("Given type: {}, expected type: {}", code_type, Type::Int)

--- a/src/modules/builtin/lines.rs
+++ b/src/modules/builtin/lines.rs
@@ -47,7 +47,7 @@ impl TypeCheckModule for LinesInvocation {
                     "Expected value of type 'Text' but got '{}'",
                     path.get_type()
                 );
-                let pos = path.get_position(meta);
+                let pos = path.get_position();
                 return error_pos!(meta, pos, msg);
             }
             Ok(())

--- a/src/modules/builtin/mv.rs
+++ b/src/modules/builtin/mv.rs
@@ -48,7 +48,7 @@ impl TypeCheckModule for Mv {
 
         let source_type = self.source.get_type();
         if source_type != Type::Text {
-            let position = self.source.get_position(meta);
+            let position = self.source.get_position();
             return error_pos!(meta, position => {
                 message: "Builtin function `mv` can only be used with values of type Text",
                 comment: format!("Given type: {}, expected type: {}", source_type, Type::Text)
@@ -57,7 +57,7 @@ impl TypeCheckModule for Mv {
 
         let dest_type = self.destination.get_type();
         if dest_type != Type::Text {
-            let position = self.destination.get_position(meta);
+            let position = self.destination.get_position();
             return error_pos!(meta, position => {
                 message: "Builtin function `mv` can only be used with values of type Text",
                 comment: format!("Given type: {}, expected type: {}", dest_type, Type::Text)

--- a/src/modules/expression/access.rs
+++ b/src/modules/expression/access.rs
@@ -76,7 +76,7 @@ impl TypeCheckModule for Access {
         self.kind = self.left.get_type();
 
         if let Some(ref mut index_expr) = self.index.as_mut() {
-            let pos = self.left.get_position(meta);
+            let pos = self.left.get_position();
             if !matches!(self.kind, Type::Array(_)) {
                 return error_pos!(meta, pos, format!("Cannot index a non-array expression of type '{}'", self.kind));
             }

--- a/src/modules/expression/binop/mod.rs
+++ b/src/modules/expression/binop/mod.rs
@@ -72,8 +72,8 @@ pub trait BinOp: SyntaxModule<ParserMetadata> + TypeCheckModule {
     }
 }
 
-pub fn get_binop_position_info(meta: &ParserMetadata, left: &Expr, right: &Expr) -> PositionInfo {
-    let begin = meta.get_token_at(left.pos.0);
-    let end = meta.get_token_at(right.pos.1);
-    PositionInfo::from_between_tokens(meta, begin, end)
+pub fn get_binop_position_info(meta: &mut ParserMetadata, left: &Expr, right: &Expr) -> PositionInfo {
+    let left_pos = left.get_position();
+    let right_pos = right.get_position();
+    PositionInfo::from_between_positions(meta, left_pos, right_pos)
 }

--- a/src/modules/expression/expr.rs
+++ b/src/modules/expression/expr.rs
@@ -102,8 +102,6 @@ pub enum ExprType {
 pub struct Expr {
     pub value: Option<ExprType>,
     pub kind: Type,
-    /// Positions of the tokens enclosing the expression
-    pub pos: (usize, usize),
     pub position: Option<PositionInfo>,
 }
 
@@ -123,17 +121,12 @@ impl Expr {
         }
     }
 
-    pub fn get_position(&self, meta: &mut ParserMetadata) -> PositionInfo {
-        if let Some(ref pos) = self.position {
-            return pos.clone();
-        }
-        let begin = meta.get_token_at(self.pos.0);
-        let end = meta.get_token_at(self.pos.1);
-        PositionInfo::from_between_tokens(meta, begin, end)
+    pub fn get_position(&self) -> PositionInfo {
+        self.position.clone().expect("Expr position wasn't set in the parsing stage")
     }
 
     pub fn get_error_message(&self, meta: &mut ParserMetadata) -> Message {
-        let pos = self.get_position(meta);
+        let pos = self.get_position();
         Message::new_err_at_position(meta, pos)
     }
 }
@@ -145,13 +138,12 @@ impl SyntaxModule<ParserMetadata> for Expr {
         Expr {
             value: None,
             kind: Type::Null,
-            pos: (0, 0),
             position: None,
         }
     }
 
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
-        let result = parse_expression!(meta, [
+        *self = parse_expression!(meta, [
             ternary @ TernOp => [ Ternary ],
             range @ BinOp => [ Range ],
             or @ BinOp => [ Or ],
@@ -175,8 +167,6 @@ impl SyntaxModule<ParserMetadata> for Expr {
                 VariableGet
             ]
         ]);
-        *self = result;
-        self.position = Some(self.get_position(meta));
         Ok(())
     }
 }

--- a/src/modules/expression/expr.rs
+++ b/src/modules/expression/expr.rs
@@ -103,7 +103,8 @@ pub struct Expr {
     pub value: Option<ExprType>,
     pub kind: Type,
     /// Positions of the tokens enclosing the expression
-    pub pos: (usize, usize)
+    pub pos: (usize, usize),
+    pub position: Option<PositionInfo>,
 }
 
 impl Typed for Expr {
@@ -123,6 +124,9 @@ impl Expr {
     }
 
     pub fn get_position(&self, meta: &mut ParserMetadata) -> PositionInfo {
+        if let Some(ref pos) = self.position {
+            return pos.clone();
+        }
         let begin = meta.get_token_at(self.pos.0);
         let end = meta.get_token_at(self.pos.1);
         PositionInfo::from_between_tokens(meta, begin, end)
@@ -141,7 +145,8 @@ impl SyntaxModule<ParserMetadata> for Expr {
         Expr {
             value: None,
             kind: Type::Null,
-            pos: (0, 0)
+            pos: (0, 0),
+            position: None,
         }
     }
 
@@ -171,6 +176,7 @@ impl SyntaxModule<ParserMetadata> for Expr {
             ]
         ]);
         *self = result;
+        self.position = Some(self.get_position(meta));
         Ok(())
     }
 }

--- a/src/modules/expression/literal/array.rs
+++ b/src/modules/expression/literal/array.rs
@@ -76,7 +76,7 @@ impl TypeCheckModule for Array {
             expr.typecheck(meta)?;
             // Handle nested arrays
             if expr.get_type().is_array() {
-                let pos = expr.get_position(meta);
+                let pos = expr.get_position();
                 return error_pos!(meta, pos, "Arrays cannot be nested due to the Bash limitations")
             }
         }
@@ -97,7 +97,7 @@ impl TypeCheckModule for Array {
                 for expr in &self.exprs {
                     let expr_type = expr.get_type();
                     if expr_type != **expected_type {
-                        let pos = expr.get_position(meta);
+                        let pos = expr.get_position();
                         return error_pos!(meta, pos, format!("Expected array value of type '{expected_type}'"))
                     }
                 }
@@ -110,7 +110,7 @@ impl TypeCheckModule for Array {
             for expr in &self.exprs[1..] {
                 let expr_type = expr.get_type();
                 if expr_type != **element_type {
-                    let pos = expr.get_position(meta);
+                    let pos = expr.get_position();
                     return error_pos!(meta, pos, format!("Array elements must have the same type. Expected '{}', found '{}'", element_type, expr_type));
                 }
             }

--- a/src/modules/expression/macros.rs
+++ b/src/modules/expression/macros.rs
@@ -16,7 +16,8 @@ macro_rules! parse_expression_group {
                         node = Expr {
                             kind: module.get_type(),
                             value: Some(ExprType::$cur_modules(module)),
-                            pos: (start_index, end_index)
+                            pos: (start_index, end_index),
+                            position: None,
                         };
                         continue
                     }
@@ -45,7 +46,8 @@ macro_rules! parse_expression_group {
                         node = Expr {
                             kind: module.get_type(),
                             value: Some(ExprType::$cur_modules(module)),
-                            pos: (start_index, end_index)
+                            pos: (start_index, end_index),
+                            position: None,
                         };
                         continue
                     }
@@ -77,7 +79,8 @@ macro_rules! parse_expression_group {
                         node = Expr {
                             kind: module.get_type(),
                             value: Some(ExprType::$cur_modules(module)),
-                            pos: (start_index, end_index)
+                            pos: (start_index, end_index),
+                            position: None,
                         };
                     }
                     Err(Failure::Quiet(_)) => {}
@@ -101,7 +104,8 @@ macro_rules! parse_expression_group {
                     return Ok(Expr {
                         kind: module.get_type(),
                         value: Some(ExprType::$cur_modules(module)),
-                        pos: (start_index, $meta.get_index())
+                        pos: (start_index, $meta.get_index()),
+                        position: None,
                     })
                 },
                 Err(Failure::Quiet(_)) => {},
@@ -126,7 +130,8 @@ macro_rules! parse_expression_group {
                         node = Expr {
                             kind: module.get_type(),
                             value: Some(ExprType::$cur_modules(module)),
-                            pos: (start_index, end_index)
+                            pos: (start_index, end_index),
+                            position: None,
                         };
                         continue
                     }
@@ -148,7 +153,8 @@ macro_rules! parse_expression_group {
                 Ok(()) => return Ok(Expr {
                     kind: module.get_type(),
                     value: Some(ExprType::$cur_modules(module)),
-                    pos: (start_index, $meta.get_index())
+                    pos: (start_index, $meta.get_index()),
+                    position: None,
                 }),
                 Err(Failure::Quiet(_)) => {},
                 Err(Failure::Loud(err)) => return Err(Failure::Loud(err))

--- a/src/modules/expression/macros.rs
+++ b/src/modules/expression/macros.rs
@@ -16,8 +16,11 @@ macro_rules! parse_expression_group {
                         node = Expr {
                             kind: module.get_type(),
                             value: Some(ExprType::$cur_modules(module)),
-                            pos: (start_index, end_index),
-                            position: None,
+                            position: {
+                                let begin = $meta.get_token_at(start_index);
+                                let end = $meta.get_token_at(end_index);
+                                Some(PositionInfo::from_between_tokens($meta, begin, end))
+                            },
                         };
                         continue
                     }
@@ -46,8 +49,11 @@ macro_rules! parse_expression_group {
                         node = Expr {
                             kind: module.get_type(),
                             value: Some(ExprType::$cur_modules(module)),
-                            pos: (start_index, end_index),
-                            position: None,
+                            position: {
+                                let begin = $meta.get_token_at(start_index);
+                                let end = $meta.get_token_at(end_index);
+                                Some(PositionInfo::from_between_tokens($meta, begin, end))
+                            },
                         };
                         continue
                     }
@@ -79,8 +85,11 @@ macro_rules! parse_expression_group {
                         node = Expr {
                             kind: module.get_type(),
                             value: Some(ExprType::$cur_modules(module)),
-                            pos: (start_index, end_index),
-                            position: None,
+                            position: {
+                                let begin = $meta.get_token_at(start_index);
+                                let end = $meta.get_token_at(end_index);
+                                Some(PositionInfo::from_between_tokens($meta, begin, end))
+                            },
                         };
                     }
                     Err(Failure::Quiet(_)) => {}
@@ -104,8 +113,11 @@ macro_rules! parse_expression_group {
                     return Ok(Expr {
                         kind: module.get_type(),
                         value: Some(ExprType::$cur_modules(module)),
-                        pos: (start_index, $meta.get_index()),
-                        position: None,
+                        position: {
+                            let begin = $meta.get_token_at(start_index);
+                            let end = $meta.get_token_at($meta.get_index());
+                            Some(PositionInfo::from_between_tokens($meta, begin, end))
+                        },
                     })
                 },
                 Err(Failure::Quiet(_)) => {},
@@ -130,8 +142,11 @@ macro_rules! parse_expression_group {
                         node = Expr {
                             kind: module.get_type(),
                             value: Some(ExprType::$cur_modules(module)),
-                            pos: (start_index, end_index),
-                            position: None,
+                            position: {
+                                let begin = $meta.get_token_at(start_index);
+                                let end = $meta.get_token_at(end_index);
+                                Some(PositionInfo::from_between_tokens($meta, begin, end))
+                            },
                         };
                         continue
                     }
@@ -153,8 +168,11 @@ macro_rules! parse_expression_group {
                 Ok(()) => return Ok(Expr {
                     kind: module.get_type(),
                     value: Some(ExprType::$cur_modules(module)),
-                    pos: (start_index, $meta.get_index()),
-                    position: None,
+                    position: {
+                        let begin = $meta.get_token_at(start_index);
+                        let end = $meta.get_token_at($meta.get_index());
+                        Some(PositionInfo::from_between_tokens($meta, begin, end))
+                    },
                 }),
                 Err(Failure::Quiet(_)) => {},
                 Err(Failure::Loud(err)) => return Err(Failure::Loud(err))

--- a/src/modules/expression/typeop/cast.rs
+++ b/src/modules/expression/typeop/cast.rs
@@ -52,9 +52,7 @@ impl TypeCheckModule for Cast {
     fn typecheck(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         self.expr.typecheck(meta)?;
 
-        let begin = meta.get_token_at(self.expr.pos.0);
-        let end = meta.get_current_token();
-        let pos = PositionInfo::from_between_tokens(meta, begin, end);
+        let pos = self.expr.get_position();
         if !meta.context.cc_flags.contains(&CCFlags::AllowAbsurdCast) {
             let flag_name = get_ccflag_name(CCFlags::AllowAbsurdCast);
             let l_type = self.expr.get_type();

--- a/src/modules/function/invocation_utils.rs
+++ b/src/modules/function/invocation_utils.rs
@@ -97,6 +97,16 @@ fn run_function_with_args(
             }
         }
     }
+    // Capture caller trace and path for the correct trace in errors
+    let caller_trace = meta.context.trace.clone();
+    let caller_path = meta.context.path.clone();
+
+    let call_site_pos = if let Some(ref t) = tok {
+        Some(PositionInfo::from_token(meta, Some(t.clone())))
+    } else {
+        None
+    };
+
     // Swap the contexts to use the function context
     let res = meta.with_context_ref(&mut context, |meta| {
         // Create a sub context for new variables
@@ -115,7 +125,23 @@ fn run_function_with_args(
                 meta.context.fun_ret_type = Some(fun.returns.clone());
             }
             // Typecheck the function body
-            block.typecheck(meta)?;
+            if let Err(failure) = block.typecheck(meta) {
+                match failure {
+                    Failure::Loud(mut msg) => {
+                        let mut new_trace = Vec::new();
+                        if caller_path != meta.context.path {
+                            new_trace.extend(caller_trace.clone());
+                        }
+                        if let Some(ref pos) = call_site_pos {
+                            new_trace.push(pos.clone());
+                        }
+                        new_trace.extend(msg.trace);
+                        msg.trace = new_trace;
+                        return Err(Failure::Loud(msg));
+                    }
+                    _ => return Err(failure),
+                }
+            }
             Ok(())
         })?;
         Ok(())

--- a/src/modules/function/invocation_utils.rs
+++ b/src/modules/function/invocation_utils.rs
@@ -100,12 +100,7 @@ fn run_function_with_args(
     // Capture caller trace and path for the correct trace in errors
     let caller_trace = meta.context.trace.clone();
     let caller_path = meta.context.path.clone();
-
-    let call_site_pos = if let Some(ref t) = tok {
-        Some(PositionInfo::from_token(meta, Some(t.clone())))
-    } else {
-        None
-    };
+    let call_site_pos = tok.as_ref().map(|t| PositionInfo::from_token(meta, Some(t.clone())));
 
     // Swap the contexts to use the function context
     let res = meta.with_context_ref(&mut context, |meta| {

--- a/src/modules/loops/iter_loop.rs
+++ b/src/modules/loops/iter_loop.rs
@@ -107,7 +107,7 @@ impl TypeCheckModule for IterLoop {
         self.iter_type = match self.iter_expr.get_type() {
             Type::Array(kind) => *kind,
             _ => {
-                let pos = self.iter_expr.get_position(meta);
+                let pos = self.iter_expr.get_position();
                 return error_pos!(meta, pos, "Expected iterable");
             }
         };

--- a/src/modules/variable/set.rs
+++ b/src/modules/variable/set.rs
@@ -74,13 +74,13 @@ impl TypeCheckModule for VariableSet {
         if self.index.is_some() {
             if let Type::Array(kind) = &self.var_type {
                 if !right_type.is_allowed_in(kind) {
-                    let tok = self.expr.get_position(meta);
+                    let tok = self.expr.get_position();
                     return error_pos!(meta, tok, format!("Cannot assign value of type '{right_type}' to an array of '{kind}'"));
                 }
             }
         }
         else if !right_type.is_allowed_in(&self.var_type) {
-            let tok = self.expr.get_position(meta);
+            let tok = self.expr.get_position();
             return error_pos!(meta, tok, format!("Cannot assign value of type '{right_type}' to a variable of type '{}'", self.var_type));
         }
 


### PR DESCRIPTION
Closes #486 

The problem was that the function is lazily evaluated because the `array_contains` accepts a generic argument. To solve this I store the position of the called function before evaluating it and I add it to the trace if there was error running this function.

<img width="326" height="145" alt="Screenshot 2025-12-04 at 15 28 47" src="https://github.com/user-attachments/assets/d01de9c7-29b7-4c90-9cdc-c2f9d574dada" />

This solution could be improved if `PositionInfo::from_between_pos` was introduced to Heraclitus - hence draft