### PR TITLE
feat(stdlib): add array sort functions

### DIFF
--- a/src/std/array.ab
+++ b/src/std/array.ab
@@ -165,39 +165,43 @@ pub fun array_filled(size, value = 0) {
 }
 
 /// Return the sorted array, leaving the original array unchanged.
-/// Pass `human` value `true` for human readable sort.
 /// Pass `desc` value `true` for descending order.
+/// Pass `version_sort` value `true` for version sort,
+/// this only applies to text arrays.
 ///
 /// ### Usage
 /// ```ab
 /// echo(sorted([-3,15,7,2], true)) // Outputs [-3, 2, 7, 15]
 /// ```
-pub fun sorted(array: [], human: Bool = false, desc: Bool = false): [] {
+pub fun sorted(array: [], desc: Bool = false, version_sort: Bool = false): [] {
     if array is [Null] or len(array) <= 1:
         return array
 
     const desc_flag = desc then "-r" else ""
-    const human_flag = human
-        then array is [Num] or array is [Int]
-            then "-h"
-            else "-V"
-        else ""
+    let sort_flag = ""
+    if {
+        array is [Text] and version_sort:
+            sort_flag = "-V"
+        array is [Num] or array is [Int] or array is [Bool]:
+            sort_flag = "-n"
+    }
 
     let result = []
-    trust $ IFS="\n" read -rd '' -a {nameof result} < <(printf "%s\n" "\$\{{nameof array}[@]}" | sort {human_flag} {desc_flag}) $
+    trust $ IFS="\n" read -rd '' -a {nameof result} < <(printf "%s\n" "\$\{{nameof array}[@]}" | sort {sort_flag} {desc_flag}) $
     return result
 }
 
 /// Sort the array in-place.
-/// Pass `human` value `true` for human readable sort.
 /// Pass `desc` value `true` for descending order.
+/// Pass `version_sort` value `true` for version sort,
+/// this only applies to text arrays.
 ///
 /// ### Usage
 /// ```ab
-/// let array = ["-3","15","foo","bar"]
+/// let array = ["15","-3","foo","bar"]
 /// sort(array)
-/// echo(array) // Outputs ["15", "-3", "bar", "foo"]
+/// echo(array) // Outputs ["-3", "15", "bar", "foo"]
 /// ```
-pub fun sort(ref array: [], human: Bool = false, desc: Bool = false): Null {
-    array = sorted(array, human, desc)
+pub fun sort(ref array: [], desc: Bool = false, version_sort: Bool = false): Null {
+    array = sorted(array, desc, version_sort)
 }

--- a/src/std/array.ab
+++ b/src/std/array.ab
@@ -163,3 +163,41 @@ pub fun array_filled(size, value = 0) {
 
     return array
 }
+
+/// Return the sorted array, leaving the original array unchanged.
+/// Pass `human` value `true` for human readable sort.
+/// Pass `desc` value `true` for descending order.
+///
+/// ### Usage
+/// ```ab
+/// echo(sorted([-3,15,7,2], true)) // Outputs [-3, 2, 7, 15]
+/// ```
+pub fun sorted(array: [], human: Bool = false, desc: Bool = false): [] {
+    if array is [Null] or len(array) <= 1:
+        return array
+
+    const desc_flag = desc then "-r" else ""
+    const human_flag = human
+        then array is [Num] or array is [Int]
+            then "-h"
+            else "-V"
+        else ""
+
+    let result = []
+    trust $ IFS="\n" read -rd '' -a {nameof result} < <(printf "%s\n" "\$\{{nameof array}[@]}" | sort {human_flag} {desc_flag}) $
+    return result
+}
+
+/// Sort the array in-place.
+/// Pass `human` value `true` for human readable sort.
+/// Pass `desc` value `true` for descending order.
+///
+/// ### Usage
+/// ```ab
+/// let array = ["-3","15","foo","bar"]
+/// sort(array)
+/// echo(array) // Outputs ["15", "-3", "bar", "foo"]
+/// ```
+pub fun sort(ref array: [], human: Bool = false, desc: Bool = false): Null {
+    array = sorted(array, human, desc)
+}

--- a/src/tests/stdlib/array_sort.ab
+++ b/src/tests/stdlib/array_sort.ab
@@ -2,19 +2,19 @@ import { sort } from "std/array"
 
 // Output
 // Array length: 6
-// [10 -5 6 a c d]
+// [-5 10 6 a c d]
 // Array length: 6
 // [6 10 a c d -5]
 // Array length: 6
 // [-5 d c a 10 6]
 // Array length: 4
-// [10 -2 5 7]
+// [-2 10 5 7]
 // Array length: 4
-// [7 5 -2 10]
+// [7 5 10 -2]
 // Array length: 4
 // [-2 5 7 10]
 // Array length: 4
-// [11.5 2.34 -5.4 6.1]
+// [-5.4 11.5 2.34 6.1]
 // Array length: 4
 // [-5.4 2.34 6.1 11.5]
 // Array length: 2

--- a/src/tests/stdlib/array_sort.ab
+++ b/src/tests/stdlib/array_sort.ab
@@ -1,40 +1,40 @@
 import { sort } from "std/array"
 
 // Output
-// Array length: 6
-// [-5 10 6 a c d]
-// Array length: 6
-// [6 10 a c d -5]
-// Array length: 6
-// [-5 d c a 10 6]
-// Array length: 4
-// [-2 10 5 7]
-// Array length: 4
-// [7 5 10 -2]
+// Array length: 7
+// [-5 1 12 2 a c d]
+// Array length: 7
+// [1 2 12 a c d -5]
+// Array length: 7
+// [d c a 2 12 1 -5]
 // Array length: 4
 // [-2 5 7 10]
 // Array length: 4
-// [-5.4 11.5 2.34 6.1]
+// [10 7 5 -2]
+// Array length: 4
+// [-2 5 7 10]
 // Array length: 4
 // [-5.4 2.34 6.1 11.5]
+// Array length: 4
+// [11.5 6.1 2.34 -5.4]
 // Array length: 2
 // [0 1]
 // Array length: 2
 // [ ]
 
-fun test_sort(arr: [], human: Bool, desc: Bool) {
-    sort(arr, human, desc)
+fun test_sort(arr: [], desc: Bool, version_sort: Bool) {
+    sort(arr, desc, version_sort)
     echo("Array length: {len(arr)}")
     echo("[{arr}]")
 }
 
 main {
-    test_sort(["c", "d", "a", "10", "6", "-5"], false, false)
-    test_sort(["c", "d", "a", "10", "6", "-5"], true, false)
-    test_sort(["c", "d", "a", "10", "6", "-5"], true, true)
+    test_sort(["c", "d", "a", "1", "12", "2", "-5"], false, false)
+    test_sort(["c", "d", "a", "1", "12", "2", "-5"], false, true)
+    test_sort(["c", "d", "a", "1", "12", "2", "-5"], true, false)
     test_sort([7, 10, 5, -2], false, false)
-    test_sort([7, 10, 5, -2], false, true)
     test_sort([7, 10, 5, -2], true, false)
+    test_sort([7, 10, 5, -2], false, true)
     test_sort([11.5, 6.1, -5.4, 2.34], false, false)
     test_sort([11.5, 6.1, -5.4, 2.34], true, false)
     test_sort([true, false], false, false)

--- a/src/tests/stdlib/array_sort.ab
+++ b/src/tests/stdlib/array_sort.ab
@@ -1,0 +1,42 @@
+import { sort } from "std/array"
+
+// Output
+// Array length: 6
+// [10 -5 6 a c d]
+// Array length: 6
+// [6 10 a c d -5]
+// Array length: 6
+// [-5 d c a 10 6]
+// Array length: 4
+// [10 -2 5 7]
+// Array length: 4
+// [7 5 -2 10]
+// Array length: 4
+// [-2 5 7 10]
+// Array length: 4
+// [11.5 2.34 -5.4 6.1]
+// Array length: 4
+// [-5.4 2.34 6.1 11.5]
+// Array length: 2
+// [0 1]
+// Array length: 2
+// [ ]
+
+fun test_sort(arr: [], human: Bool, desc: Bool) {
+    sort(arr, human, desc)
+    echo("Array length: {len(arr)}")
+    echo("[{arr}]")
+}
+
+main {
+    test_sort(["c", "d", "a", "10", "6", "-5"], false, false)
+    test_sort(["c", "d", "a", "10", "6", "-5"], true, false)
+    test_sort(["c", "d", "a", "10", "6", "-5"], true, true)
+    test_sort([7, 10, 5, -2], false, false)
+    test_sort([7, 10, 5, -2], false, true)
+    test_sort([7, 10, 5, -2], true, false)
+    test_sort([11.5, 6.1, -5.4, 2.34], false, false)
+    test_sort([11.5, 6.1, -5.4, 2.34], true, false)
+    test_sort([true, false], false, false)
+    test_sort([null, null], false, false)
+}

--- a/src/tests/stdlib/array_sorted.ab
+++ b/src/tests/stdlib/array_sorted.ab
@@ -2,19 +2,19 @@ import { sorted } from "std/array"
 
 // Output
 // Array length: 6
-// [10 -5 6 a c d]
+// [-5 10 6 a c d]
 // Array length: 6
 // [6 10 a c d -5]
 // Array length: 6
 // [-5 d c a 10 6]
 // Array length: 4
-// [10 -2 5 7]
+// [-2 10 5 7]
 // Array length: 4
-// [7 5 -2 10]
+// [7 5 10 -2]
 // Array length: 4
 // [-2 5 7 10]
 // Array length: 4
-// [11.5 2.34 -5.4 6.1]
+// [-5.4 11.5 2.34 6.1]
 // Array length: 4
 // [-5.4 2.34 6.1 11.5]
 // Array length: 2

--- a/src/tests/stdlib/array_sorted.ab
+++ b/src/tests/stdlib/array_sorted.ab
@@ -1,0 +1,42 @@
+import { sorted } from "std/array"
+
+// Output
+// Array length: 6
+// [10 -5 6 a c d]
+// Array length: 6
+// [6 10 a c d -5]
+// Array length: 6
+// [-5 d c a 10 6]
+// Array length: 4
+// [10 -2 5 7]
+// Array length: 4
+// [7 5 -2 10]
+// Array length: 4
+// [-2 5 7 10]
+// Array length: 4
+// [11.5 2.34 -5.4 6.1]
+// Array length: 4
+// [-5.4 2.34 6.1 11.5]
+// Array length: 2
+// [0 1]
+// Array length: 2
+// [ ]
+
+fun test_sorted(arr: [], human: Bool, desc: Bool) {
+    const result = sorted(arr, human, desc)
+    echo("Array length: {len(result)}")
+    echo("[{result}]")
+}
+
+main {
+    test_sorted(["c", "d", "a", "10", "6", "-5"], false, false)
+    test_sorted(["c", "d", "a", "10", "6", "-5"], true, false)
+    test_sorted(["c", "d", "a", "10", "6", "-5"], true, true)
+    test_sorted([7, 10, 5, -2], false, false)
+    test_sorted([7, 10, 5, -2], false, true)
+    test_sorted([7, 10, 5, -2], true, false)
+    test_sorted([11.5, 6.1, -5.4, 2.34], false, false)
+    test_sorted([11.5, 6.1, -5.4, 2.34], true, false)
+    test_sorted([true, false], false, false)
+    test_sorted([null, null], false, false)
+}

--- a/src/tests/stdlib/array_sorted.ab
+++ b/src/tests/stdlib/array_sorted.ab
@@ -1,40 +1,40 @@
 import { sorted } from "std/array"
 
 // Output
-// Array length: 6
-// [-5 10 6 a c d]
-// Array length: 6
-// [6 10 a c d -5]
-// Array length: 6
-// [-5 d c a 10 6]
-// Array length: 4
-// [-2 10 5 7]
-// Array length: 4
-// [7 5 10 -2]
+// Array length: 7
+// [-5 1 12 2 a c d]
+// Array length: 7
+// [1 2 12 a c d -5]
+// Array length: 7
+// [d c a 2 12 1 -5]
 // Array length: 4
 // [-2 5 7 10]
 // Array length: 4
-// [-5.4 11.5 2.34 6.1]
+// [10 7 5 -2]
+// Array length: 4
+// [-2 5 7 10]
 // Array length: 4
 // [-5.4 2.34 6.1 11.5]
+// Array length: 4
+// [11.5 6.1 2.34 -5.4]
 // Array length: 2
 // [0 1]
 // Array length: 2
 // [ ]
 
-fun test_sorted(arr: [], human: Bool, desc: Bool) {
-    const result = sorted(arr, human, desc)
+fun test_sorted(arr: [], desc: Bool, version_sort: Bool) {
+    const result = sorted(arr, desc, version_sort)
     echo("Array length: {len(result)}")
     echo("[{result}]")
 }
 
 main {
-    test_sorted(["c", "d", "a", "10", "6", "-5"], false, false)
-    test_sorted(["c", "d", "a", "10", "6", "-5"], true, false)
-    test_sorted(["c", "d", "a", "10", "6", "-5"], true, true)
+    test_sorted(["c", "d", "a", "1", "12", "2", "-5"], false, false)
+    test_sorted(["c", "d", "a", "1", "12", "2", "-5"], false, true)
+    test_sorted(["c", "d", "a", "1", "12", "2", "-5"], true, false)
     test_sorted([7, 10, 5, -2], false, false)
-    test_sorted([7, 10, 5, -2], false, true)
     test_sorted([7, 10, 5, -2], true, false)
+    test_sorted([7, 10, 5, -2], false, true)
     test_sorted([11.5, 6.1, -5.4, 2.34], false, false)
     test_sorted([11.5, 6.1, -5.4, 2.34], true, false)
     test_sorted([true, false], false, false)


### PR DESCRIPTION
Hi there. I gave #614 a try and added sort functions for arrays. They work with arrays of all the standard amber data types. For numbers the -h option seemed more sensible to me.

- sort and sorted function added to array.ab
- added tests to for both functions

Closes #614