### PR TITLE
Fix duplicate function generation in Bash

### DIFF
--- a/src/modules/function/invocation_utils.rs
+++ b/src/modules/function/invocation_utils.rs
@@ -213,7 +213,9 @@ pub fn handle_function_parameters(
             .map(|arg| arg.kind.clone())
             .collect();
         // We set persist to false, because we don't want to cache the function instance
-        let _ = run_function_with_args(meta, fun.clone(), &declared_types, tok.clone(), false);
+        let _ = meta.with_first_pass_ctx(true, |meta| {
+            run_function_with_args(meta, fun.clone(), &declared_types, tok.clone(), false)
+        });
         meta.fun_cache.set_first_pass_done(id);
     }
 
@@ -226,7 +228,7 @@ pub fn handle_function_parameters(
         .find(|fun| fun.args == args)
     {
         Some(fun) => Ok((fun.returns.clone(), fun.variant_id)),
-        None => Ok(run_function_with_args(meta, fun, args, tok, true)?),
+        None => Ok(run_function_with_args(meta, fun, args, tok, !meta.first_pass_ctx)?),
     };
 
     result

--- a/src/tests/compiling/recursive_function_call.ab
+++ b/src/tests/compiling/recursive_function_call.ab
@@ -1,0 +1,10 @@
+fun foo(arg: Int | Num) {
+    echo "Value: {arg}"
+}
+
+fun bar(a: Int, b: Num) {
+    foo(a)
+    foo(b)
+}
+
+bar(1, 2)

--- a/src/tests/snapshots/amber__tests__compiling__recursive_function_call.ab.snap
+++ b/src/tests/snapshots/amber__tests__compiling__recursive_function_call.ab.snap
@@ -1,0 +1,17 @@
+---
+source: src/tests/compiling.rs
+expression: ast
+---
+foo__0_v0() {
+    local arg_7="${1}"
+    echo "Value: ${arg_7}"
+}
+
+bar__1_v0() {
+    local a_5="${1}"
+    local b_6="${2}"
+    foo__0_v0 "${a_5}"
+    foo__0_v0 "${b_6}"
+}
+
+bar__1_v0 1 2

--- a/src/utils/metadata/parser.rs
+++ b/src/utils/metadata/parser.rs
@@ -40,6 +40,8 @@ pub struct ParserMetadata {
     #[context]
     pub suppress_warnings: bool,
     /// Skip persisting function instances during first-pass typechecking
+    /// First pass is used for typechecking a function with declared and not concrete types
+    /// This is used to generally assess if a function is valid and emit errors if it is not
     #[context]
     pub first_pass_ctx: bool,
     /// Whether sudo modifier is used anywhere in the code

--- a/src/utils/metadata/parser.rs
+++ b/src/utils/metadata/parser.rs
@@ -39,6 +39,9 @@ pub struct ParserMetadata {
     /// Suppress warnings during monomorphic function re-typechecking
     #[context]
     pub suppress_warnings: bool,
+    /// Skip persisting function instances during first-pass typechecking
+    #[context]
+    pub first_pass_ctx: bool,
     /// Whether sudo modifier is used anywhere in the code
     pub sudo_used: bool,
 }
@@ -267,6 +270,7 @@ impl Metadata for ParserMetadata {
             narrowed_types: Vec::new(),
             suppress_warnings: false,
             sudo_used: false,
+            first_pass_ctx: false,
         }
     }
 


### PR DESCRIPTION
The problem was that the information about running first-pass function call wasn't propagated to the function calls inside of the function.

Closes #963 