### PR TITLE
Add support for functions in nameof

### DIFF
--- a/src/modules/builtin/len.rs
+++ b/src/modules/builtin/len.rs
@@ -20,7 +20,7 @@ impl Typed for Len {
 
 impl UnOp for Len {
     fn set_expr(&mut self, expr: Expr) {
-        self.value = Box::new(expr);
+        *self.value = expr;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/builtin/lines.rs
+++ b/src/modules/builtin/lines.rs
@@ -33,7 +33,7 @@ impl SyntaxModule<ParserMetadata> for LinesInvocation {
         let mut path = Expr::new();
         syntax(meta, &mut path)?;
         token(meta, ")")?;
-        self.path = Box::new(Some(path));
+        *self.path = Some(path);
         Ok(())
     }
 }

--- a/src/modules/builtin/nameof.rs
+++ b/src/modules/builtin/nameof.rs
@@ -4,12 +4,14 @@ use crate::modules::variable::variable_name_extensions;
 use crate::translate::module::TranslateModule;
 use crate::utils::{ParserMetadata, TranslateMetadata};
 use heraclitus_compiler::prelude::*;
+use crate::raw_fragment;
 
 #[derive(Debug, Clone)]
 pub struct Nameof {
     name: String,
     token: Option<Token>,
     global_id: Option<usize>,
+    function_info: Option<(usize, usize)>,
 }
 
 impl Typed for Nameof {
@@ -26,6 +28,7 @@ impl SyntaxModule<ParserMetadata> for Nameof {
             name: String::new(),
             token: None,
             global_id: None,
+            function_info: None,
         }
     }
 
@@ -43,22 +46,42 @@ impl TypeCheckModule for Nameof {
             Some(var_decl) => {
                 self.name.clone_from(&var_decl.name);
                 self.global_id = var_decl.global_id;
+                meta.mark_var_modified(&self.name);
             }
             None => {
-                return error!(meta, self.token.clone(), format!("Variable '{}' not found", self.name))
+                // If variable not found, try to find a function
+                match meta.get_fun_declaration(&self.name) {
+                    Some(fun_decl) => {
+                        // Check if the function is strictly typed
+                        if !fun_decl.args.iter().all(|arg| arg.kind.is_strictly_typed()) {
+                            return error!(meta, self.token.clone(), 
+                                format!("Function '{}' is not strictly typed", self.name),
+                                "All function parameters have to be of concrete type"
+                            )
+                        }
+                        // Since strictly typed functions are compiled eagerly, we can assume variant 0 exists
+                        self.function_info = Some((fun_decl.id, 0));
+                    }
+                    None => return error!(meta, self.token.clone(), format!("Variable or function '{}' not found", self.name))
+                }
             }
         };
-        meta.mark_var_modified(&self.name);
         Ok(())
     }
 }
 
 impl TranslateModule for Nameof {
-    fn translate(&self, _meta: &mut TranslateMetadata) -> FragmentKind {
-        VarExprFragment::new(&self.name, Type::Text)
-            .with_global_id(self.global_id)
-            .with_render_type(VarRenderType::NameOf)
-            .to_frag()
+    fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
+        if let Some((id, variant)) = self.function_info {
+            let prefix = meta.gen_variable_prefix(&self.name);
+            let name = format!("{}{}__{}_v{}", prefix, self.name, id, variant);
+            raw_fragment!("{}", name)
+        } else {
+            VarExprFragment::new(&self.name, Type::Text)
+                .with_global_id(self.global_id)
+                .with_render_type(VarRenderType::NameOf)
+                .to_frag()
+        }
     }
 }
 

--- a/src/modules/builtin/nameof.rs
+++ b/src/modules/builtin/nameof.rs
@@ -12,7 +12,7 @@ pub struct Nameof {
     name: String,
     token: Option<Token>,
     global_id: Option<usize>,
-    function_info: Option<(usize, usize)>,
+    function_variant: Option<(usize, usize)>,
 }
 
 impl Typed for Nameof {
@@ -29,7 +29,7 @@ impl SyntaxModule<ParserMetadata> for Nameof {
             name: String::new(),
             token: None,
             global_id: None,
-            function_info: None,
+            function_variant: None,
         }
     }
 
@@ -78,7 +78,7 @@ impl TypeCheckModule for Nameof {
                             }
                         };
 
-                        self.function_info = Some((fun_decl.id, variant_id));
+                        self.function_variant = Some((fun_decl.id, variant_id));
                     }
                     None => return error!(meta, self.token.clone(), format!("Variable or function '{}' not found", self.name))
                 }
@@ -90,10 +90,10 @@ impl TypeCheckModule for Nameof {
 
 impl TranslateModule for Nameof {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        if let Some((id, variant)) = self.function_info {
+        if let Some((id, variant)) = self.function_variant {
             let prefix = meta.gen_variable_prefix(&self.name);
-            let name = format!("{}{}__{}_v{}", prefix, self.name, id, variant);
-            raw_fragment!("{}", name)
+            let name = format!("{prefix}{}__{id}_v{variant}", self.name);
+            raw_fragment!("{name}")
         } else {
             VarExprFragment::new(&self.name, Type::Text)
                 .with_global_id(self.global_id)

--- a/src/modules/builtin/nameof.rs
+++ b/src/modules/builtin/nameof.rs
@@ -57,7 +57,7 @@ impl TypeCheckModule for Nameof {
                         // Check if the function is strictly typed
                         if !fun_decl.args.iter().all(|arg| arg.kind.is_strictly_typed()) {
                             return error!(meta, self.token.clone(), 
-                                format!("Function '{}' is not strictly typed", self.name),
+                                format!("Function '{}' must be strictly typed to be used with 'nameof'.", self.name),
                                 "All function parameters have to be of concrete type"
                             )
                         }

--- a/src/modules/builtin/nameof.rs
+++ b/src/modules/builtin/nameof.rs
@@ -1,4 +1,5 @@
 use crate::modules::prelude::*;
+use crate::modules::function::invocation_utils::run_function_with_args;
 use crate::modules::types::{Type, Typed};
 use crate::modules::variable::variable_name_extensions;
 use crate::translate::module::TranslateModule;
@@ -49,8 +50,9 @@ impl TypeCheckModule for Nameof {
                 meta.mark_var_modified(&self.name);
             }
             None => {
-                // If variable not found, try to find a function
-                match meta.get_fun_declaration(&self.name) {
+                let fun_decl_opt = meta.get_fun_declaration(&self.name).cloned();
+
+                match fun_decl_opt {
                     Some(fun_decl) => {
                         // Check if the function is strictly typed
                         if !fun_decl.args.iter().all(|arg| arg.kind.is_strictly_typed()) {
@@ -59,8 +61,24 @@ impl TypeCheckModule for Nameof {
                                 "All function parameters have to be of concrete type"
                             )
                         }
-                        // Since strictly typed functions are compiled eagerly, we can assume variant 0 exists
-                        self.function_info = Some((fun_decl.id, 0));
+                        let args_types: Vec<Type> = fun_decl.args.iter().map(|arg| arg.kind.clone()).collect();
+                        let fun_instance = meta.fun_cache.get_instances(fun_decl.id).unwrap().iter().find(|fun| fun.args == args_types);
+                        
+                        // Check if the function variant is already compiled
+                        let variant_id = match fun_instance {
+                            Some(fun_instance) => fun_instance.variant_id,
+                            None => {
+                                // Compile the function on demand to get the variant ID
+                                run_function_with_args(
+                                    meta, 
+                                    fun_decl.clone(), 
+                                    &args_types, 
+                                    self.token.clone()
+                                )?.1
+                            }
+                        };
+
+                        self.function_info = Some((fun_decl.id, variant_id));
                     }
                     None => return error!(meta, self.token.clone(), format!("Variable or function '{}' not found", self.name))
                 }

--- a/src/modules/expression/access.rs
+++ b/src/modules/expression/access.rs
@@ -45,7 +45,7 @@ impl Access {
     }
 
     pub fn set_left(&mut self, left: Expr) {
-        self.left = Box::new(left);
+        *self.left = left;
     }
 
     pub fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
@@ -65,7 +65,7 @@ impl SyntaxModule<ParserMetadata> for Access {
         let mut index = Expr::new();
         syntax(meta, &mut index)?;
         token(meta, "]")?;
-        self.index = Box::new(Some(index));
+        *self.index = Some(index);
         Ok(())
     }
 }

--- a/src/modules/expression/binop/add.rs
+++ b/src/modules/expression/binop/add.rs
@@ -22,11 +22,11 @@ impl Typed for Add {
 
 impl BinOp for Add {
     fn set_left(&mut self, left: Expr) {
-        self.left = Box::new(left);
+        *self.left = left;
     }
 
     fn set_right(&mut self, right: Expr) {
-        self.right = Box::new(right);
+        *self.right = right;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/binop/and.rs
+++ b/src/modules/expression/binop/and.rs
@@ -20,11 +20,11 @@ impl Typed for And {
 
 impl BinOp for And {
     fn set_left(&mut self, left: Expr) {
-        self.left = Box::new(left);
+        *self.left = left;
     }
 
     fn set_right(&mut self, right: Expr) {
-        self.right = Box::new(right);
+        *self.right = right;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/binop/div.rs
+++ b/src/modules/expression/binop/div.rs
@@ -22,11 +22,11 @@ impl Typed for Div {
 
 impl BinOp for Div {
     fn set_left(&mut self, left: Expr) {
-        self.left = Box::new(left);
+        *self.left = left;
     }
 
     fn set_right(&mut self, right: Expr) {
-        self.right = Box::new(right);
+        *self.right = right;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/binop/eq.rs
+++ b/src/modules/expression/binop/eq.rs
@@ -21,11 +21,11 @@ impl Typed for Eq {
 
 impl BinOp for Eq {
     fn set_left(&mut self, left: Expr) {
-        self.left = Box::new(left);
+        *self.left = left;
     }
 
     fn set_right(&mut self, right: Expr) {
-        self.right = Box::new(right);
+        *self.right = right;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/binop/ge.rs
+++ b/src/modules/expression/binop/ge.rs
@@ -20,11 +20,11 @@ impl Typed for Ge {
 
 impl BinOp for Ge {
     fn set_left(&mut self, left: Expr) {
-        self.left = Box::new(left);
+        *self.left = left;
     }
 
     fn set_right(&mut self, right: Expr) {
-        self.right = Box::new(right);
+        *self.right = right;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/binop/gt.rs
+++ b/src/modules/expression/binop/gt.rs
@@ -20,11 +20,11 @@ impl Typed for Gt {
 
 impl BinOp for Gt {
     fn set_left(&mut self, left: Expr) {
-        self.left = Box::new(left);
+        *self.left = left;
     }
 
     fn set_right(&mut self, right: Expr) {
-        self.right = Box::new(right);
+        *self.right = right;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/binop/le.rs
+++ b/src/modules/expression/binop/le.rs
@@ -20,11 +20,11 @@ impl Typed for Le {
 
 impl BinOp for Le {
     fn set_left(&mut self, left: Expr) {
-        self.left = Box::new(left);
+        *self.left = left;
     }
 
     fn set_right(&mut self, right: Expr) {
-        self.right = Box::new(right);
+        *self.right = right;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/binop/lt.rs
+++ b/src/modules/expression/binop/lt.rs
@@ -20,11 +20,11 @@ impl Typed for Lt {
 
 impl BinOp for Lt {
     fn set_left(&mut self, left: Expr) {
-        self.left = Box::new(left);
+        *self.left = left;
     }
 
     fn set_right(&mut self, right: Expr) {
-        self.right = Box::new(right);
+        *self.right = right;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/binop/mod.rs
+++ b/src/modules/expression/binop/mod.rs
@@ -4,6 +4,7 @@ use crate::utils::metadata::ParserMetadata;
 use crate::utils::pluralize;
 use super::super::expression::expr::{Expr, ExprType};
 use crate::modules::typecheck::TypeCheckModule;
+use crate::utils::pretty_join;
 
 pub mod add;
 pub mod sub;
@@ -37,7 +38,7 @@ pub trait BinOp: SyntaxModule<ParserMetadata> + TypeCheckModule {
         let left_match = allowed_types.iter().any(|types| left_type.is_allowed_in(types));
         let right_match = allowed_types.iter().any(|types| right_type.is_allowed_in(types));
         if !left_match || !right_match {
-            let pretty_types = Type::pretty_join(allowed_types, "and");
+            let pretty_types = pretty_join(allowed_types, "and");
             let comment = pluralize(allowed_types.len(), "Allowed type is", "Allowed types are");
             let pos = get_binop_position_info(meta, left, right);
             let message = Message::new_err_at_position(meta, pos)

--- a/src/modules/expression/binop/modulo.rs
+++ b/src/modules/expression/binop/modulo.rs
@@ -20,11 +20,11 @@ impl Typed for Modulo {
 
 impl BinOp for Modulo {
     fn set_left(&mut self, left: Expr) {
-        self.left = Box::new(left);
+        *self.left = left;
     }
 
     fn set_right(&mut self, right: Expr) {
-        self.right = Box::new(right);
+        *self.right = right;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/binop/mul.rs
+++ b/src/modules/expression/binop/mul.rs
@@ -21,11 +21,11 @@ impl Typed for Mul {
 
 impl BinOp for Mul {
     fn set_left(&mut self, left: Expr) {
-        self.left = Box::new(left);
+        *self.left = left;
     }
 
     fn set_right(&mut self, right: Expr) {
-        self.right = Box::new(right);
+        *self.right = right;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/binop/neq.rs
+++ b/src/modules/expression/binop/neq.rs
@@ -21,11 +21,11 @@ impl Typed for Neq {
 
 impl BinOp for Neq {
     fn set_left(&mut self, left: Expr) {
-        self.left = Box::new(left);
+        *self.left = left;
     }
 
     fn set_right(&mut self, right: Expr) {
-        self.right = Box::new(right);
+        *self.right = right;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/binop/or.rs
+++ b/src/modules/expression/binop/or.rs
@@ -20,11 +20,11 @@ impl Typed for Or {
 
 impl BinOp for Or {
     fn set_left(&mut self, left: Expr) {
-        self.left = Box::new(left);
+        *self.left = left;
     }
 
     fn set_right(&mut self, right: Expr) {
-        self.right = Box::new(right);
+        *self.right = right;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/binop/range.rs
+++ b/src/modules/expression/binop/range.rs
@@ -22,11 +22,11 @@ impl Typed for Range {
 
 impl BinOp for Range {
     fn set_left(&mut self, left: Expr) {
-        self.from = Box::new(left);
+        *self.from = left;
     }
 
     fn set_right(&mut self, right: Expr) {
-        self.to = Box::new(right);
+        *self.to = right;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/binop/sub.rs
+++ b/src/modules/expression/binop/sub.rs
@@ -21,11 +21,11 @@ impl Typed for Sub {
 
 impl BinOp for Sub {
     fn set_left(&mut self, left: Expr) {
-        self.left = Box::new(left);
+        *self.left = left;
     }
 
     fn set_right(&mut self, right: Expr) {
-        self.right = Box::new(right);
+        *self.right = right;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/ternop/ternary.rs
+++ b/src/modules/expression/ternop/ternary.rs
@@ -23,15 +23,15 @@ impl Typed for Ternary {
 
 impl TernOp for Ternary {
     fn set_left(&mut self, left: Expr) {
-        self.cond = Box::new(left);
+        *self.cond = left;
     }
 
     fn set_middle(&mut self, middle: Expr) {
-        self.true_expr = Box::new(middle);
+        *self.true_expr = middle;
     }
 
     fn set_right(&mut self, right: Expr) {
-        self.false_expr = Box::new(right);
+        *self.false_expr = right;
     }
 
     fn parse_operator_left(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/typeop/cast.rs
+++ b/src/modules/expression/typeop/cast.rs
@@ -20,7 +20,7 @@ impl Typed for Cast {
 
 impl TypeOp for Cast {
     fn set_left(&mut self, left: Expr) {
-        self.expr = Box::new(left);
+        *self.expr = left;
     }
 
     fn set_right(&mut self, right: Type) {

--- a/src/modules/expression/typeop/is.rs
+++ b/src/modules/expression/typeop/is.rs
@@ -20,7 +20,7 @@ impl Typed for Is {
 
 impl TypeOp for Is {
     fn set_left(&mut self, left: Expr) {
-        self.expr = Box::new(left);
+        *self.expr = left;
     }
 
     fn set_right(&mut self, right: Type) {

--- a/src/modules/expression/unop/mod.rs
+++ b/src/modules/expression/unop/mod.rs
@@ -2,6 +2,7 @@ use heraclitus_compiler::prelude::*;
 use crate::{modules::types::{Type, Typed}, utils::{pluralize, ParserMetadata}};
 use super::expr::Expr;
 use crate::modules::typecheck::TypeCheckModule;
+use crate::utils::pretty_join;
 
 pub mod not;
 pub mod neg;
@@ -21,7 +22,7 @@ pub trait UnOp: SyntaxModule<ParserMetadata> + TypeCheckModule {
         if !expr_match {
             let message = expr.get_error_message(meta);
             let msg = format!("Cannot perform {operator} on value of type '{expr_type}'");
-            let pretty_types = Type::pretty_join(allowed_types, "and");
+            let pretty_types = pretty_join(allowed_types, "and");
             let sentence = pluralize(allowed_types.len(), "Allowed type is", "Allowed types are");
             let comment = format!("{sentence} {pretty_types}.");
             Err(Failure::Loud((message).message(msg).comment(comment)))

--- a/src/modules/expression/unop/neg.rs
+++ b/src/modules/expression/unop/neg.rs
@@ -24,7 +24,7 @@ impl Typed for Neg {
 
 impl UnOp for Neg {
     fn set_expr(&mut self, expr: Expr) {
-        self.expr = Box::new(expr);
+        *self.expr = expr;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/expression/unop/not.rs
+++ b/src/modules/expression/unop/not.rs
@@ -19,7 +19,7 @@ impl Typed for Not {
 
 impl UnOp for Not {
     fn set_expr(&mut self, expr: Expr) {
-        self.expr = Box::new(expr);
+        *self.expr = expr;
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {

--- a/src/modules/function/declaration.rs
+++ b/src/modules/function/declaration.rs
@@ -1,5 +1,4 @@
 use crate::raw_fragment;
-use crate::modules::function::invocation_utils::run_function_with_args;
 use crate::translate::fragments::get_variable_name;
 use std::collections::HashSet;
 use std::ffi::OsStr;
@@ -346,18 +345,6 @@ impl TypeCheckModule for FunctionDeclaration {
                 ctx,
                 block,
             )?;
-
-            // Compile function eagerly if it's strictly typed (required for nameof operator)
-            if self.args.iter().all(|arg| arg.kind.is_strictly_typed()) {
-                let fun_decl = meta.get_fun_declaration(&self.name).unwrap().clone();
-                let args_types: Vec<Type> = fun_decl.args.iter().map(|arg| arg.kind.clone()).collect();
-                let _ = run_function_with_args(
-                    meta, 
-                    fun_decl.clone(), 
-                    &args_types, 
-                    self.name_token.clone()
-                );
-            }
 
             Ok(())
         })

--- a/src/modules/function/declaration.rs
+++ b/src/modules/function/declaration.rs
@@ -1,4 +1,5 @@
 use crate::raw_fragment;
+use crate::modules::function::invocation_utils::run_function_with_args;
 use crate::translate::fragments::get_variable_name;
 use std::collections::HashSet;
 use std::ffi::OsStr;
@@ -345,6 +346,19 @@ impl TypeCheckModule for FunctionDeclaration {
                 ctx,
                 block,
             )?;
+
+            // Compile function eagerly if it's strictly typed (required for nameof operator)
+            if self.args.iter().all(|arg| arg.kind.is_strictly_typed()) {
+                let fun_decl = meta.get_fun_declaration(&self.name).unwrap().clone();
+                let args_types: Vec<Type> = fun_decl.args.iter().map(|arg| arg.kind.clone()).collect();
+                let _ = run_function_with_args(
+                    meta, 
+                    fun_decl.clone(), 
+                    &args_types, 
+                    self.name_token.clone()
+                );
+            }
+
             Ok(())
         })
     }

--- a/src/modules/function/invocation_utils.rs
+++ b/src/modules/function/invocation_utils.rs
@@ -24,7 +24,7 @@ fn ordinal_number(index: usize) -> String {
     result
 }
 
-fn run_function_with_args(
+pub fn run_function_with_args(
     meta: &mut ParserMetadata,
     mut fun: FunctionDecl,
     args: &[Type],

--- a/src/modules/shorthand/mod.rs
+++ b/src/modules/shorthand/mod.rs
@@ -3,6 +3,7 @@ use crate::modules::prelude::*;
 use crate::utils::pluralize;
 use super::expression::expr::Expr;
 use super::types::{Type, Typed};
+use crate::utils::pretty_join;
 
 pub mod add;
 pub mod sub;
@@ -22,7 +23,7 @@ pub fn shorthand_typecheck_allowed_types(
     if !rhs_match || !rhs_type.is_allowed_in(var_type) {
         let message = rhs.get_error_message(meta);
         let msg = format!("Cannot perform {operator} on value of type '{var_type}' and value of type '{rhs_type}'");
-        let pretty_types = Type::pretty_join(allowed_types, "and");
+        let pretty_types = pretty_join(allowed_types, "and");
         let sentence = pluralize(allowed_types.len(), "Allowed type is", "Allowed types are");
         let comment = format!("{sentence} {pretty_types}.");
         Err(Failure::Loud(message.message(msg).comment(comment)))

--- a/src/modules/types.rs
+++ b/src/modules/types.rs
@@ -54,6 +54,15 @@ impl Type {
         matches!(self, Type::Array(_))
     }
 
+    pub fn is_strictly_typed(&self) -> bool {
+        match self {
+            Type::Generic => false,
+            Type::Union(_) => false,
+            Type::Array(inner) => inner.is_strictly_typed(),
+            _ => true,
+        }
+    }
+
 
 
     pub fn pretty_join(types: &[Self], op: &str) -> String {

--- a/src/modules/types.rs
+++ b/src/modules/types.rs
@@ -62,23 +62,6 @@ impl Type {
             _ => true,
         }
     }
-
-
-
-    pub fn pretty_join(types: &[Self], op: &str) -> String {
-        let mut all_types = types.iter().map(|kind| kind.to_string()).collect_vec();
-        let last_item = all_types.pop();
-        let comma_separated = all_types.iter().join(", ");
-        if let Some(last) = last_item {
-            if types.len() == 1 {
-                last
-            } else {
-                [comma_separated, last].join(&format!(" {op} "))
-            }
-        } else {
-            comma_separated
-        }
-    }
 }
 
 impl Display for Type {

--- a/src/tests/erroring/nameof_generic_function.ab
+++ b/src/tests/erroring/nameof_generic_function.ab
@@ -1,5 +1,5 @@
 // Output
-// Function 'foo' is not strictly typed
+// Function 'foo' must be strictly typed to be used with 'nameof'.
 
 fun foo(a: []) {
     echo a

--- a/src/tests/erroring/nameof_generic_function.ab
+++ b/src/tests/erroring/nameof_generic_function.ab
@@ -1,0 +1,8 @@
+// Output
+// Function 'foo' is not strictly typed
+
+fun foo(a: []) {
+    echo a
+}
+
+echo nameof foo

--- a/src/tests/erroring/nameof_union_function.ab
+++ b/src/tests/erroring/nameof_union_function.ab
@@ -1,5 +1,5 @@
 // Output
-// Function 'foo' is not strictly typed
+// Function 'foo' must be strictly typed to be used with 'nameof'.
 
 fun foo(a: Text | Num) {
     echo a

--- a/src/tests/erroring/nameof_union_function.ab
+++ b/src/tests/erroring/nameof_union_function.ab
@@ -1,0 +1,8 @@
+// Output
+// Function 'foo' is not strictly typed
+
+fun foo(a: Text | Num) {
+    echo a
+}
+
+echo nameof foo

--- a/src/tests/stdlib/array_extract_at.ab
+++ b/src/tests/stdlib/array_extract_at.ab
@@ -6,7 +6,7 @@ import { array_extract_at } from "std/array"
 // Value at 2: "two" (3) [zero one three]
 // Value at 3: "three" (3) [zero one two]
 
-fun test_extract(data: [Text], index: Num): Null? {
+fun test_extract(data: [Text], index: Int): Null? {
     const value = array_extract_at(data, index)?
     echo "Value at {index}: \"{value}\" ({len(data)}) [{data}]"
 }

--- a/src/tests/stdlib/array_remove_at.ab
+++ b/src/tests/stdlib/array_remove_at.ab
@@ -12,7 +12,7 @@ import { array_remove_at } from "std/array"
 // Array after 3: (3) [zero one two]
 // Array after 4: (4) [zero one two three]
 
-fun test_remove(data: [Text], index: Num): Null {
+fun test_remove(data: [Text], index: Int): Null {
     array_remove_at(data, index)
     echo "Array after {index}: ({len(data)}) [{data}]"
 }

--- a/src/tests/validity/nameof_function.ab
+++ b/src/tests/validity/nameof_function.ab
@@ -1,0 +1,11 @@
+// Output
+// Hello!
+// Hello!
+
+fun foo(): Null {
+    echo "Hello!"
+}
+
+foo()
+
+trust $ {nameof foo} $

--- a/src/tests/validity/nameof_function_uncalled.ab
+++ b/src/tests/validity/nameof_function_uncalled.ab
@@ -1,0 +1,8 @@
+// Output
+// hello
+
+fun foo() {
+    echo "hello"
+}
+
+trust $ {nameof foo} $

--- a/src/tests/validity/nameof_recursion.ab
+++ b/src/tests/validity/nameof_recursion.ab
@@ -1,0 +1,28 @@
+// Output
+// True
+// True
+// Compiled
+
+fun is_even(n: Int): Bool {
+    if n == 0 {
+        echo "True"
+        return true
+    }
+    return is_odd(n - 1)
+}
+
+fun is_odd(n: Int): Bool {
+    if n == 0 {
+        echo "False"
+        return false
+    }
+    return is_even(n - 1)
+}
+
+$ {nameof is_even} 2 $ failed {
+    echo "Failed 2"
+}
+$ {nameof is_odd} 3 $ failed {
+    echo "Failed 3"
+}
+echo "Compiled"

--- a/src/tests/validity/nameof_recursion.sh
+++ b/src/tests/validity/nameof_recursion.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Written in [Amber](https://amber-lang.com/)
+# version: nightly-8-g867be7b
+# Output
+# True
+# False
+# Compiled
+is_even__0_v0() {
+    local n_0="${1}"
+    if [ "$(( n_0 == 0 ))" != 0 ]; then
+        echo "True"
+        ret_is_even0_v0=1
+        return 0
+    fi
+    is_odd__1_v0 "$(( n_0 - 1 ))"
+    ret_is_even0_v0="${ret_is_odd1_v0}"
+    return 0
+}
+
+is_odd__1_v0() {
+    local n_1="${1}"
+    if [ "$(( n_1 == 0 ))" != 0 ]; then
+        echo "False"
+        ret_is_odd1_v0=0
+        return 0
+    fi
+    is_even__0_v0 "$(( n_1 - 1 ))"
+    ret_is_odd1_v0="${ret_is_even0_v0}"
+    return 0
+}
+
+is_even__0_v0 2
+__status=$?
+if [ "${__status}" != 0 ]; then
+    echo "Failed 2"
+fi
+is_odd__1_v0 3
+__status=$?
+if [ "${__status}" != 0 ]; then
+    echo "Failed 3"
+fi
+echo "Compiled"

--- a/src/tests/validity/nameof_ref.ab
+++ b/src/tests/validity/nameof_ref.ab
@@ -1,0 +1,18 @@
+// Output
+// 2
+// 1
+
+fun swap(ref a: Int, ref b: Int) {
+    const tmp = a
+    a = b
+    b = tmp
+}
+
+trust $ 
+a=1
+b=2
+{nameof swap} a b
+echo "\$\{a}"
+echo "\$\{b}"
+$
+

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,9 @@ pub mod function_metadata;
 pub mod import_cache;
 pub mod metadata;
 
+use itertools::Itertools;
+use std::fmt::Display;
+
 pub use metadata::*;
 
 pub fn pluralize<'a>(amount: usize, single: &'a str, multiple: &'a str) -> &'a str {
@@ -13,6 +16,21 @@ pub fn pluralize<'a>(amount: usize, single: &'a str, multiple: &'a str) -> &'a s
         multiple
     } else {
         single
+    }
+}
+
+pub fn pretty_join<T: Display>(items: &[T], op: &str) -> String {
+    let mut all_items = items.iter().map(|item| item.to_string()).collect_vec();
+    let last_item = all_items.pop();
+    let comma_separated = all_items.iter().join(", ");
+    if let Some(last) = last_item {
+        if items.len() == 1 {
+            last
+        } else {
+            [comma_separated, last].join(&format!(" {op} "))
+        }
+    } else {
+        comma_separated
     }
 }
 


### PR DESCRIPTION
This makes so that `nameof` works but only for strictly typed functions (only for functions which type is known at compile time). The support for generic types requires additional syntax which we can introduce later.

Closes #673 