### PR TITLE
Remove redundant labels in Github Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,6 @@ name: Bug report
 about: Create a report to help us improve
 title: '[BUG]'
 type: bug
-labels: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,6 @@ name: Feature request
 about: Suggest an idea for this project
 type: feature
 title: '[Feature]'
-labels: enhancement
 assignees: ''
 
 ---


### PR DESCRIPTION
We don't need to use `bug` or `enhancement` for issues as we already use types `bug` and `feature`