### PR TITLE
feat(stdlib): Add CLI parsing helpers

### DIFF
--- a/src/std/cli.ab
+++ b/src/std/cli.ab
@@ -1,0 +1,263 @@
+import { array_contains, array_extract_at, array_remove_at } from "std/array"
+import { char_at, slice, starts_with } from "std/text"
+
+/// Minimal CLI parsing helpers for Amber scripts.
+///
+/// ### Usage
+/// ```ab
+/// import { cli_args, take_command, take_flag, take_option, take_all_positionals, cli_assert_empty } from "std/cli"
+///
+/// main(raw_args) {
+///     let args = cli_args(raw_args)
+///     const command = take_command(args, ["build", "serve"]) failed { "build" }
+///     const verbose = take_flag(args, "--verbose", "-v")
+///     const output = take_option(args, "--output", "-o") failed { "stdout" }
+///     const paths = take_all_positionals(args)
+///     cli_assert_empty(args)?
+///
+///     echo("command={command}")
+///     echo("verbose={verbose}")
+///     echo("output={output}")
+///     echo("paths={paths}")
+/// }
+/// ```
+
+fun is_long_option(arg: Text): Bool {
+    return starts_with(arg, "--") and not is_option_terminator(arg)
+}
+
+fun is_short_option(arg: Text): Bool {
+    return starts_with(arg, "-") and not starts_with(arg, "--") and len(arg) > 1
+}
+
+fun is_option_terminator(arg: Text): Bool {
+    return arg == "--"
+}
+
+fun split_long_option(arg: Text): [Text] {
+    let index = 0
+    while index < len(arg) {
+        if char_at(arg, index) == "=" {
+            return [slice(arg, 0, index), slice(arg, index + 1)]
+        }
+        index += 1
+    }
+    return [arg, ""]
+}
+
+fun find_option_index(args: [Text], long: Text, short: Text = "", allow_inline_long: Bool = false): Int {
+    const long_eq = long + "="
+    for index, arg in args {
+        if is_option_terminator(arg) {
+            return -1
+        }
+        if arg == long or (short != "" and arg == short) {
+            return index
+        }
+        if allow_inline_long and starts_with(arg, long_eq) {
+            return index
+        }
+    }
+    return -1
+}
+
+fun find_terminator_index(args: [Text]): Int {
+    for index, arg in args {
+        if is_option_terminator(arg) {
+            return index
+        }
+    }
+    return -1
+}
+
+/// Drops the executable or script entry from `raw_args` so callers work with user args only.
+///
+/// ### Usage
+/// ```ab
+/// main(raw_args) {
+///     const args = cli_args(raw_args)
+///     echo(args)
+/// }
+/// ```
+pub fun cli_args(raw_args: [Text]): [Text] {
+    if len(raw_args) <= 1 {
+        const args = [Text]
+        return args
+    }
+    return raw_args[1..len(raw_args)]
+}
+
+/// Removes a matching flag from `args` and returns whether it was present.
+///
+/// Parsing stops at `--`.
+///
+/// ### Usage
+/// ```ab
+/// let args = ["build", "--verbose"]
+/// const verbose = take_flag(args, "--verbose", "-v")
+/// echo(verbose) // true
+/// echo(args) // [build]
+/// ```
+pub fun take_flag(ref args: [Text], long: Text, short: Text = ""): Bool {
+    const index = find_option_index(args, long, short)
+    if index < 0 {
+        return false
+    }
+    array_remove_at(args, index)
+    return true
+}
+
+/// Removes a matching option and its value from `args` and returns the parsed value.
+///
+/// Supports `--name value`, `--name=value`, and `-n value`.
+/// The function fails when the option is absent or when it is present without a value.
+/// Parsing stops at `--`, and `--name=` is treated as malformed usage.
+/// When the same option appears multiple times, the first matching occurrence is consumed.
+///
+/// ### Usage
+/// ```ab
+/// let args = ["--output=dist/app.sh"]
+/// const output = take_option(args, "--output", "-o")?
+/// echo(output) // dist/app.sh
+/// echo(args) // []
+/// ```
+pub fun take_option(ref args: [Text], long: Text, short: Text = ""): Text? {
+    const long_eq = long + "="
+    const index = find_option_index(args, long, short, true)
+    if index < 0 {
+        fail 1
+    }
+
+    const arg = args[index]
+    if starts_with(arg, long_eq) {
+        const parts = split_long_option(arg)
+        if parts[1] == "" {
+            fail 1
+        }
+        array_remove_at(args, index)
+        return parts[1]
+    }
+
+    const value_index = index + 1
+    if value_index >= len(args) {
+        fail 1
+    }
+    if is_option_terminator(args[value_index]) {
+        fail 1
+    }
+    const value = args[value_index]
+    array_remove_at(args, value_index)
+    array_remove_at(args, index)
+    return value
+}
+
+/// Consumes the first remaining token only if it is a non-option command from `commands`.
+///
+/// The function fails when the next token is missing, is an option, or does not match one of the
+/// allowed commands.
+///
+/// ### Usage
+/// ```ab
+/// let args = ["serve", "--verbose"]
+/// const command = take_command(args, ["build", "serve"])?
+/// echo(command) // serve
+/// echo(args) // [--verbose]
+/// ```
+pub fun take_command(ref args: [Text], commands: [Text]): Text? {
+    if len(args) == 0 {
+        fail 1
+    }
+
+    const command = args[0]
+    if is_option_terminator(command) or is_long_option(command) or is_short_option(command) {
+        fail 1
+    }
+    if not array_contains(commands, command) {
+        fail 1
+    }
+
+    array_remove_at(args, 0)
+    return command
+}
+
+/// Consumes the next positional token from `args`.
+///
+/// If `--` is present, the first token after it is always treated as positional.
+/// Otherwise, the first non-option token is consumed, even when later options remain.
+/// The function fails when no positional token remains.
+///
+/// ### Usage
+/// ```ab
+/// let args = ["--verbose", "--", "--raw"]
+/// const value = take_positional(args)?
+/// echo(value) // --raw
+/// echo(args) // [--verbose]
+/// ```
+pub fun take_positional(ref args: [Text]): Text? {
+    const terminator_index = find_terminator_index(args)
+    if terminator_index >= 0 {
+        if terminator_index + 1 >= len(args) {
+            fail 1
+        }
+        array_remove_at(args, terminator_index)
+        return array_extract_at(args, terminator_index)?
+    }
+
+    let index = 0
+    while index < len(args) {
+        const arg = args[index]
+        if not is_long_option(arg) and not is_short_option(arg) {
+            return array_extract_at(args, index)?
+        }
+        index += 1
+    }
+
+    fail 1
+}
+
+/// Consumes and returns all remaining positional tokens from `args`.
+///
+/// If `--` is present, all tokens after it are treated as positional and tokens before it are left unchanged.
+/// Otherwise, every remaining non-option token is consumed in order.
+///
+/// ### Usage
+/// ```ab
+/// let args = ["file1", "--verbose", "file2"]
+/// const files = take_all_positionals(args)
+/// echo(files) // [file1 file2]
+/// echo(args) // [--verbose]
+/// ```
+pub fun take_all_positionals(ref args: [Text]): [Text] {
+    const terminator_index = find_terminator_index(args)
+    if terminator_index >= 0 {
+        const positionals = args[terminator_index + 1..len(args)]
+        args = args[0..terminator_index]
+        return positionals
+    }
+
+    let positionals = [Text]
+    while true {
+        const positional = take_positional(args) failed {
+            return positionals
+        }
+        positionals += [positional]
+    }
+    return positionals
+}
+
+/// Fails when unconsumed arguments remain in `args`.
+///
+/// ### Usage
+/// ```ab
+/// let args = []
+/// cli_assert_empty(args)?
+/// ```
+pub fun cli_assert_empty(args: [Text]): Null? {
+    if len(args) == 0 {
+        return null
+    }
+    if len(args) == 1 and is_option_terminator(args[0]) {
+        return null
+    }
+    fail 1
+}

--- a/src/std/cli.ab
+++ b/src/std/cli.ab
@@ -81,8 +81,7 @@ fun find_terminator_index(args: [Text]): Int {
 /// ```
 pub fun cli_args(raw_args: [Text]): [Text] {
     if len(raw_args) <= 1 {
-        const args = [Text]
-        return args
+        return [Text]
     }
     return raw_args[1..len(raw_args)]
 }
@@ -113,6 +112,7 @@ pub fun take_flag(ref args: [Text], long: Text, short: Text = ""): Bool {
 /// The function fails when the option is absent or when it is present without a value.
 /// Parsing stops at `--`, and `--name=` is treated as malformed usage.
 /// When the same option appears multiple times, the first matching occurrence is consumed.
+/// On any failure path, `args` is left unmodified so callers can safely fall back.
 ///
 /// ### Usage
 /// ```ab
@@ -122,14 +122,13 @@ pub fun take_flag(ref args: [Text], long: Text, short: Text = ""): Bool {
 /// echo(args) // []
 /// ```
 pub fun take_option(ref args: [Text], long: Text, short: Text = ""): Text? {
-    const long_eq = long + "="
     const index = find_option_index(args, long, short, true)
     if index < 0 {
         fail 1
     }
 
     const arg = args[index]
-    if starts_with(arg, long_eq) {
+    if is_long_option(arg) and arg != long {
         const parts = split_long_option(arg)
         if parts[1] == "" {
             fail 1
@@ -242,7 +241,6 @@ pub fun take_all_positionals(ref args: [Text]): [Text] {
         }
         positionals += [positional]
     }
-    return positionals
 }
 
 /// Fails when unconsumed arguments remain in `args`.

--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -7,6 +7,42 @@ use crate::testing::get_tests_to_run;
 use crate::TestCommand;
 use std::path::PathBuf;
 
+fn compile_without_messages(amber_code: &str) -> String {
+    let options = CompilerOptions::default();
+    let compiler = AmberCompiler::new(amber_code.to_string(), None, options);
+    let (messages, bash_code) = compiler.compile().unwrap();
+    assert_eq!(messages.len(), 0);
+    bash_code
+}
+
+fn eval_bash_with_args(bash_code: String, args: &[&str]) -> String {
+    let quoted_args = args
+        .iter()
+        .map(|arg| format!("\"{}\"", arg.replace('"', "\\\"")))
+        .collect::<Vec<String>>();
+    let bash_code = if quoted_args.is_empty() {
+        bash_code
+    } else {
+        format!("set -- {}\n{}", quoted_args.join(" "), bash_code)
+    };
+
+    let output = AmberCompiler::find_shell(None)
+        .expect("Failed to find shell")
+        .arg("-c")
+        .arg(bash_code)
+        .output()
+        .expect("Failed to execute shell");
+
+    assert!(output.status.success());
+    String::from_utf8(output.stdout).unwrap()
+}
+
+fn write_temp_amber_script(amber_code: &str) -> NamedTempFile {
+    let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+    std::fs::write(temp_file.path(), amber_code).expect("Failed to write test file");
+    temp_file
+}
+
 // Test that the bash error code is forwarded to the exit code of amber.
 #[test]
 fn bash_error_exit_code() {
@@ -42,33 +78,72 @@ fn main_args_passed_correctly() {
         }
         "#;
 
-    // Amber compiler setup and parse
-    let options = CompilerOptions::default();
-    let compiler = AmberCompiler::new(amber_code.to_string(), None, options);
-    let (messages, bash_code) = compiler.compile().unwrap();
-
-    // Assert no warnings
-    assert_eq!(messages.len(), 0);
-
-    // Prepend arguments to the bash code to simulate passing arguments
-    // We use `set --` to set positional parameters
-    let bash_code_with_args = format!("set -- one two three\n{}", bash_code);
-
-    // Execute the bash code and check the output
-    let output = AmberCompiler::find_shell(None)
-        .expect("Failed to find shell")
-        .arg("-c")
-        .arg(bash_code_with_args)
-        .output()
-        .expect("Failed to execute shell");
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let bash_code = compile_without_messages(amber_code);
+    let stdout = eval_bash_with_args(bash_code, &["one", "two", "three"]);
     let lines: Vec<&str> = stdout.trim().lines().collect();
     assert_eq!(lines.len(), 4);
     assert_eq!(lines[1], "one");
     assert_eq!(lines[2], "two");
     assert_eq!(lines[3], "three");
+}
+
+#[test]
+fn cli_args_drop_script_name() {
+    let amber_code = r#"
+        import { cli_args } from "std/cli"
+
+        main(raw_args) {
+            const args = cli_args(raw_args)
+            for arg in args {
+                echo(arg)
+            }
+        }
+        "#;
+
+    let bash_code = compile_without_messages(amber_code);
+    let stdout = eval_bash_with_args(bash_code, &["one", "two", "three"]);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines, vec!["one", "two", "three"]);
+}
+
+#[test]
+fn cli_args_no_user_arguments() {
+    let amber_code = r#"
+        import { cli_args } from "std/cli"
+
+        main(raw_args) {
+            const args = cli_args(raw_args)
+            echo(len(args))
+        }
+        "#;
+
+    let bash_code = compile_without_messages(amber_code);
+    let stdout = eval_bash_with_args(bash_code, &[]);
+    assert_eq!(stdout.trim(), "0");
+}
+
+#[test]
+fn test_cli_raw_args_forwarded_to_script() {
+    let mut cmd = Command::new(amber_bin());
+
+    let amber_code = r#"
+        import { cli_args } from "std/cli"
+
+        main(raw_args) {
+            const args = cli_args(raw_args)
+            echo("args=({len(args)}) [{args}]")
+        }
+        "#;
+
+    let temp_file = write_temp_amber_script(amber_code);
+
+    cmd.arg(temp_file.path())
+        .args(["one", "two", "three"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("args=(3) [one two three]"));
+
+    let _ = temp_file.close();
 }
 
 #[test]
@@ -329,14 +404,13 @@ fn test_cli_typo_suggestion() {
 fn test_cli_file_starting_with_dash() {
     let mut cmd = Command::new(amber_bin());
 
-    let temp_file = NamedTempFile::new().expect("Failed to create temp file");
     let amber_code = r#"
         main {
             echo("Hello from dash file")
         }
         "#;
 
-    std::fs::write(temp_file.path(), amber_code).expect("Failed to write test file");
+    let temp_file = write_temp_amber_script(amber_code);
 
     let output = cmd.arg(temp_file.path()).assert().success();
     let _ = temp_file.close();

--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -18,7 +18,7 @@ fn compile_without_messages(amber_code: &str) -> String {
 fn eval_bash_with_args(bash_code: String, args: &[&str]) -> String {
     let quoted_args = args
         .iter()
-        .map(|arg| format!("\"{}\"", arg.replace('"', "\\\"")))
+        .map(|arg| format!("'{}'", arg.replace('\'', "'\\''")))
         .collect::<Vec<String>>();
     let bash_code = if quoted_args.is_empty() {
         bash_code
@@ -120,6 +120,26 @@ fn cli_args_no_user_arguments() {
     let bash_code = compile_without_messages(amber_code);
     let stdout = eval_bash_with_args(bash_code, &[]);
     assert_eq!(stdout.trim(), "0");
+}
+
+#[test]
+fn eval_bash_with_args_passes_literal_values() {
+    let amber_code = r#"
+        main(args) {
+            for arg in args {
+                echo(arg)
+            }
+        }
+        "#;
+
+    let bash_code = compile_without_messages(amber_code);
+    let stdout = eval_bash_with_args(bash_code, &[r#"$HOME"#, r#"a\b"#, r#"`pwd`"#, r#"can't"#]);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines.len(), 5);
+    assert_eq!(lines[1], "$HOME");
+    assert_eq!(lines[2], r#"a\b"#);
+    assert_eq!(lines[3], "`pwd`");
+    assert_eq!(lines[4], "can't");
 }
 
 #[test]

--- a/src/tests/stdlib/cli_args.ab
+++ b/src/tests/stdlib/cli_args.ab
@@ -1,0 +1,9 @@
+import { cli_args } from "std/cli"
+
+// Output
+// args=(0) []
+
+main(raw_args) {
+    const args = cli_args(raw_args)
+    echo("args=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_assert_empty.ab
+++ b/src/tests/stdlib/cli_assert_empty.ab
@@ -1,0 +1,27 @@
+import { cli_assert_empty, take_flag } from "std/cli"
+
+// Output
+// empty ok
+// terminator ok
+// consumed options ok
+// leftover args
+
+main {
+    let args = [Text]
+    cli_assert_empty(args)?
+    echo("empty ok")
+
+    args = ["--"]
+    cli_assert_empty(args)?
+    echo("terminator ok")
+
+    args = ["--verbose", "--"]
+    take_flag(args, "--verbose")
+    cli_assert_empty(args)?
+    echo("consumed options ok")
+
+    args = ["build"]
+    cli_assert_empty(args) failed {
+        echo("leftover args")
+    }
+}

--- a/src/tests/stdlib/cli_assert_empty.ab
+++ b/src/tests/stdlib/cli_assert_empty.ab
@@ -5,6 +5,7 @@ import { cli_assert_empty, take_flag } from "std/cli"
 // terminator ok
 // consumed options ok
 // leftover args
+// rest=(1) [build]
 
 main {
     let args = [Text]
@@ -24,4 +25,5 @@ main {
     cli_assert_empty(args) failed {
         echo("leftover args")
     }
+    echo("rest=({len(args)}) [{args}]")
 }

--- a/src/tests/stdlib/cli_flag_absent.ab
+++ b/src/tests/stdlib/cli_flag_absent.ab
@@ -1,0 +1,12 @@
+import { take_flag } from "std/cli"
+
+// Output
+// verbose=0
+// rest=(1) [build]
+
+main {
+    let args = ["build"]
+    const verbose = take_flag(args, "--verbose", "-v")
+    echo("verbose={verbose}")
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_option_terminator.ab
+++ b/src/tests/stdlib/cli_option_terminator.ab
@@ -1,0 +1,18 @@
+import { take_flag, take_positional } from "std/cli"
+
+// Output
+// verbose=1
+// first=--verbose
+// second=tail
+// rest=(0) []
+
+main {
+    let args = ["--verbose", "--", "--verbose", "tail"]
+    const verbose = take_flag(args, "--verbose")
+    const first = take_positional(args)?
+    const second = take_positional(args)?
+    echo("verbose={verbose}")
+    echo("first={first}")
+    echo("second={second}")
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_all_positionals.ab
+++ b/src/tests/stdlib/cli_take_all_positionals.ab
@@ -1,0 +1,12 @@
+import { take_all_positionals } from "std/cli"
+
+// Output
+// files=(2) [file1 file2]
+// rest=(1) [--verbose]
+
+main {
+    let args = ["file1", "--verbose", "file2"]
+    const files = take_all_positionals(args)
+    echo("files=({len(files)}) [{files}]")
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_all_positionals_after_terminator.ab
+++ b/src/tests/stdlib/cli_take_all_positionals_after_terminator.ab
@@ -1,0 +1,12 @@
+import { take_all_positionals } from "std/cli"
+
+// Output
+// files=(2) [--verbose tail]
+// rest=(1) [build]
+
+main {
+    let args = ["build", "--", "--verbose", "tail"]
+    const files = take_all_positionals(args)
+    echo("files=({len(files)}) [{files}]")
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_command.ab
+++ b/src/tests/stdlib/cli_take_command.ab
@@ -1,0 +1,12 @@
+import { take_command } from "std/cli"
+
+// Output
+// command=build
+// rest=(2) [--verbose target.txt]
+
+main {
+    let args = ["build", "--verbose", "target.txt"]
+    const command = take_command(args, ["build", "serve"])?
+    echo("command={command}")
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_command_mismatch.ab
+++ b/src/tests/stdlib/cli_take_command_mismatch.ab
@@ -1,0 +1,11 @@
+import { take_command } from "std/cli"
+
+// Output
+// command mismatch
+
+main {
+    let args = ["deploy"]
+    take_command(args, ["build", "serve"]) failed {
+        echo("command mismatch")
+    }
+}

--- a/src/tests/stdlib/cli_take_command_mismatch.ab
+++ b/src/tests/stdlib/cli_take_command_mismatch.ab
@@ -2,10 +2,12 @@ import { take_command } from "std/cli"
 
 // Output
 // command mismatch
+// deploy
 
 main {
     let args = ["deploy"]
     take_command(args, ["build", "serve"]) failed {
         echo("command mismatch")
     }
+    echo(args)
 }

--- a/src/tests/stdlib/cli_take_command_option_first.ab
+++ b/src/tests/stdlib/cli_take_command_option_first.ab
@@ -1,0 +1,13 @@
+import { take_command } from "std/cli"
+
+// Output
+// command missing
+// rest=(2) [--verbose build]
+
+main {
+    let args = ["--verbose", "build"]
+    take_command(args, ["build", "serve"]) failed {
+        echo("command missing")
+    }
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_flag_long.ab
+++ b/src/tests/stdlib/cli_take_flag_long.ab
@@ -1,0 +1,12 @@
+import { take_flag } from "std/cli"
+
+// Output
+// verbose=1
+// rest=(2) [build target.txt]
+
+main {
+    let args = ["build", "--verbose", "target.txt"]
+    const verbose = take_flag(args, "--verbose")
+    echo("verbose={verbose}")
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_flag_short.ab
+++ b/src/tests/stdlib/cli_take_flag_short.ab
@@ -1,0 +1,12 @@
+import { take_flag } from "std/cli"
+
+// Output
+// verbose=1
+// rest=(2) [serve file.txt]
+
+main {
+    let args = ["serve", "-v", "file.txt"]
+    const verbose = take_flag(args, "--verbose", "-v")
+    echo("verbose={verbose}")
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_flag_stops_at_terminator.ab
+++ b/src/tests/stdlib/cli_take_flag_stops_at_terminator.ab
@@ -1,0 +1,12 @@
+import { take_flag } from "std/cli"
+
+// Output
+// verbose=0
+// rest=(3) [build -- --verbose]
+
+main {
+    let args = ["build", "--", "--verbose"]
+    const verbose = take_flag(args, "--verbose", "-v")
+    echo("verbose={verbose}")
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_option_failures.ab
+++ b/src/tests/stdlib/cli_take_option_failures.ab
@@ -1,0 +1,23 @@
+import { take_option } from "std/cli"
+
+// Output
+// option absent
+// option missing value
+// option inline missing value
+
+main {
+    let args = ["build"]
+    take_option(args, "--output") failed {
+        echo("option absent")
+    }
+
+    args = ["build", "--output"]
+    take_option(args, "--output") failed {
+        echo("option missing value")
+    }
+
+    args = ["build", "--output="]
+    take_option(args, "--output") failed {
+        echo("option inline missing value")
+    }
+}

--- a/src/tests/stdlib/cli_take_option_failures.ab
+++ b/src/tests/stdlib/cli_take_option_failures.ab
@@ -4,6 +4,8 @@ import { take_option } from "std/cli"
 // option absent
 // option missing value
 // option inline missing value
+// short option missing value
+// option value is terminator
 
 main {
     let args = ["build"]
@@ -19,5 +21,15 @@ main {
     args = ["build", "--output="]
     take_option(args, "--output") failed {
         echo("option inline missing value")
+    }
+
+    args = ["build", "-o"]
+    take_option(args, "--output", "-o") failed {
+        echo("short option missing value")
+    }
+
+    args = ["build", "--output", "--"]
+    take_option(args, "--output") failed {
+        echo("option value is terminator")
     }
 }

--- a/src/tests/stdlib/cli_take_option_long_inline.ab
+++ b/src/tests/stdlib/cli_take_option_long_inline.ab
@@ -1,0 +1,12 @@
+import { take_option } from "std/cli"
+
+// Output
+// output=dist/app.sh
+// rest=(1) [build]
+
+main {
+    let args = ["build", "--output=dist/app.sh"]
+    const output = take_option(args, "--output")?
+    echo("output={output}")
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_option_long_separate.ab
+++ b/src/tests/stdlib/cli_take_option_long_separate.ab
@@ -1,0 +1,12 @@
+import { take_option } from "std/cli"
+
+// Output
+// output=dist/app.sh
+// rest=(1) [build]
+
+main {
+    let args = ["build", "--output", "dist/app.sh"]
+    const output = take_option(args, "--output")?
+    echo("output={output}")
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_option_repeated.ab
+++ b/src/tests/stdlib/cli_take_option_repeated.ab
@@ -1,0 +1,12 @@
+import { take_option } from "std/cli"
+
+// Output
+// first=one
+// rest=(4) [build --output two tail]
+
+main {
+    let args = ["build", "--output", "one", "--output", "two", "tail"]
+    const first = take_option(args, "--output")?
+    echo("first={first}")
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_option_repeated.ab
+++ b/src/tests/stdlib/cli_take_option_repeated.ab
@@ -2,11 +2,14 @@ import { take_option } from "std/cli"
 
 // Output
 // first=one
-// rest=(4) [build --output two tail]
+// second=two
+// rest=(2) [build tail]
 
 main {
     let args = ["build", "--output", "one", "--output", "two", "tail"]
     const first = take_option(args, "--output")?
+    const second = take_option(args, "--output")?
     echo("first={first}")
+    echo("second={second}")
     echo("rest=({len(args)}) [{args}]")
 }

--- a/src/tests/stdlib/cli_take_option_short.ab
+++ b/src/tests/stdlib/cli_take_option_short.ab
@@ -1,0 +1,12 @@
+import { take_option } from "std/cli"
+
+// Output
+// output=dist/app.sh
+// rest=(1) [build]
+
+main {
+    let args = ["build", "-o", "dist/app.sh"]
+    const output = take_option(args, "--output", "-o")?
+    echo("output={output}")
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_option_short_dash_value.ab
+++ b/src/tests/stdlib/cli_take_option_short_dash_value.ab
@@ -1,0 +1,12 @@
+import { take_option } from "std/cli"
+
+// Output
+// output=-x
+// rest=(1) [build]
+
+main {
+    let args = ["build", "-o", "-x"]
+    const output = take_option(args, "--output", "-o")?
+    echo("output={output}")
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_option_stops_at_terminator.ab
+++ b/src/tests/stdlib/cli_take_option_stops_at_terminator.ab
@@ -1,0 +1,13 @@
+import { take_option } from "std/cli"
+
+// Output
+// option absent
+// rest=(3) [build -- --output=dist/app.sh]
+
+main {
+    let args = ["build", "--", "--output=dist/app.sh"]
+    take_option(args, "--output", "-o") failed {
+        echo("option absent")
+    }
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_positional.ab
+++ b/src/tests/stdlib/cli_take_positional.ab
@@ -1,0 +1,15 @@
+import { take_positional } from "std/cli"
+
+// Output
+// first=input.txt
+// second=output.txt
+// rest=(1) [--verbose]
+
+main {
+    let args = ["--verbose", "input.txt", "output.txt"]
+    const first = take_positional(args)?
+    const second = take_positional(args)?
+    echo("first={first}")
+    echo("second={second}")
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_positional_missing.ab
+++ b/src/tests/stdlib/cli_take_positional_missing.ab
@@ -1,0 +1,11 @@
+import { take_positional } from "std/cli"
+
+// Output
+// positional missing
+
+main {
+    let args = ["--verbose", "-v"]
+    take_positional(args) failed {
+        echo("positional missing")
+    }
+}

--- a/src/tests/stdlib/cli_take_positional_mixed_args.ab
+++ b/src/tests/stdlib/cli_take_positional_mixed_args.ab
@@ -1,0 +1,15 @@
+import { take_positional } from "std/cli"
+
+// Output
+// first=file1
+// second=file2
+// rest=(1) [--verbose]
+
+main {
+    let args = ["file1", "--verbose", "file2"]
+    const first = take_positional(args)?
+    const second = take_positional(args)?
+    echo("first={first}")
+    echo("second={second}")
+    echo("rest=({len(args)}) [{args}]")
+}

--- a/src/tests/stdlib/cli_take_positional_terminator_missing.ab
+++ b/src/tests/stdlib/cli_take_positional_terminator_missing.ab
@@ -1,0 +1,13 @@
+import { take_positional } from "std/cli"
+
+// Output
+// positional missing
+// rest=(2) [--verbose --]
+
+main {
+    let args = ["--verbose", "--"]
+    take_positional(args) failed {
+        echo("positional missing")
+    }
+    echo("rest=({len(args)}) [{args}]")
+}


### PR DESCRIPTION
## Summary

Add a new `std/cli` module for common argument parsing patterns in Amber scripts.

This includes helpers for:
- normalizing `raw_args` with `cli_args`
- matching commands from an allowed set
- consuming long and short flags
- consuming long and short options
- consuming positional arguments
- collecting all remaining positional arguments
- asserting that parsing finished without leftovers

This also fixes terminator handling so a lone `--` is treated as syntax rather than an unconsumed argument once parsing is complete.

## Tests

- add stdlib fixture coverage for commands, flags, options, positionals, and `--`
- add tests for `cli_args(raw_args)`
- add an end-to-end CLI test for forwarded script arguments

## Validation

- `cargo test cli_`
- `cargo test cli_take_option_`
- `cargo test cli_take_flag_`
- `cargo test cli_assert_empty`
- `cargo test test_cli_file_starting_with_dash`
- `cargo test test_cli_raw_args_forwarded_to_script`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI parsing library: drops the script name, handles long/short flags and named options (inline or separate values), subcommands, repeated options, and positional arguments; respects the `--` terminator and validates missing values.

* **Tests**
  * Extensive tests covering argument forwarding, terminator behavior, flag/option/positional success and failure cases, repeated options, and end-of-input assertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->