### PR TITLE
Update optimizer to mark variables used in indexes as used

### DIFF
--- a/src/optimizer/unused_vars.rs
+++ b/src/optimizer/unused_vars.rs
@@ -174,6 +174,10 @@ fn find_unused_variables(ast: &FragmentKind, meta: &mut UnusedVariablesMetadata)
                 meta.symbols.push_back(SymbolType::Statement(var_stmt.get_name(), dependencies));
             } else {
                 find_unused_variables(&var_stmt.value, meta);
+                if let Some(index) = &var_stmt.index {
+                    find_unused_variables(index, meta);
+                }
+
             }
 
         }
@@ -191,6 +195,9 @@ fn find_unused_variables(ast: &FragmentKind, meta: &mut UnusedVariablesMetadata)
                         find_unused_variables(end, meta);
                     }
                 }
+            }
+            if let Some(default_value) = &var_expr.default_value {
+                find_unused_variables(default_value, meta);
             }
         }
         FragmentKind::Subprocess(subprocess) => {

--- a/src/tests/optimizing/unused_variables_array_assign_index.ab
+++ b/src/tests/optimizing/unused_variables_array_assign_index.ab
@@ -1,0 +1,8 @@
+fun foo(): Int {
+    return 0
+}
+
+let x = foo()
+let arr = [""]
+arr[x] = "A"
+echo arr[0]

--- a/src/tests/snapshots/amber__tests__optimizing__unused_variables_array_assign_index.ab.snap
+++ b/src/tests/snapshots/amber__tests__optimizing__unused_variables_array_assign_index.ab.snap
@@ -1,0 +1,14 @@
+---
+source: src/tests/optimizing.rs
+expression: output
+---
+foo__0_v0() {
+    ret_foo0_v0=0
+    return 0
+}
+
+foo__0_v0 
+x_0="${ret_foo0_v0}"
+arr_1=("")
+arr_1["${x_0}"]="A"
+echo "${arr_1[0]}"


### PR DESCRIPTION
There was a critical bug related to optimizer that optimized away variables that were used as indexes.