### PR TITLE
union type for some functions, color names

### DIFF
--- a/src/std/env.ab
+++ b/src/std/env.ab
@@ -1,4 +1,5 @@
 import * from "std/fs"
+import { array_find } from "std/array"
 import * from "std/text"
 
 /// Retrieves the value of an environment variable, optionally sourcing it from a file if not already set.
@@ -52,7 +53,7 @@ pub fun env_var_test(name: Text): Bool {
 /// ```ab
 /// env_const_set("API_KEY", "secret123")
 /// ```
-pub fun env_const_set(name: Text, val: Text): Null? {
+pub fun env_const_set(name: Text, val: Text | Int | Bool): Null? {
     $ readonly \${nameof name}="\${nameof val}" 2> /dev/null $?
 }
 
@@ -60,9 +61,9 @@ pub fun env_const_set(name: Text, val: Text): Null? {
 ///
 /// ### Usage
 /// ```ab
-/// env_var_set("DEBUG", "true")
+/// env_var_set("DEBUG", true)
 /// ```
-pub fun env_var_set(name: Text, val: Text): Null? {
+pub fun env_var_set(name: Text, val: Text | Int | Bool): Null? {
     $ export \${nameof name}="\${nameof val}" 2> /dev/null $?
 }
 
@@ -182,7 +183,7 @@ pub fun is_root(): Bool {
 /// ```ab
 /// printf("Hello %s!", ["World"])
 /// ```
-pub fun printf(format: Text, args: [Text] = [""]): Null {
+pub fun printf(format: Text, args: [Text] = []): Null {
     trust $ {nameof args}=("{format}" "\$\{{nameof args}[@]}") $
     trust $ printf "\$\{{nameof args}[@]}" $
 }
@@ -202,9 +203,46 @@ pub fun escaped(text: Text): Text {
 /// ### Usage
 /// ```ab
 /// printf("%s\n", [styled("Error!", 1, 31, 40)])
+/// printf("%s\n", [styled("Warning!", 1, "white", "yellow")])
+///
+/// ### Supported color names
+/// | Color name | Foreground code | Background code
+/// | black | 30 | 40 |
+/// | red | 31 | 41 |
+/// | green | 32 | 42 |
+/// | yellow | 33 | 43 |
+/// | orange | 93 | 103 |
+/// | blue | 34 | 44 |
+/// | purple | 35 | 45 |
+/// | cyan | 36 | 46 |
+/// | gray | 37 | 47 | 
+/// | white | 97 | 107 |
+///
+/// For all supported color codes, please visit https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
 /// ```
-pub fun styled(message: Text, style: Int, fg: Int, bg: Int): Text {
-    return "\x1b[{style};{fg};{bg}m{escaped(message)}\x1b[0m"
+pub fun styled(message: Text, style: Int, fg: Int | Text, bg: Int | Text): Text {
+    // https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
+    const colors_name = ["black", "red", "green", "yellow", "orange", "blue", "purple", "cyan", "gray", "white"];
+    let fg_code = "";
+    let bg_code = "";
+    if bg is Text {
+        const colors_code = [40, 41, 42, 103, 43, 44, 45, 46, 47, 97];
+        const color_index = array_find(colors_name, bg)
+        if color_index == -1: echo_error("Invalid background color name provided", 1)
+        bg_code = "{colors_code[color_index]}"
+    } else { 
+        bg_code = "{bg}";
+    }
+
+    if fg is Text {
+        const colors_code = [30, 31, 32, 93, 33, 34, 35, 36, 37];
+        const color_index = array_find(colors_name, fg)
+        if color_index == -1: echo_error("Invalid foreground color name provided", 1)
+        fg_code = "{colors_code[color_index]}"
+    } else {
+        fg_code = "{fg}";
+    }
+    return "\x1b[{style};{fg_code};{bg_code}m{escaped(message)}\x1b[0m"
 }
 
 /// Returns a text as bold.
@@ -241,10 +279,37 @@ pub fun underlined(message: Text): Text {
 ///
 /// ### Usage
 /// ```ab
-/// echo_colored("Red text", 31)
+/// echo_colored("Red text", "red")
+/// echo_colored("Blue text", 34)
 /// ```
-pub fun echo_colored(message: Text, color: Int): Null {
-    printf("\x1b[{color as Text}m%s\x1b[0m\n", [message])
+/// 
+/// ### Supported color names
+/// | Color name | Code |
+/// | black | 30 |
+/// | red | 31 |
+/// | green | 32 |
+/// | yellow | 93 |
+/// | orange | 33 |
+/// | blue | 34 |
+/// | purple | 35 |
+/// | cyan | 36 |
+/// | gray | 37 |
+/// | white | 97 |
+///
+/// For all supported color codes, please visit https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
+pub fun echo_colored(message: Text, color: Text | Int): Null {
+    let color_code = "";
+    if color is Text {
+        // https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
+        const colors_name = ["black", "red", "green", "yellow", "orange", "blue", "purple", "cyan", "gray", "white"];
+        const colors_code = [30, 31, 32, 93, 33, 34, 35, 36, 37, 97];
+        const color_index = array_find(colors_name, color)
+        if color_index == -1: echo_error("Invalid color name provided", 1)
+        color_code = "{colors_code[color_index]}"
+    } else {
+       color_code = "{color}"
+    }
+    printf("\x1b[{color_code}m%s\x1b[0m\n", [message])
 }
 
 /// Prints a text as a info message.

--- a/src/std/env.ab
+++ b/src/std/env.ab
@@ -208,7 +208,7 @@ pub fun escaped(text: Text): Text {
 /// printf("%s\n", [styled("Warning!", 1, "white", "yellow")])
 ///
 /// ### Supported color names
-/// | Color name | Foreground code | Background code
+/// | Color name | Foreground code | Background code |
 /// | black | 30 | 40 |
 /// | red | 31 | 41 |
 /// | green | 32 | 42 |

--- a/src/std/env.ab
+++ b/src/std/env.ab
@@ -61,7 +61,9 @@ pub fun env_const_set(name: Text, val: Text | Int | Bool): Null? {
 ///
 /// ### Usage
 /// ```ab
-/// env_var_set("DEBUG", true)
+/// env_var_set("STATUS","succeeded")
+/// env_var_set("COUNT", 100)
+/// env_var_set("DEBUG", true) // note that `true` is saved as int (`1`)
 /// ```
 pub fun env_var_set(name: Text, val: Text | Int | Bool): Null? {
     $ export \${nameof name}="\${nameof val}" 2> /dev/null $?

--- a/src/std/env.ab
+++ b/src/std/env.ab
@@ -225,24 +225,24 @@ pub fun escaped(text: Text): Text {
 pub fun styled(message: Text, style: Int, fg: Int | Text, bg: Int | Text): Text {
     // https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
     const colors_name = ["black", "red", "green", "yellow", "orange", "blue", "purple", "cyan", "gray", "white"];
-    let fg_code = "";
-    let bg_code = "";
+    let fg_code = 0;
+    let bg_code = 0;
     if bg is Text {
         const colors_code = [40, 41, 42, 103, 43, 44, 45, 46, 47, 97];
         const color_index = array_find(colors_name, bg)
         if color_index == -1: echo_error("Invalid background color name provided", 1)
-        bg_code = "{colors_code[color_index]}"
+        bg_code = colors_code[color_index]
     } else { 
-        bg_code = "{bg}";
+        bg_code = bg;
     }
 
     if fg is Text {
         const colors_code = [30, 31, 32, 93, 33, 34, 35, 36, 37];
         const color_index = array_find(colors_name, fg)
         if color_index == -1: echo_error("Invalid foreground color name provided", 1)
-        fg_code = "{colors_code[color_index]}"
+        fg_code = colors_code[color_index]
     } else {
-        fg_code = "{fg}";
+        fg_code = fg
     }
     return "\x1b[{style};{fg_code};{bg_code}m{escaped(message)}\x1b[0m"
 }
@@ -300,16 +300,16 @@ pub fun underlined(message: Text): Text {
 ///
 /// For all supported color codes, please visit https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
 pub fun echo_colored(message: Text, color: Text | Int): Null {
-    let color_code = "";
+    let color_code = 0;
     if color is Text {
         // https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
         const colors_name = ["black", "red", "green", "yellow", "orange", "blue", "purple", "cyan", "gray", "white"];
         const colors_code = [30, 31, 32, 93, 33, 34, 35, 36, 37, 97];
         const color_index = array_find(colors_name, color)
         if color_index == -1: echo_error("Invalid color name provided", 1)
-        color_code = "{colors_code[color_index]}"
+        color_code = colors_code[color_index]
     } else {
-       color_code = "{color}"
+       color_code = color
     }
     printf("\x1b[{color_code}m%s\x1b[0m\n", [message])
 }

--- a/src/tests/stdlib/env_echo_colored.ab
+++ b/src/tests/stdlib/env_echo_colored.ab
@@ -4,5 +4,5 @@ import * from "std/env"
 // [33mHello Amber![0m
 
 main {
-    echo_colored("Hello Amber!", 33)
+    echo_colored("Hello Amber!", "orange")
 } 

--- a/src/tests/stdlib/env_echo_colored.ab
+++ b/src/tests/stdlib/env_echo_colored.ab
@@ -2,7 +2,8 @@ import * from "std/env"
 
 // Output
 // [33mHello Amber![0m
-
+// [33mHello Amber![0m
 main {
     echo_colored("Hello Amber!", "orange")
+    echo_colored("Hello Amber!", 33)
 } 


### PR DESCRIPTION
i couldn't understand why compiler complains about setting "Text" value to "Int" variable so i ended up using text variable for color code directly (makes sense since e.g. `echo_colored` returns int as text)
now im not sure how to change expected test result, so i haven't added more tests yet

also updated types for generic functions where it would be appropriate (e.g. `env_var_set()`)

Closes #941 