### PR TITLE
Rename nightly build to contain sem-ver of the next patch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,21 +171,42 @@ jobs:
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
           SHORT_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           if [ '${{ github.event_name }}' = 'schedule' ]; then
             # Check if any nightly release already exists for this SHA
             SHORT_SHA="${SHORT_SHA:0:7}"
 
             EXISTING=$(gh release list --limit 100 \
-              | grep "^nightly-" \
-              | grep -- "-${SHORT_SHA}" \
+              | grep "nightly" \
+              | grep "${SHORT_SHA}" \
               || true)
 
             if [ -n "$EXISTING" ]; then
               echo "tag_name=skip" >> $GITHUB_OUTPUT
               echo "Nightly release already exists for SHA ${SHORT_SHA}"
             else
-              NIGHTLY_TAG="nightly-$(date --iso-8601)-${SHORT_SHA}"
+              # Get the latest release tag to determine the next version
+              LATEST_TAG=$(gh release list --limit 1 --exclude-drafts --exclude-pre-releases --json tagName --jq '.[0].tagName')
+              
+              if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
+                LATEST_TAG="0.0.0"
+              fi
+              
+              IFS='.' read -r -a parts <<< "$LATEST_TAG"
+              MAJOR="${parts[0]}"
+              MINOR="${parts[1]}"
+              PATCH="${parts[2]}"
+
+              # Strip "-alpha" suffix if present
+              PATCH="${PATCH%%-*}"
+              
+              # Increment patch version
+              PATCH=$((PATCH + 1))
+              NEXT_VER="$MAJOR.$MINOR.$PATCH"
+              
+              NIGHTLY_TAG="${NEXT_VER}-nightly-$(date +%Y-%m-%d)-${SHORT_SHA}"
+              
               echo "tag_name=$NIGHTLY_TAG" >> $GITHUB_OUTPUT
               echo "prerelease=true" >> $GITHUB_OUTPUT
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,26 +186,36 @@ jobs:
               echo "tag_name=skip" >> $GITHUB_OUTPUT
               echo "Nightly release already exists for SHA ${SHORT_SHA}"
             else
+              echo "Computing LATEST_TAG"
               # Get the latest release tag to determine the next version
               LATEST_TAG=$(gh release list --limit 1 --exclude-drafts --exclude-pre-releases --json tagName --jq '.[0].tagName')
-              
+              echo "LATEST_TAG: $LATEST_TAG"
               if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
                 LATEST_TAG="0.0.0"
               fi
+              echo "LATEST_TAG: $LATEST_TAG"
               
               IFS='.' read -r -a parts <<< "$LATEST_TAG"
+
+              echo "parts: ${parts[@]}"
+
               MAJOR="${parts[0]}"
               MINOR="${parts[1]}"
               PATCH="${parts[2]}"
 
+              echo "MAJOR: $MAJOR"
+              echo "MINOR: $MINOR"
+              echo "PATCH: $PATCH"
               # Strip "-alpha" suffix if present
               PATCH="${PATCH%%-*}"
               
               # Increment patch version
               PATCH=$((PATCH + 1))
               NEXT_VER="$MAJOR.$MINOR.$PATCH"
+              echo "NEXT_VER: $NEXT_VER"
               
               NIGHTLY_TAG="${NEXT_VER}-nightly-$(date +%Y-%m-%d)-${SHORT_SHA}"
+              echo "NIGHTLY_TAG: $NIGHTLY_TAG"
               
               echo "tag_name=$NIGHTLY_TAG" >> $GITHUB_OUTPUT
               echo "prerelease=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,6 @@ jobs:
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
           SHORT_SHA: ${{ github.sha }}
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           if [ '${{ github.event_name }}' = 'schedule' ]; then
             # Check if any nightly release already exists for this SHA

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,12 @@
 name: Amber Release
 
+run-name: >-
+  ${{ 
+    github.event_name == 'release' 
+    && format('Release Official ({0})', github.ref_name) 
+    || format('Release Nightly (#{0})', github.run_number) 
+  }}
+
 on:
   release:
     types: [published]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [linux, macos, windows, installers]
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,7 @@ jobs:
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
           SHORT_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ '${{ github.event_name }}' = 'schedule' ] || [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
             # Check if any nightly release already exists for this SHA
@@ -186,36 +187,26 @@ jobs:
               echo "tag_name=skip" >> $GITHUB_OUTPUT
               echo "Nightly release already exists for SHA ${SHORT_SHA}"
             else
-              echo "Computing LATEST_TAG"
               # Get the latest release tag to determine the next version
               LATEST_TAG=$(gh release list --limit 1 --exclude-drafts --exclude-pre-releases --json tagName --jq '.[0].tagName')
-              echo "LATEST_TAG: $LATEST_TAG"
+              
               if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
                 LATEST_TAG="0.0.0"
               fi
-              echo "LATEST_TAG: $LATEST_TAG"
               
               IFS='.' read -r -a parts <<< "$LATEST_TAG"
-
-              echo "parts: ${parts[@]}"
-
               MAJOR="${parts[0]}"
               MINOR="${parts[1]}"
               PATCH="${parts[2]}"
 
-              echo "MAJOR: $MAJOR"
-              echo "MINOR: $MINOR"
-              echo "PATCH: $PATCH"
               # Strip "-alpha" suffix if present
               PATCH="${PATCH%%-*}"
               
               # Increment patch version
               PATCH=$((PATCH + 1))
               NEXT_VER="$MAJOR.$MINOR.$PATCH"
-              echo "NEXT_VER: $NEXT_VER"
               
               NIGHTLY_TAG="${NEXT_VER}-nightly-$(date +%Y-%m-%d)-${SHORT_SHA}"
-              echo "NIGHTLY_TAG: $NIGHTLY_TAG"
               
               echo "tag_name=$NIGHTLY_TAG" >> $GITHUB_OUTPUT
               echo "prerelease=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
I just prefer to keep the semver that we've been used for stable releases.
**Before:**
```
nightly-2025-12-05-0da23d
```
**After:**
```
0.5.2-nightly-2025-12-05-0da23d
```