### PR TITLE
ci(nightly): Add manual triggering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     types: [published]
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 env:
   BIN_NAME: amber
@@ -172,7 +173,7 @@ jobs:
           TAG_NAME: ${{ github.event.release.tag_name }}
           SHORT_SHA: ${{ github.sha }}
         run: |
-          if [ '${{ github.event_name }}' = 'schedule' ]; then
+          if [ '${{ github.event_name }}' = 'schedule' ] || [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
             # Check if any nightly release already exists for this SHA
             SHORT_SHA="${SHORT_SHA:0:7}"
 


### PR DESCRIPTION
I've added workflow_dispatch event. So you can now manually trigger the nightly build by the following way:

<img width="1380" height="419" alt="image" src="https://github.com/user-attachments/assets/dae9ec6c-d158-4e96-8f70-3b303171a218" />

(works when only the commit is not yet released!)
