### PR TITLE
ci: Add rust-problem-matchers for clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -153,6 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: r7kamura/rust-problem-matchers@v1
       - uses: dtolnay/rust-toolchain@stable
       - name: Cache dependencies installed with cargo
         uses: actions/cache@v4


### PR DESCRIPTION
This makes the below warnings

<img width="653" height="675" alt="image" src="https://github.com/user-attachments/assets/bbb96fb7-e236-463a-8acf-d5297d269487" />

which are shown in the changes tab of PRs:

<img width="795" height="485" alt="image" src="https://github.com/user-attachments/assets/def15811-c789-48be-a795-fce89cc86f7d" />

(This is because outputs in special format are used by GitHub. https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md for details)