### PR TITLE
feat: Avoid trimming indentation from doc code blocks

### DIFF
--- a/src/modules/statement/comment_doc.rs
+++ b/src/modules/statement/comment_doc.rs
@@ -23,6 +23,7 @@ impl SyntaxModule<ParserMetadata> for CommentDoc {
                 if token.word.starts_with("///") {
                     self.value = token.word[3..].trim().to_string();
                     meta.increment_index();
+                    let mut inside_code_block = false;
                     while let Some(token) = meta.get_current_token() {
                         let is_token_underneath = token.pos.0 == col + 1;
                         let last_char = self.value.chars().last().unwrap_or('\n');
@@ -36,16 +37,35 @@ impl SyntaxModule<ParserMetadata> for CommentDoc {
                             // Update the column of the last comment
                             col = token.pos.0;
                             meta.increment_index();
-                            // If the comment signifies a paragraph break, we add two newlines
-                            if token.word[3..].trim().is_empty() {
-                                if last_char == '\n' {
-                                    continue;
+
+                            let line = &token.word[3..];
+                            let trimmed_line = &line.trim();
+
+                            if trimmed_line.is_empty() {
+                                // If the comment signifies a paragraph break, we add two newlines
+                                if last_char != '\n' {
+                                    self.value.push_str("\n\n");
                                 }
-                                self.value.push_str("\n\n");
-                                continue;
+                            } else {
+                                if last_char != '\n' { self.value.push(' ') }
+                                match *trimmed_line {
+                                    "```ab" => {
+                                        inside_code_block = true;
+                                        self.value.push_str(trimmed_line);
+                                    },
+                                    "```" => {
+                                        inside_code_block = false;
+                                        self.value.push_str(trimmed_line);
+                                    },
+                                    // Add code lines without trimming the start
+                                    _ if inside_code_block => {
+                                        self.value.push_str(line[1..].trim_end());
+                                    },
+                                    _ => {
+                                        self.value.push_str(trimmed_line);
+                                    }
+                                }
                             }
-                            let delimiter = if last_char == '\n' { "" } else { " " };
-                            self.value.push_str(&format!("{}{}", delimiter, token.word[3..].trim()));
                         } else {
                             break;
                         }

--- a/src/modules/statement/comment_doc.rs
+++ b/src/modules/statement/comment_doc.rs
@@ -49,7 +49,7 @@ impl SyntaxModule<ParserMetadata> for CommentDoc {
                             } else {
                                 if last_char != '\n' { self.value.push(' '); }
                                 if trimmed_line.starts_with("```") {
-                                    if let Some(_) = code_block_column_position {
+                                    if code_block_column_position.is_some() {
                                         code_block_column_position = None;
                                     } else {
                                         code_block_column_position = line.find("```");

--- a/src/modules/statement/comment_doc.rs
+++ b/src/modules/statement/comment_doc.rs
@@ -23,7 +23,7 @@ impl SyntaxModule<ParserMetadata> for CommentDoc {
                 if token.word.starts_with("///") {
                     self.value = token.word[3..].trim().to_string();
                     meta.increment_index();
-                    let mut inside_code_block = false;
+                    let mut code_block_column_position: Option<usize> = None;
                     while let Some(token) = meta.get_current_token() {
                         let is_token_underneath = token.pos.0 == col + 1;
                         let last_char = self.value.chars().last().unwrap_or('\n');
@@ -47,23 +47,22 @@ impl SyntaxModule<ParserMetadata> for CommentDoc {
                                     self.value.push_str("\n\n");
                                 }
                             } else {
-                                if last_char != '\n' { self.value.push(' ') }
-                                match *trimmed_line {
-                                    "```ab" => {
-                                        inside_code_block = true;
-                                        self.value.push_str(trimmed_line);
-                                    },
-                                    "```" => {
-                                        inside_code_block = false;
-                                        self.value.push_str(trimmed_line);
-                                    },
-                                    // Add code lines without trimming the start
-                                    _ if inside_code_block => {
-                                        self.value.push_str(line[1..].trim_end());
-                                    },
-                                    _ => {
-                                        self.value.push_str(trimmed_line);
+                                if last_char != '\n' { self.value.push(' '); }
+                                if trimmed_line.starts_with("```") {
+                                    if let Some(_) = code_block_column_position {
+                                        code_block_column_position = None;
+                                    } else {
+                                        code_block_column_position = line.find("```");
                                     }
+                                    self.value.push_str(trimmed_line);
+                                }
+                                else if let Some(code_line_start_index) = code_block_column_position {
+                                    // Add code lines relative to the starting code fence's column position. 
+                                    let start_index = code_line_start_index.min(line.len());
+                                    self.value.push_str(line[start_index..].trim_end());
+                                }
+                                else {
+                                    self.value.push_str(trimmed_line);
                                 }
                             }
                         } else {


### PR DESCRIPTION
- Avoids trimming indentation from doc code block lines by keeping track of whether the current line is between two code fences or not.
  - Assumes that "\`\`\`ab" and "\`\`\`" are the start and end fences respectively.
  - Also assumes that the start of the indentation is one space after "///".
- Additionally remove the use of `format` as it just a combination of two `push_str`s, but also creates a new `String`.

I'm not that sure about the second point but let me know if `format` is still preferred here, I just feel like it creating a new `String` is unnecessary, when you can just refer to the original `&str`s.

Closes #956.