### PR TITLE
README for `scripts/`

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,7 @@
+# `docs.ab` and `keywords.ab`
+
+## docs.ab 
+Automated script that generates documentation for our standard library (`stdlib`) based on `src/std/` directory
+
+## keywords.ab 
+Automatic script which returns alphabetically sorted list of keywords that are used in Amber based on `grammar.ebnf` file


### PR DESCRIPTION
added simple README for current scripts inside `scripts/`:

> # `docs.ab` and `keywords.ab`
>
> ## docs.ab 
> Automated script that generates documentation for our standard library (`stdlib`) based on `src/std/` directory
>
> ## keywords.ab 
> Automatic script which returns alphabetically sorted list of keywords that are used in Amber based on `grammar.ebnf` file