### PR TITLE
ci(nightly): Include amber version in the nightly builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [linux, macos, windows, installers]
     steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -185,7 +187,7 @@ jobs:
               echo "tag_name=skip" >> $GITHUB_OUTPUT
               echo "Nightly release already exists for SHA ${SHORT_SHA}"
             else
-              NIGHTLY_TAG="nightly-$(date --iso-8601)-${SHORT_SHA}"
+              NIGHTLY_TAG="nightly-$(yq .package.version Cargo.toml)-$(date --iso-8601)-${SHORT_SHA}"
               echo "tag_name=$NIGHTLY_TAG" >> $GITHUB_OUTPUT
               echo "prerelease=true" >> $GITHUB_OUTPUT
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     types: [published]
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 env:
   BIN_NAME: amber
@@ -174,7 +175,7 @@ jobs:
           TAG_NAME: ${{ github.event.release.tag_name }}
           SHORT_SHA: ${{ github.sha }}
         run: |
-          if [ '${{ github.event_name }}' = 'schedule' ]; then
+          if [ '${{ github.event_name }}' = 'schedule' ] || [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
             # Check if any nightly release already exists for this SHA
             SHORT_SHA="${SHORT_SHA:0:7}"
 


### PR DESCRIPTION
> @lens0021 I know that this is a nightly build, but I wonder if we could add amber version to the nightly tag
>
> _Originally posted by @Ph0enixKM in https://github.com/amber-lang/amber/issues/871#issuecomment-3618679258_

Now the tags should be like `nightly-0.5.1-alpha-2025-12-05-44dd148`.
An actually built release: https://github.com/lens0021/amber/releases/tag/nightly-0.5.1-alpha-2025-12-05-44dd148

And I've added workflow_dispatch event. So you can now manually trigger the nightly build by the following way:

<img width="1380" height="419" alt="image" src="https://github.com/user-attachments/assets/dae9ec6c-d158-4e96-8f70-3b303171a218" />
