### PR TITLE
ci: Add `zizmor` Security Analysis

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,3 +19,4 @@ jobs:
       - uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
         with:
           advanced-security: false
+          annotations: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,21 @@
+name: zizmor Security Analysis
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
+        with:
+          advanced-security: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,22 +1,51 @@
 name: zizmor Security Analysis
 
 on:
+  schedule:
+    - cron: '0 0 0 * *'
   push:
-    branches: ["main"]
-  pull_request:
-    branches: ["**"]
+    branches:
+      - zizmor # temporarily when this on PR
 
 permissions: {}
+
+env:
+  ZIZMOR_VERSION: v1.18.0
 
 jobs:
   zizmor:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ${{ github.workspace }}/.tools
+          key: zizmor-{{ env.ZIZMOR_VERSION }}
+          restore-key: zizmor-
+
+      - name: Install zizmor
+        run: |
+          if [ "${{ steps.cache-zizmor.outputs.cache-hit }}" != "true" ]; then
+            curl -Lo zizmor.tar.gz "https://github.com/zizmorcore/zizmor/releases/download/$ZIZMOR_VERSION/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+            tar -xvzf zizmor.tar.gz
+            install zizmor "$HOME/.tools"
+          fi
+          echo "$HOME/.tools" >> $GITHUB_PATH
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
 
-      - uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
+      - name: Try automatic fix
+        run: |
+          zizmor . --fix
+
+      - uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:
-          advanced-security: false
-          annotations: true
+          commit-message: &title Address zizmor issue(s)
+          branch: bot-zizmor-fix
+          title: *title
+
+      - name: Report remaning issues
+        run: |
+          zizmor . --format github
+

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -72,7 +72,7 @@ jobs:
             cat zizmor-report.md
             echo '```'
           } >> issue-body.md
-          issue_number=$(gh issue list --label "zizmor" --state open --json number --jq '.[0].number' || echo "")
+          issue_number=$(gh issue list --search "Security: zizmor findings" --state open --json number --jq '.[0].number' || echo "")
           echo "issue_number=$issue_number" >> $GITHUB_OUTPUT
 
       - uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,7 +2,7 @@ name: zizmor Security Analysis
 
 on:
   schedule:
-    - cron: '0 0 0 * *'
+    - cron: '0 0 * * 0' # weekly
   push:
     branches:
       - zizmor # temporarily when this on PR

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -7,7 +7,10 @@ on:
     branches:
       - zizmor # temporarily when this on PR
 
-permissions: {}
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 env:
   ZIZMOR_VERSION: v1.18.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,9 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        id: cache-zizmor
         with:
-          path: ${{ github.workspace }}/.tools
-          key: zizmor-{{ env.ZIZMOR_VERSION }}
+          path: ~/.tools
+          key: zizmor-${{ env.ZIZMOR_VERSION }}
           restore-keys: zizmor-
 
       - name: Install zizmor
@@ -27,6 +28,7 @@ jobs:
           if [ "${{ steps.cache-zizmor.outputs.cache-hit }}" != "true" ]; then
             curl -Lo zizmor.tar.gz "https://github.com/zizmorcore/zizmor/releases/download/$ZIZMOR_VERSION/zizmor-x86_64-unknown-linux-gnu.tar.gz"
             tar -xvzf zizmor.tar.gz
+            mkdir -p "$HOME/.tools"
             install zizmor "$HOME/.tools"
           fi
           echo "$HOME/.tools" >> $GITHUB_PATH

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -38,6 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: Try automatic fix
+        continue-on-error: true
         run: |
           zizmor . --fix
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -56,7 +56,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          zizmor . > zizmor-report.md
+          zizmor . --min-severity high > zizmor-report.md
           zizmor_fail=$?
           echo "zizmor-fail=$zizmor_fail" >> $GITHUB_OUTPUT
           exit 0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -48,7 +48,34 @@ jobs:
           branch: bot-zizmor-fix
           title: *title
 
-      - name: Report remaning issues
+      - name: Check for security issues
+        id: zizmor-check
+        continue-on-error: true
         run: |
-          zizmor . --format github
+          set +e
+          zizmor . > zizmor-report.md
+          zizmor_fail=$?
+          echo "zizmor-fail=$zizmor_fail" >> $GITHUB_OUTPUT
+          exit 0
+
+      - name: Write issue body
+        id: after-zizmor
+        if: steps.zizmor-check.outputs.zizmor-fail != '0'
+        run: |
+          {
+            echo '**Workflow Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            echo '**Commit:** ${{ github.sha }}'
+            echo '```'
+            cat zizmor-report.md
+            echo '```'
+          } >> issue-body.md
+          issue_number=$(gh issue list --label "zizmor" --state open --json number --jq '.[0].number' || echo "")
+          echo "issue_number=$issue_number" >> $GITHUB_OUTPUT
+
+      - uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1
+        if: steps.zizmor-check.outputs.zizmor-fail != '0'
+        with:
+          title: "Security: zizmor findings"
+          content-filepath: issue-body.md
+          issue-number: ${{ steps.after-zizmor.outputs.issue_number }}
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/.tools
           key: zizmor-{{ env.ZIZMOR_VERSION }}
-          restore-key: zizmor-
+          restore-keys: zizmor-
 
       - name: Install zizmor
         run: |


### PR DESCRIPTION
> zizmor is a static analysis tool for GitHub Actions.
> -- https://github.com/zizmorcore/zizmor

So this adds a workflow for `zizmor`.
Note: The added [zizmor-action](https://github.com/zizmorcore/zizmor-action) is in development status. I think it is okay.