### PR TITLE
Remove testing push trigger of zizmor workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,9 +3,6 @@ name: zizmor Security Analysis
 on:
   schedule:
     - cron: '0 0 * * 0' # weekly
-  push:
-    branches:
-      - zizmor # temporarily when this on PR
 
 permissions:
   contents: read


### PR DESCRIPTION
Removes push trigger for the 'zizmor' branch in the workflow.

I accidentally left this!