### PR TITLE
Failed and exited should provide an Int exit code

### DIFF
--- a/src/modules/condition/failure_handler.rs
+++ b/src/modules/condition/failure_handler.rs
@@ -191,7 +191,7 @@ impl TypeCheckModule for FailureHandler {
         // If we have a parameter (exit code for failed or exited), add it to scope and typecheck the block
         if !self.param_name.is_empty() && (self.failure_type == FailureType::Failed || self.failure_type == FailureType::Exited) {
             meta.with_push_scope(true, |meta| {
-                let var = VariableDecl::new(self.param_name.clone(), Type::Num)
+                let var = VariableDecl::new(self.param_name.clone(), Type::Int)
                     .with_warn(VariableDeclWarn::from_token(meta, self.param_name_tok.clone()));
                 self.param_global_id = meta.add_var(var);
                 self.block.typecheck(meta)

--- a/src/modules/condition/failure_handler.rs
+++ b/src/modules/condition/failure_handler.rs
@@ -179,7 +179,6 @@ impl SyntaxModule<ParserMetadata> for FailureHandler {
             }
         }
 
-
         self.is_main = meta.context.is_main_ctx;
         self.is_parsed = true;
         Ok(())

--- a/src/tests/erroring/exit_code_int.ab
+++ b/src/tests/erroring/exit_code_int.ab
@@ -1,0 +1,4 @@
+// Output
+// Builtin function `exit` can only be used with values of type Int
+
+exit(1.2)

--- a/src/tests/validity/failed_exited_code_is_num.ab
+++ b/src/tests/validity/failed_exited_code_is_num.ab
@@ -1,0 +1,10 @@
+silent $ echo "hello" $ failed(code) {
+    // Won't compile if code is not an Int
+    exit(code)
+}
+
+silent $ echo "hello" $ exited(code) {
+    echo("Succeeded")
+    // Won't compile if code is not an Int
+    exit(code)
+}


### PR DESCRIPTION
Fixes:
```
$ cmd $ failed(code) {
  code is Num // Resolves to `true`. The `code` should be of type `Int` instead
} 
```