### PR TITLE
Replace duplicate statement lists

### DIFF
--- a/meta/src/dispatch.rs
+++ b/meta/src/dispatch.rs
@@ -1,0 +1,98 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Error, Fields, Ident, Variant};
+
+/// Check if a variant has the `#[dispatch(translate_discard)]` attribute
+fn has_translate_discard(variant: &Variant) -> bool {
+    variant.attrs.iter().any(|attr| {
+        attr.path().is_ident("dispatch")
+            && attr
+                .parse_args::<Ident>()
+                .map(|ident| ident == "translate_discard")
+                .unwrap_or(false)
+    })
+}
+
+/// Validate that a variant is a tuple variant with exactly one field
+fn validate_variant(variant: &Variant) -> Result<(), Error> {
+    match &variant.fields {
+        Fields::Unnamed(fields) if fields.unnamed.len() == 1 => Ok(()),
+        _ => Err(Error::new_spanned(
+            variant,
+            "StatementDispatch requires tuple variants with exactly one field",
+        )),
+    }
+}
+
+/// Generate the StatementDispatch implementations for an enum
+pub fn generate_dispatch(input: &DeriveInput) -> TokenStream {
+    generate_dispatch_inner(input).unwrap_or_else(|err| err.to_compile_error())
+}
+
+fn generate_dispatch_inner(input: &DeriveInput) -> Result<TokenStream, Error> {
+    let enum_name = &input.ident;
+
+    let variants = match &input.data {
+        Data::Enum(data_enum) => &data_enum.variants,
+        _ => {
+            return Err(Error::new_spanned(
+                input,
+                "StatementDispatch can only be derived for enums",
+            ))
+        }
+    };
+
+    for variant in variants {
+        validate_variant(variant)?;
+    }
+
+    let typecheck_arms = variants.iter().map(|v| {
+        let name = &v.ident;
+        quote! { #enum_name::#name(inner) => inner.typecheck(meta) }
+    });
+
+    let translate_arms = variants.iter().map(|v| {
+        let name = &v.ident;
+        if has_translate_discard(v) {
+            quote! {
+                #enum_name::#name(inner) => {
+                    inner.translate(meta);
+                    FragmentKind::Empty
+                }
+            }
+        } else {
+            quote! { #enum_name::#name(inner) => inner.translate(meta) }
+        }
+    });
+
+    let document_arms = variants.iter().map(|v| {
+        let name = &v.ident;
+        quote! { #enum_name::#name(inner) => inner.document(meta) }
+    });
+
+    Ok(quote! {
+        impl TypeCheckModule for #enum_name {
+            fn typecheck(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
+                match self {
+                    #(#typecheck_arms),*
+                }
+            }
+        }
+
+        impl TranslateModule for #enum_name {
+            fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
+                match self {
+                    #(#translate_arms),*
+                }
+            }
+        }
+
+        impl DocumentationModule for #enum_name {
+            fn document(&self, meta: &ParserMetadata) -> String {
+                match self {
+                    #(#document_arms),*
+                }
+            }
+        }
+    })
+}

--- a/meta/src/dispatch.rs
+++ b/meta/src/dispatch.rs
@@ -25,28 +25,6 @@ fn validate_variant(variant: &Variant) -> Result<(), Error> {
 }
 
 /// Generate the StatementDispatch implementations for an enum
-///
-/// # Compile-time errors
-///
-/// The macro will fail to compile if applied to a struct:
-///
-/// ```compile_fail
-/// use amber_meta::StatementDispatch;
-///
-/// #[derive(StatementDispatch)]
-/// struct Test;
-/// ```
-///
-/// The macro will also fail if applied to an enum with unit variants:
-///
-/// ```compile_fail
-/// use amber_meta::StatementDispatch;
-///
-/// #[derive(StatementDispatch)]
-/// enum InvalidVariant {
-///     Unit,
-/// }
-/// ```
 pub fn generate_dispatch(input: &DeriveInput) -> TokenStream {
     generate_dispatch_inner(input).unwrap_or_else(|err| err.to_compile_error())
 }

--- a/meta/src/dispatch.rs
+++ b/meta/src/dispatch.rs
@@ -25,6 +25,28 @@ fn validate_variant(variant: &Variant) -> Result<(), Error> {
 }
 
 /// Generate the StatementDispatch implementations for an enum
+///
+/// # Compile-time errors
+///
+/// The macro will fail to compile if applied to a struct:
+///
+/// ```compile_fail
+/// use amber_meta::StatementDispatch;
+///
+/// #[derive(StatementDispatch)]
+/// struct Test;
+/// ```
+///
+/// The macro will also fail if applied to an enum with unit variants:
+///
+/// ```compile_fail
+/// use amber_meta::StatementDispatch;
+///
+/// #[derive(StatementDispatch)]
+/// enum InvalidVariant {
+///     Unit,
+/// }
+/// ```
 pub fn generate_dispatch(input: &DeriveInput) -> TokenStream {
     generate_dispatch_inner(input).unwrap_or_else(|err| err.to_compile_error())
 }

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -1,3 +1,4 @@
+mod dispatch;
 mod helper;
 mod manager;
 mod utils;
@@ -6,7 +7,7 @@ use crate::helper::HelperVisitor;
 use crate::manager::ManagerVisitor;
 use proc_macro::TokenStream;
 use syn::visit::Visit;
-use syn::*;
+use syn::{DeriveInput, ItemStruct, parse_macro_input};
 
 /// Derive macro `ContextManager` allows changes to be made to annotated
 /// fields on a struct, with automatic reset on early error return.
@@ -100,5 +101,21 @@ pub fn context_helper(input: TokenStream) -> TokenStream {
     let mut visitor = HelperVisitor::new(&input.ident);
     visitor.visit_item_struct(&input);
     let output = visitor.make_block();
+    TokenStream::from(output)
+}
+
+/// Derive macro `StatementDispatch` generates trait implementations for
+/// `TypeCheckModule`, `TranslateModule`, and `DocumentationModule` for
+/// statement enums.
+///
+/// Each enum variant must be a tuple variant with exactly one field.
+/// The generated implementations dispatch to the inner type's implementation.
+///
+/// Use `#[dispatch(translate_discard)]` on a variant to make its
+/// `translate` method discard the result and return `FragmentKind::Empty`.
+#[proc_macro_derive(StatementDispatch, attributes(dispatch))]
+pub fn statement_dispatch(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let output = dispatch::generate_dispatch(&input);
     TokenStream::from(output)
 }

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -113,6 +113,28 @@ pub fn context_helper(input: TokenStream) -> TokenStream {
 ///
 /// Use `#[dispatch(translate_discard)]` on a variant to make its
 /// `translate` method discard the result and return `FragmentKind::Empty`.
+///
+/// # Compile-time errors
+///
+/// The macro will fail to compile if applied to a struct:
+///
+/// ```compile_fail
+/// use amber_meta::StatementDispatch;
+///
+/// #[derive(StatementDispatch)]
+/// struct Test;
+/// ```
+///
+/// The macro will also fail if applied to an enum with unit variants:
+///
+/// ```compile_fail
+/// use amber_meta::StatementDispatch;
+///
+/// #[derive(StatementDispatch)]
+/// enum InvalidVariant {
+///     Unit,
+/// }
+/// ```
 #[proc_macro_derive(StatementDispatch, attributes(dispatch))]
 pub fn statement_dispatch(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/src/modules/statement/mod.rs
+++ b/src/modules/statement/mod.rs
@@ -22,36 +22,3 @@ macro_rules! parse_statement {
         Err(Failure::Quiet(error.unwrap()))
     }};
 }
-
-#[macro_export]
-macro_rules! typecheck_statement {
-    ($meta:expr, $stmt_type:expr, [$($stmt:ident),*]) => {
-        match $stmt_type {
-            $(
-                StmtType::$stmt(stmt) => stmt.typecheck($meta)?,
-            )*
-        }
-    };
-}
-
-#[macro_export]
-macro_rules! translate_statement {
-    ($stmt_type:expr, [$($stmt:ident),*], |$var:ident| $body:expr) => {
-        match $stmt_type {
-            $(
-                StmtType::$stmt($var) => $body,
-            )*
-        }
-    };
-}
-
-#[macro_export]
-macro_rules! document_statement {
-    ($stmt_type:expr, [$($stmt:ident),*], $var:ident, $body:expr) => {
-        match $stmt_type {
-            $(
-                StmtType::$stmt($var) => $body,
-            )*
-        }
-    };
-}


### PR DESCRIPTION
This diff addresses #947 by eliminating the duplicate statement type lists in [stmt.rs](https://github.com/amber-lang/amber/blob/staging/src/modules/statement/stmt.rs).

Previously, adding a new statement type required updating four separate locations: the `StmtType` enum definition, plus three macro invocations (`typecheck_statement!`, `translate_statement!`, `document_statement!`) that each maintained identical lists of all 32 statement types.

The new `StatementDispatch` derive macro auto-generates the `TypeCheckModule`, `TranslateModule`, and `DocumentationModule` implementations by iterating over enum variants at compile time. Adding a new statement type now requires only two changes: adding the variant to `StmtType` and adding it to `parse_statement!` (which must remain manual since parsing order matters).

The `#[dispatch(translate_discard)]` attribute handles the special case where `Expr` statements need to discard their translation result to avoid malformed bash output.
