### PR TITLE
refactor: add impl_documentation_noop! macro for empty DocumentationModule

### DIFF
--- a/src/docs/module.rs
+++ b/src/docs/module.rs
@@ -1,5 +1,19 @@
 use crate::utils::ParserMetadata;
 
+/// Implements DocumentationModule with an empty string for types that have no documentation.
+#[macro_export]
+macro_rules! impl_documentation_noop {
+    ($($t:ty),* $(,)?) => {
+        $(
+            impl $crate::docs::module::DocumentationModule for $t {
+                fn document(&self, _meta: &$crate::utils::ParserMetadata) -> String {
+                    String::new()
+                }
+            }
+        )*
+    };
+}
+
 pub trait DocumentationModule {
     fn document(&self, meta: &ParserMetadata) -> String;
 }

--- a/src/modules/builtin/cd.rs
+++ b/src/modules/builtin/cd.rs
@@ -106,8 +106,4 @@ impl TranslateModule for Cd {
     }
 }
 
-impl DocumentationModule for Cd {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Cd);

--- a/src/modules/builtin/clear.rs
+++ b/src/modules/builtin/clear.rs
@@ -37,8 +37,4 @@ impl TranslateModule for Clear {
     }
 }
 
-impl DocumentationModule for Clear {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Clear);

--- a/src/modules/builtin/cp.rs
+++ b/src/modules/builtin/cp.rs
@@ -163,8 +163,4 @@ impl TranslateModule for Cp {
     }
 }
 
-impl DocumentationModule for Cp {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Cp);

--- a/src/modules/builtin/disown.rs
+++ b/src/modules/builtin/disown.rs
@@ -95,8 +95,4 @@ impl TranslateModule for Disown {
     }
 }
 
-impl DocumentationModule for Disown {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Disown);

--- a/src/modules/builtin/echo.rs
+++ b/src/modules/builtin/echo.rs
@@ -58,8 +58,4 @@ impl TranslateModule for Echo {
     }
 }
 
-impl DocumentationModule for Echo {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Echo);

--- a/src/modules/builtin/exit.rs
+++ b/src/modules/builtin/exit.rs
@@ -72,8 +72,4 @@ impl TranslateModule for Exit {
     }
 }
 
-impl DocumentationModule for Exit {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Exit);

--- a/src/modules/builtin/len.rs
+++ b/src/modules/builtin/len.rs
@@ -76,8 +76,4 @@ impl TranslateModule for Len {
     }
 }
 
-impl DocumentationModule for Len {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Len);

--- a/src/modules/builtin/lines.rs
+++ b/src/modules/builtin/lines.rs
@@ -152,8 +152,4 @@ impl TranslateModule for LinesInvocation {
     }
 }
 
-impl DocumentationModule for LinesInvocation {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(LinesInvocation);

--- a/src/modules/builtin/lock.rs
+++ b/src/modules/builtin/lock.rs
@@ -163,8 +163,4 @@ impl TranslateModule for Lock {
     }
 }
 
-impl DocumentationModule for Lock {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Lock);

--- a/src/modules/builtin/ls.rs
+++ b/src/modules/builtin/ls.rs
@@ -237,8 +237,4 @@ impl TranslateModule for Ls {
     }
 }
 
-impl DocumentationModule for Ls {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Ls);

--- a/src/modules/builtin/mv.rs
+++ b/src/modules/builtin/mv.rs
@@ -124,8 +124,4 @@ impl TranslateModule for Mv {
     }
 }
 
-impl DocumentationModule for Mv {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Mv);

--- a/src/modules/builtin/nameof.rs
+++ b/src/modules/builtin/nameof.rs
@@ -137,8 +137,4 @@ impl TranslateModule for Nameof {
     }
 }
 
-impl DocumentationModule for Nameof {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Nameof);

--- a/src/modules/builtin/pid.rs
+++ b/src/modules/builtin/pid.rs
@@ -47,8 +47,4 @@ impl TranslateModule for Pid {
     }
 }
 
-impl DocumentationModule for Pid {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Pid);

--- a/src/modules/builtin/pwd.rs
+++ b/src/modules/builtin/pwd.rs
@@ -47,8 +47,4 @@ impl TranslateModule for Pwd {
     }
 }
 
-impl DocumentationModule for Pwd {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Pwd);

--- a/src/modules/builtin/rm.rs
+++ b/src/modules/builtin/rm.rs
@@ -178,8 +178,4 @@ impl TranslateModule for Rm {
     }
 }
 
-impl DocumentationModule for Rm {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Rm);

--- a/src/modules/builtin/shellname.rs
+++ b/src/modules/builtin/shellname.rs
@@ -1,4 +1,3 @@
-use crate::docs::module::DocumentationModule;
 use crate::modules::prelude::*;
 use crate::modules::typecheck::TypeCheckModule;
 use crate::modules::types::{Type, Typed};
@@ -45,8 +44,4 @@ impl TranslateModule for Shellname {
     }
 }
 
-impl DocumentationModule for Shellname {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Shellname);

--- a/src/modules/builtin/shellversion.rs
+++ b/src/modules/builtin/shellversion.rs
@@ -1,4 +1,3 @@
-use crate::docs::module::DocumentationModule;
 use crate::modules::prelude::*;
 use crate::modules::typecheck::TypeCheckModule;
 use crate::modules::types::{Type, Typed};
@@ -45,8 +44,4 @@ impl TranslateModule for Shellversion {
     }
 }
 
-impl DocumentationModule for Shellversion {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Shellversion);

--- a/src/modules/builtin/sleep.rs
+++ b/src/modules/builtin/sleep.rs
@@ -146,8 +146,4 @@ impl TranslateModule for Sleep {
     }
 }
 
-impl DocumentationModule for Sleep {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Sleep);

--- a/src/modules/builtin/wait.rs
+++ b/src/modules/builtin/wait.rs
@@ -97,8 +97,4 @@ impl TranslateModule for Await {
     }
 }
 
-impl DocumentationModule for Await {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Await);

--- a/src/modules/command/cmd.rs
+++ b/src/modules/command/cmd.rs
@@ -121,8 +121,4 @@ impl TranslateModule for Command {
     }
 }
 
-impl DocumentationModule for Command {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Command);

--- a/src/modules/command/modifier.rs
+++ b/src/modules/command/modifier.rs
@@ -214,8 +214,4 @@ impl TranslateModule for CommandModifier {
     }
 }
 
-impl DocumentationModule for CommandModifier {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(CommandModifier);

--- a/src/modules/condition/ifchain.rs
+++ b/src/modules/condition/ifchain.rs
@@ -17,11 +17,7 @@ pub struct IfChain {
     pub false_block: Option<(Vec<Comment>, Box<Block>)>,
 }
 
-impl DocumentationModule for IfChain {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(IfChain);
 
 impl IfChain {
     fn warn_dead_code(meta: &mut ParserMetadata, pos: PositionInfo, reason: &str) {

--- a/src/modules/condition/ifcond.rs
+++ b/src/modules/condition/ifcond.rs
@@ -171,8 +171,4 @@ impl TranslateModule for IfCondition {
     }
 }
 
-impl DocumentationModule for IfCondition {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(IfCondition);

--- a/src/modules/expression/access.rs
+++ b/src/modules/expression/access.rs
@@ -153,8 +153,4 @@ impl TranslateModule for Access {
     }
 }
 
-impl DocumentationModule for Access {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Access);

--- a/src/modules/expression/binop/add.rs
+++ b/src/modules/expression/binop/add.rs
@@ -94,8 +94,4 @@ impl TranslateModule for Add {
     }
 }
 
-impl DocumentationModule for Add {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Add);

--- a/src/modules/expression/binop/and.rs
+++ b/src/modules/expression/binop/and.rs
@@ -107,8 +107,4 @@ impl TranslateModule for And {
     }
 }
 
-impl DocumentationModule for And {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(And);

--- a/src/modules/expression/binop/div.rs
+++ b/src/modules/expression/binop/div.rs
@@ -81,8 +81,4 @@ impl TranslateModule for Div {
     }
 }
 
-impl DocumentationModule for Div {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Div);

--- a/src/modules/expression/binop/eq.rs
+++ b/src/modules/expression/binop/eq.rs
@@ -89,8 +89,4 @@ impl TranslateModule for Eq {
     }
 }
 
-impl DocumentationModule for Eq {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Eq);

--- a/src/modules/expression/binop/ge.rs
+++ b/src/modules/expression/binop/ge.rs
@@ -106,8 +106,4 @@ impl TranslateModule for Ge {
     }
 }
 
-impl DocumentationModule for Ge {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Ge);

--- a/src/modules/expression/binop/gt.rs
+++ b/src/modules/expression/binop/gt.rs
@@ -106,8 +106,4 @@ impl TranslateModule for Gt {
     }
 }
 
-impl DocumentationModule for Gt {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Gt);

--- a/src/modules/expression/binop/le.rs
+++ b/src/modules/expression/binop/le.rs
@@ -106,8 +106,4 @@ impl TranslateModule for Le {
     }
 }
 
-impl DocumentationModule for Le {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Le);

--- a/src/modules/expression/binop/lt.rs
+++ b/src/modules/expression/binop/lt.rs
@@ -106,8 +106,4 @@ impl TranslateModule for Lt {
     }
 }
 
-impl DocumentationModule for Lt {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Lt);

--- a/src/modules/expression/binop/modulo.rs
+++ b/src/modules/expression/binop/modulo.rs
@@ -83,8 +83,4 @@ impl TranslateModule for Modulo {
     }
 }
 
-impl DocumentationModule for Modulo {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Modulo);

--- a/src/modules/expression/binop/mul.rs
+++ b/src/modules/expression/binop/mul.rs
@@ -82,8 +82,4 @@ impl TranslateModule for Mul {
     }
 }
 
-impl DocumentationModule for Mul {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Mul);

--- a/src/modules/expression/binop/neq.rs
+++ b/src/modules/expression/binop/neq.rs
@@ -89,8 +89,4 @@ impl TranslateModule for Neq {
     }
 }
 
-impl DocumentationModule for Neq {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Neq);

--- a/src/modules/expression/binop/or.rs
+++ b/src/modules/expression/binop/or.rs
@@ -110,8 +110,4 @@ impl TranslateModule for Or {
     }
 }
 
-impl DocumentationModule for Or {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Or);

--- a/src/modules/expression/binop/range.rs
+++ b/src/modules/expression/binop/range.rs
@@ -304,8 +304,4 @@ impl Range {
     }
 }
 
-impl DocumentationModule for Range {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Range);

--- a/src/modules/expression/binop/sub.rs
+++ b/src/modules/expression/binop/sub.rs
@@ -82,8 +82,4 @@ impl TranslateModule for Sub {
     }
 }
 
-impl DocumentationModule for Sub {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Sub);

--- a/src/modules/expression/literal/array.rs
+++ b/src/modules/expression/literal/array.rs
@@ -162,8 +162,4 @@ impl TranslateModule for Array {
     }
 }
 
-impl DocumentationModule for Array {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Array);

--- a/src/modules/expression/literal/bool.rs
+++ b/src/modules/expression/literal/bool.rs
@@ -46,8 +46,4 @@ impl TranslateModule for Bool {
     }
 }
 
-impl DocumentationModule for Bool {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Bool);

--- a/src/modules/expression/literal/integer.rs
+++ b/src/modules/expression/literal/integer.rs
@@ -1,4 +1,3 @@
-use crate::docs::module::DocumentationModule;
 use crate::modules::prelude::*;
 use crate::modules::types::{Type, Typed};
 use crate::translate::module::TranslateModule;
@@ -46,8 +45,4 @@ impl TranslateModule for Integer {
     }
 }
 
-impl DocumentationModule for Integer {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Integer);

--- a/src/modules/expression/literal/null.rs
+++ b/src/modules/expression/literal/null.rs
@@ -1,10 +1,7 @@
 use crate::fragments;
 use crate::modules::prelude::*;
 use crate::translate::module::TranslateModule;
-use crate::{
-    docs::module::DocumentationModule,
-    modules::types::{Type, Typed},
-};
+use crate::modules::types::{Type, Typed};
 use heraclitus_compiler::prelude::*;
 
 #[derive(Debug, Clone)]
@@ -41,8 +38,4 @@ impl TranslateModule for Null {
     }
 }
 
-impl DocumentationModule for Null {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Null);

--- a/src/modules/expression/literal/number.rs
+++ b/src/modules/expression/literal/number.rs
@@ -1,4 +1,3 @@
-use crate::docs::module::DocumentationModule;
 use crate::modules::prelude::*;
 use crate::modules::types::{Type, Typed};
 use crate::translate::module::TranslateModule;
@@ -57,8 +56,4 @@ impl Number {
     }
 }
 
-impl DocumentationModule for Number {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Number);

--- a/src/modules/expression/literal/status.rs
+++ b/src/modules/expression/literal/status.rs
@@ -1,4 +1,3 @@
-use crate::docs::module::DocumentationModule;
 use crate::modules::prelude::FragmentKind;
 use crate::modules::prelude::*;
 use crate::modules::types::{Type, Typed};
@@ -52,8 +51,4 @@ impl TranslateModule for Status {
     }
 }
 
-impl DocumentationModule for Status {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Status);

--- a/src/modules/expression/literal/text.rs
+++ b/src/modules/expression/literal/text.rs
@@ -1,4 +1,3 @@
-use crate::docs::module::DocumentationModule;
 use crate::modules::expression::expr::Expr;
 use crate::modules::expression::interpolated_region::{
     parse_interpolated_region, InterpolatedRegionType,
@@ -85,8 +84,4 @@ impl TranslateModule for Text {
     }
 }
 
-impl DocumentationModule for Text {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Text);

--- a/src/modules/expression/parentheses.rs
+++ b/src/modules/expression/parentheses.rs
@@ -1,5 +1,4 @@
 use super::expr::Expr;
-use crate::docs::module::DocumentationModule;
 use crate::modules::prelude::FragmentKind;
 use crate::modules::typecheck::TypeCheckModule;
 use crate::modules::types::{Type, Typed};
@@ -63,8 +62,4 @@ impl TranslateModule for Parentheses {
     }
 }
 
-impl DocumentationModule for Parentheses {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Parentheses);

--- a/src/modules/expression/ternop/ternary.rs
+++ b/src/modules/expression/ternop/ternary.rs
@@ -1,5 +1,4 @@
 use super::TernOp;
-use crate::docs::module::DocumentationModule;
 use crate::fragments;
 use crate::modules::expression::binop::get_binop_position_info;
 use crate::modules::expression::expr::Expr;
@@ -191,8 +190,4 @@ impl TranslateModule for Ternary {
     }
 }
 
-impl DocumentationModule for Ternary {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Ternary);

--- a/src/modules/expression/typeop/cast.rs
+++ b/src/modules/expression/typeop/cast.rs
@@ -89,8 +89,4 @@ impl TranslateModule for Cast {
     }
 }
 
-impl DocumentationModule for Cast {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Cast);

--- a/src/modules/expression/typeop/is.rs
+++ b/src/modules/expression/typeop/is.rs
@@ -102,8 +102,4 @@ impl TranslateModule for Is {
     }
 }
 
-impl DocumentationModule for Is {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Is);

--- a/src/modules/expression/unop/neg.rs
+++ b/src/modules/expression/unop/neg.rs
@@ -1,4 +1,3 @@
-use crate::docs::module::DocumentationModule;
 use crate::modules::expression::expr::Expr;
 use crate::modules::expression::unop::UnOp;
 use crate::modules::prelude::{ArithmeticFragment, FragmentKind, FragmentRenderable, RawFragment};
@@ -94,8 +93,4 @@ impl Neg {
     }
 }
 
-impl DocumentationModule for Neg {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Neg);

--- a/src/modules/expression/unop/not.rs
+++ b/src/modules/expression/unop/not.rs
@@ -1,6 +1,5 @@
 use super::super::expr::Expr;
 use super::UnOp;
-use crate::docs::module::DocumentationModule;
 use crate::modules::prelude::*;
 use crate::modules::types::{Type, Typed};
 use crate::utils::{metadata::ParserMetadata, TranslateMetadata};
@@ -72,8 +71,4 @@ impl TranslateModule for Not {
     }
 }
 
-impl DocumentationModule for Not {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Not);

--- a/src/modules/function/fail.rs
+++ b/src/modules/function/fail.rs
@@ -1,4 +1,3 @@
-use crate::docs::module::DocumentationModule;
 use crate::modules::expression::expr::Expr;
 use crate::modules::prelude::FragmentKind;
 use crate::modules::prelude::*;
@@ -119,8 +118,4 @@ impl TranslateModule for Fail {
     }
 }
 
-impl DocumentationModule for Fail {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Fail);

--- a/src/modules/function/invocation.rs
+++ b/src/modules/function/invocation.rs
@@ -314,8 +314,4 @@ impl TranslateModule for FunctionInvocation {
     }
 }
 
-impl DocumentationModule for FunctionInvocation {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(FunctionInvocation);

--- a/src/modules/function/ret.rs
+++ b/src/modules/function/ret.rs
@@ -78,8 +78,4 @@ impl TranslateModule for Return {
     }
 }
 
-impl DocumentationModule for Return {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Return);

--- a/src/modules/imports/import.rs
+++ b/src/modules/imports/import.rs
@@ -303,8 +303,4 @@ impl TranslateModule for Import {
     }
 }
 
-impl DocumentationModule for Import {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Import);

--- a/src/modules/loops/break_stmt.rs
+++ b/src/modules/loops/break_stmt.rs
@@ -1,4 +1,3 @@
-use crate::docs::module::DocumentationModule;
 use crate::fragments;
 use crate::modules::prelude::*;
 use crate::translate::module::TranslateModule;
@@ -46,8 +45,4 @@ impl TranslateModule for Break {
     }
 }
 
-impl DocumentationModule for Break {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Break);

--- a/src/modules/loops/continue_stmt.rs
+++ b/src/modules/loops/continue_stmt.rs
@@ -43,8 +43,4 @@ impl TranslateModule for Continue {
     }
 }
 
-impl DocumentationModule for Continue {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Continue);

--- a/src/modules/loops/infinite_loop.rs
+++ b/src/modules/loops/infinite_loop.rs
@@ -52,8 +52,4 @@ impl TranslateModule for InfiniteLoop {
     }
 }
 
-impl DocumentationModule for InfiniteLoop {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(InfiniteLoop);

--- a/src/modules/loops/iter_loop.rs
+++ b/src/modules/loops/iter_loop.rs
@@ -1,6 +1,5 @@
 use heraclitus_compiler::prelude::*;
 
-use crate::docs::module::DocumentationModule;
 use crate::modules::block::Block;
 use crate::modules::builtin::lines::LinesInvocation;
 use crate::modules::expression::expr::{Expr, ExprType};
@@ -231,8 +230,4 @@ impl IterLoop {
     }
 }
 
-impl DocumentationModule for IterLoop {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(IterLoop);

--- a/src/modules/loops/while_loop.rs
+++ b/src/modules/loops/while_loop.rs
@@ -69,8 +69,4 @@ impl TranslateModule for WhileLoop {
     }
 }
 
-impl DocumentationModule for WhileLoop {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(WhileLoop);

--- a/src/modules/main.rs
+++ b/src/modules/main.rs
@@ -115,8 +115,4 @@ impl TranslateModule for Main {
     }
 }
 
-impl DocumentationModule for Main {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Main);

--- a/src/modules/shorthand/add.rs
+++ b/src/modules/shorthand/add.rs
@@ -125,8 +125,4 @@ impl TranslateModule for ShorthandAdd {
     }
 }
 
-impl DocumentationModule for ShorthandAdd {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(ShorthandAdd);

--- a/src/modules/shorthand/div.rs
+++ b/src/modules/shorthand/div.rs
@@ -98,8 +98,4 @@ impl TranslateModule for ShorthandDiv {
     }
 }
 
-impl DocumentationModule for ShorthandDiv {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(ShorthandDiv);

--- a/src/modules/shorthand/modulo.rs
+++ b/src/modules/shorthand/modulo.rs
@@ -98,8 +98,4 @@ impl TranslateModule for ShorthandModulo {
     }
 }
 
-impl DocumentationModule for ShorthandModulo {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(ShorthandModulo);

--- a/src/modules/shorthand/mul.rs
+++ b/src/modules/shorthand/mul.rs
@@ -98,8 +98,4 @@ impl TranslateModule for ShorthandMul {
     }
 }
 
-impl DocumentationModule for ShorthandMul {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(ShorthandMul);

--- a/src/modules/shorthand/sub.rs
+++ b/src/modules/shorthand/sub.rs
@@ -98,8 +98,4 @@ impl TranslateModule for ShorthandSub {
     }
 }
 
-impl DocumentationModule for ShorthandSub {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(ShorthandSub);

--- a/src/modules/test.rs
+++ b/src/modules/test.rs
@@ -114,8 +114,4 @@ impl TranslateModule for Test {
     }
 }
 
-impl DocumentationModule for Test {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(Test);

--- a/src/modules/variable/get.rs
+++ b/src/modules/variable/get.rs
@@ -64,8 +64,4 @@ impl TranslateModule for VariableGet {
     }
 }
 
-impl DocumentationModule for VariableGet {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(VariableGet);

--- a/src/modules/variable/init.rs
+++ b/src/modules/variable/init.rs
@@ -115,8 +115,4 @@ impl TranslateModule for VariableInit {
     }
 }
 
-impl DocumentationModule for VariableInit {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(VariableInit);

--- a/src/modules/variable/init_destruct.rs
+++ b/src/modules/variable/init_destruct.rs
@@ -186,8 +186,4 @@ impl TranslateModule for VariableInitDestruct {
     }
 }
 
-impl DocumentationModule for VariableInitDestruct {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(VariableInitDestruct);

--- a/src/modules/variable/set.rs
+++ b/src/modules/variable/set.rs
@@ -2,7 +2,6 @@ use super::{
     handle_index_accessor, handle_variable_reference, prevent_constant_mutation,
     validate_index_accessor, variable_name_extensions,
 };
-use crate::docs::module::DocumentationModule;
 use crate::modules::prelude::*;
 use crate::modules::types::{Type, Typed};
 use crate::utils::{ParserMetadata, TranslateMetadata};
@@ -144,8 +143,4 @@ impl TranslateModule for VariableSet {
     }
 }
 
-impl DocumentationModule for VariableSet {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(VariableSet);

--- a/src/modules/variable/set_destruct.rs
+++ b/src/modules/variable/set_destruct.rs
@@ -1,5 +1,4 @@
 use super::{handle_variable_reference, prevent_constant_mutation, variable_name_extensions};
-use crate::docs::module::DocumentationModule;
 use crate::modules::prelude::*;
 use crate::modules::types::{Type, Typed};
 use crate::raw_fragment;
@@ -163,8 +162,4 @@ impl TranslateModule for VariableSetDestruct {
     }
 }
 
-impl DocumentationModule for VariableSetDestruct {
-    fn document(&self, _meta: &ParserMetadata) -> String {
-        "".to_string()
-    }
-}
+crate::impl_documentation_noop!(VariableSetDestruct);


### PR DESCRIPTION
## Summary

I added `impl_documentation_noop!` macro to replace boilerplate empty `DocumentationModule` implementations across 72 modules.Net reduction of  about 290 lines!

## Changes

- `src/docs/module.rs`: New `impl_documentation_noop!` macro using `$crate::` paths for proper macro hygiene
- 72 module files: Replace manual `impl DocumentationModule for X { fn document(...) { "".to_string() } }` blocks with `crate::impl_documentation_noop!(X);`
- Removed unused `use crate::docs::module::DocumentationModule;` imports from files that no longer reference the trait directly

Modules with real documentation content (`declaration.rs`, `stmt.rs`, `block.rs`, `comment.rs`, `comment_doc.rs`) are untouched.

## Testing

- `cargo test`: 652 passed, 0 failed
- `cargo clippy`: no warnings
- `cargo fmt --check`: clean

Fixes #973

This contribution was developed with AI assistance (Codex).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated many trivial module documentation implementations into a centralized generation mechanism, removing repetitive boilerplate while preserving all user-visible documentation behavior and outputs. This simplifies maintenance and reduces duplication without changing what users see.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/amber-lang/amber/pull/1082)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->