### PR TITLE
fix: exclude $0 from main(args) array

### DIFF
--- a/src/modules/main.rs
+++ b/src/modules/main.rs
@@ -96,7 +96,7 @@ impl TranslateModule for Main {
                 || FragmentKind::Empty,
                 |name| {
                     let id = self.args_global_id.unwrap_or(global_id);
-                    raw_fragment!("declare -r {name}_{id}=({quote}{dollar}0{quote} {quote}{dollar}@{quote})")
+                    raw_fragment!("declare -r {name}_{id}=({quote}{dollar}@{quote})")
                 }
             );
             // Temporarily decrease the indentation level to counteract

--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -63,7 +63,7 @@ fn main_args_passed_correctly() {
     
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert_eq!(stdout.trim(), "bash\none\ntwo\nthree");
+    assert_eq!(stdout.trim(), "one\ntwo\nthree");
 }
 
 #[test]

--- a/src/tests/validity/main_shadowing_args.ab
+++ b/src/tests/validity/main_shadowing_args.ab
@@ -1,6 +1,6 @@
 // Output
 // Succeeded
-// 1
+// 0
 
 // Argument names in different functions can be the same
 fun func1(args: Bool): Text {


### PR DESCRIPTION
The main(args) array incorrectly included $0 (script/interpreter name), causing off-by-one indexing where args[0] returned "bash" instead of the first user-provided argument.

Changed generated bash from:
  declare -r args_0=("$0" "$@")
To:
  declare -r args_0=("$@")

Fixes amber-lang/amber#992