### PR TITLE
fix(sed_version): remove non-portable `\b`

### DIFF
--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -56,12 +56,12 @@ const SED_VERSION_BUSYBOX = 2
 fun sed_version(): Int {
     // We can't match against a word "GNU" because
     // alpine's busybox sed returns "This is not GNU sed version"
-    trust $ re='\bCopyright\b.+\bFree Software Foundation\b'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
+    trust $ re='Copyright.+Free Software Foundation'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
     if status == 0 {
         return SED_VERSION_GNU
     }
     // On BSD single `sed` waits for stdin. We must use `sed --help` to avoid this.
-    trust $ re='\bBusyBox\b'; [[ \$(sed --help 2>&1) =~ \$re ]] $
+    trust $ re='BusyBox'; [[ \$(sed --help 2>&1) =~ \$re ]] $
     if status == 0 {
         return SED_VERSION_BUSYBOX
     }


### PR DESCRIPTION
This was previously fixed in replace_regex() via #686, but #717 reintroduced the same portability issue in sed_version().