### PR TITLE
fix(lock): use TMPDIR with /tmp fallback for default lock path

### DIFF
--- a/src/modules/builtin/lock.rs
+++ b/src/modules/builtin/lock.rs
@@ -108,8 +108,8 @@ impl TranslateModule for Lock {
             .path
             .as_ref()
             .map(|expr| expr.translate(meta))
-            // Set a default path to `/tmp/<basename.sh>.lock`
-            .unwrap_or(raw_fragment!("/tmp/${{0##*/}}.lock"));
+            // Set a default path using TMPDIR (falls back to /tmp)
+            .unwrap_or(raw_fragment!("${{TMPDIR:-/tmp}}/${{0##*/}}.lock"));
 
         let lock_var_stmt = VarStmtFragment::new(
             &format!("__lock_file_{}", lock_var_id),

--- a/src/tests/compiling.rs
+++ b/src/tests/compiling.rs
@@ -221,6 +221,21 @@ main {
 }
 
 #[test]
+fn test_lock_default_path_uses_tmpdir_with_tmp_fallback() {
+    let code = r#"
+main {
+    lock() ?
+}
+"#;
+    let result = translate_amber_code(code).expect("Couldn't translate Amber code");
+
+    assert!(
+        result.contains("${TMPDIR:-/tmp}/${0##*/}.lock"),
+        "Output should contain TMPDIR-based lock path with /tmp fallback"
+    );
+}
+
+#[test]
 fn test_translate_shellversion_preamble() {
     let code = r#"
 main {


### PR DESCRIPTION
## Summary

The `lock` builtin hardcodes `/tmp` for default lock file paths. This fails on Termux (Android terminal emulator) where `/tmp` is not accessible due to Android's app sandboxing.

## Changes

- `src/modules/builtin/lock.rs`: Replace hardcoded `/tmp` with `${TMPDIR:-/tmp}` in the generated Bash fragment. This respects the `TMPDIR` environment variable (which Termux sets to a writable directory) and falls back to `/tmp` on standard systems.
- `src/tests/compiling.rs`: Add a regression test verifying the generated lock path contains the TMPDIR-based pattern.

The fix is a single character-level change to the Bash template string. On Termux, `TMPDIR` points to `/data/data/com.termux/files/usr/tmp`. On standard Linux/macOS, `TMPDIR` is either unset (so `/tmp` is used) or set to a system-appropriate directory.

## Testing

- `cargo test` passes (653 tests, 0 failures)
- `cargo clippy` passes with no warnings
- New test `test_lock_default_path_uses_tmpdir_with_tmp_fallback` verifies the generated Bash contains `${TMPDIR:-/tmp}/${0##*/}.lock`

Fixes #1018

This contribution was developed with AI assistance (Codex).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The lock behavior now respects the TMPDIR environment variable for determining the default lock-file location, falling back to /tmp when TMPDIR is unset. This lets lock files be placed in a user-configured temporary directory.

* **Tests**
  * Added a unit test verifying the default lock-file path uses TMPDIR with a /tmp fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->