### PR TITLE
feat(std): updated symlink_create

### DIFF
--- a/src/std/fs.ab
+++ b/src/std/fs.ab
@@ -69,6 +69,9 @@ pub fun file_append(path: Text, content: Text): Text? {
 /// ```
 pub fun symlink_create(origin: Text, destination: Text): Null? {
     if file_exists(origin) {
+        if file_exists(destination) {
+            trust $ rm "{destination}" $
+        }
         $ ln -s "{origin}" "{destination}" $?
         return null
     }

--- a/src/std/fs.ab
+++ b/src/std/fs.ab
@@ -59,7 +59,7 @@ pub fun file_append(path: Text, content: Text): Text? {
     return $ echo "{content}" >> "{path}" $?
 }
 
-/// Creates a symbolic link.
+/// Creates a symbolic link, if destination exists it will be replaced.
 ///
 /// If the file doesn't exist, it fails and prints a message.
 ///
@@ -69,10 +69,7 @@ pub fun file_append(path: Text, content: Text): Text? {
 /// ```
 pub fun symlink_create(origin: Text, destination: Text): Null? {
     if file_exists(origin) {
-        if file_exists(destination) {
-            trust $ rm "{destination}" $
-        }
-        $ ln -s "{origin}" "{destination}" $?
+        $ ln -fs "{origin}" "{destination}" $?
         return null
     }
 

--- a/src/tests/stdlib/fs_symlink_create.ab
+++ b/src/tests/stdlib/fs_symlink_create.ab
@@ -1,8 +1,20 @@
 import { symlink_create, temp_dir_create } from "std/fs"
 
+// Output
+// Succeeded
+// Succeeded
+
 main {
     const tmpdir = temp_dir_create("amber-XXXX", true, true)?
     trust $ touch {tmpdir}/amber-symbolic $
+    trust symlink_create("{tmpdir}/amber-symbolic", "{tmpdir}/amber-symbolic-link")
+    if status == 0 {
+        echo "Succeeded"
+    } else {
+        echo "failed"
+    }
+    trust $ touch {tmpdir}/amber-symbolic $
+    trust $ touch {tmpdir}/amber-symbolic-link $
     trust symlink_create("{tmpdir}/amber-symbolic", "{tmpdir}/amber-symbolic-link")
     if status == 0 {
         echo "Succeeded"


### PR DESCRIPTION
If the file already exists for the destination when using `ln` bash crash with an error.
This change remove the destination file if exist to avoid this crash.