### PR TITLE
Last chores 0.6

### DIFF
--- a/src/modules/builtin/disown.rs
+++ b/src/modules/builtin/disown.rs
@@ -62,7 +62,7 @@ impl TypeCheckModule for Disown {
 impl TranslateModule for Disown {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
         if self.jobs.is_empty() {
-            fragments!("disown")
+            fragments!("disown || exit")
         } else {
             let mut result = fragments!("disown ");
             for (i, job) in self.jobs.iter().enumerate() {
@@ -71,7 +71,7 @@ impl TranslateModule for Disown {
                 }
                 result = fragments!(result, job.translate(meta));
             }
-            result
+            fragments!(result, " || exit")
         }
     }
 }

--- a/src/modules/builtin/disown.rs
+++ b/src/modules/builtin/disown.rs
@@ -1,5 +1,7 @@
 use crate::fragments;
+use crate::modules::expression::expr::Expr;
 use crate::modules::prelude::*;
+use crate::modules::types::{Type, Typed};
 use crate::utils::ParserMetadata;
 use amber_meta::AutoKeyword;
 use heraclitus_compiler::prelude::*;
@@ -8,32 +10,64 @@ use heraclitus_compiler::syntax_name;
 #[derive(Clone, Debug, AutoKeyword)]
 #[keyword = "disown"]
 #[kind = "builtin_stmt"]
-pub struct Disown {}
+pub struct Disown {
+    jobs: Vec<Expr>,
+}
+
+impl Typed for Disown {
+    fn get_type(&self) -> Type {
+        Type::Null
+    }
+}
 
 impl SyntaxModule<ParserMetadata> for Disown {
     syntax_name!("disown");
 
     fn new() -> Self {
-        Disown {}
+        Disown { jobs: Vec::new() }
     }
 
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         token(meta, "disown")?;
-        token(meta, "(")?;
-        token(meta, ")")?;
+        if token(meta, "(").is_ok() {
+            let mut job = Expr::new();
+            if syntax(meta, &mut job).is_ok() {
+                self.jobs.push(job);
+                while token(meta, ",").is_ok() {
+                    let mut next_job = Expr::new();
+                    syntax(meta, &mut next_job)?;
+                    self.jobs.push(next_job);
+                }
+            }
+            token(meta, ")")?;
+        }
         Ok(())
     }
 }
 
 impl TypeCheckModule for Disown {
-    fn typecheck(&mut self, _meta: &mut ParserMetadata) -> SyntaxResult {
+    fn typecheck(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
+        for job in &mut self.jobs {
+            job.typecheck(meta)?;
+        }
         Ok(())
     }
 }
 
 impl TranslateModule for Disown {
-    fn translate(&self, _meta: &mut TranslateMetadata) -> FragmentKind {
-        fragments!("disown")
+    fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
+        if self.jobs.is_empty() {
+            fragments!("disown")
+        } else {
+            let mut result = fragments!("disown ");
+            for (i, job) in self.jobs.iter().enumerate() {
+                if i > 0 {
+                    result = fragments!(result, " ");
+                }
+                result = fragments!(result, job.translate(meta));
+            }
+            result
+        }
     }
 }
 

--- a/src/modules/builtin/disown.rs
+++ b/src/modules/builtin/disown.rs
@@ -30,14 +30,19 @@ impl SyntaxModule<ParserMetadata> for Disown {
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         token(meta, "disown")?;
         if token(meta, "(").is_ok() {
+            // Handle disown() - empty argument list
+            if token(meta, ")").is_ok() {
+                return Ok(());
+            }
+            // Parse first required expression
             let mut job = Expr::new();
-            if syntax(meta, &mut job).is_ok() {
-                self.jobs.push(job);
-                while token(meta, ",").is_ok() {
-                    let mut next_job = Expr::new();
-                    syntax(meta, &mut next_job)?;
-                    self.jobs.push(next_job);
-                }
+            syntax(meta, &mut job)?;
+            self.jobs.push(job);
+            // Parse additional expressions separated by commas
+            while token(meta, ",").is_ok() {
+                let mut next_job = Expr::new();
+                syntax(meta, &mut next_job)?;
+                self.jobs.push(next_job);
             }
             token(meta, ")")?;
         }

--- a/src/modules/builtin/lines.rs
+++ b/src/modules/builtin/lines.rs
@@ -78,7 +78,7 @@ impl TranslateModule for LinesInvocation {
             // If you change this, update that one too.
             raw_fragment!("while IFS= read -r {temp} || [ -n \"${temp}\" ]; do"),
             raw_fragment!("{indent}{}+=(\"${}\")", var_expr.get_name(), temp),
-            fragments!("done <", path),
+            fragments!("done <", path, " || exit"),
         ]);
         var_expr.to_frag()
     }

--- a/src/modules/builtin/nameof.rs
+++ b/src/modules/builtin/nameof.rs
@@ -39,7 +39,13 @@ impl SyntaxModule<ParserMetadata> for Nameof {
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         token(meta, "nameof")?;
         self.token = meta.get_current_token();
-        self.name = variable(meta, variable_name_extensions())?;
+        // Support both syntax: nameof(var) and nameof var
+        if token(meta, "(").is_ok() {
+            self.name = variable(meta, variable_name_extensions())?;
+            token(meta, ")")?;
+        } else {
+            self.name = variable(meta, variable_name_extensions())?;
+        }
         Ok(())
     }
 }

--- a/src/modules/builtin/shellversion.rs
+++ b/src/modules/builtin/shellversion.rs
@@ -13,7 +13,7 @@ pub struct Shellversion {}
 
 impl Typed for Shellversion {
     fn get_type(&self) -> Type {
-        Type::Array(Box::new(Type::Text))
+        Type::Array(Box::new(Type::Int))
     }
 }
 

--- a/src/modules/builtin/shellversion.rs
+++ b/src/modules/builtin/shellversion.rs
@@ -3,7 +3,7 @@ use crate::modules::prelude::*;
 use crate::modules::typecheck::TypeCheckModule;
 use crate::modules::types::{Type, Typed};
 use crate::translate::module::TranslateModule;
-use crate::utils::{ParserMetadata, TranslateMetadata};
+use crate::utils::{ParserMetadata, ShellType, TranslateMetadata};
 use heraclitus_compiler::prelude::*;
 
 #[derive(Debug, Clone, AutoKeyword)]
@@ -13,7 +13,7 @@ pub struct Shellversion {}
 
 impl Typed for Shellversion {
     fn get_type(&self) -> Type {
-        Type::array_of(Type::Int)
+        Type::Text
     }
 }
 
@@ -26,8 +26,9 @@ impl SyntaxModule<ParserMetadata> for Shellversion {
 
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         token(meta, "shellversion")?;
-        token(meta, "(")?;
-        token(meta, ")")?;
+        if token(meta, "(").is_ok() {
+            token(meta, ")")?;
+        }
         meta.shellversion_used = true;
         Ok(())
     }
@@ -40,8 +41,12 @@ impl TypeCheckModule for Shellversion {
 }
 
 impl TranslateModule for Shellversion {
-    fn translate(&self, _meta: &mut TranslateMetadata) -> FragmentKind {
-        VarExprFragment::new("EXEC_SHELL_VERSION", Type::array_of(Type::Int)).to_frag()
+    fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
+        match meta.target.shell {
+            ShellType::Ksh => VarExprFragment::new("VERSION", Type::Text).to_frag(),
+            ShellType::Zsh => VarExprFragment::new("ZSH_VERSION", Type::Text).to_frag(),
+            _ => VarExprFragment::new("BASH_VERSION", Type::Text).to_frag(),
+        }
     }
 }
 

--- a/src/modules/builtin/shellversion.rs
+++ b/src/modules/builtin/shellversion.rs
@@ -3,7 +3,7 @@ use crate::modules::prelude::*;
 use crate::modules::typecheck::TypeCheckModule;
 use crate::modules::types::{Type, Typed};
 use crate::translate::module::TranslateModule;
-use crate::utils::{ParserMetadata, ShellType, TranslateMetadata};
+use crate::utils::{ParserMetadata, TranslateMetadata};
 use heraclitus_compiler::prelude::*;
 
 #[derive(Debug, Clone, AutoKeyword)]
@@ -13,7 +13,7 @@ pub struct Shellversion {}
 
 impl Typed for Shellversion {
     fn get_type(&self) -> Type {
-        Type::Text
+        Type::Array(Box::new(Type::Text))
     }
 }
 
@@ -41,12 +41,8 @@ impl TypeCheckModule for Shellversion {
 }
 
 impl TranslateModule for Shellversion {
-    fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        match meta.target.shell {
-            ShellType::Ksh => VarExprFragment::new("VERSION", Type::Text).to_frag(),
-            ShellType::Zsh => VarExprFragment::new("ZSH_VERSION", Type::Text).to_frag(),
-            _ => VarExprFragment::new("BASH_VERSION", Type::Text).to_frag(),
-        }
+    fn translate(&self, _meta: &mut TranslateMetadata) -> FragmentKind {
+        VarExprFragment::new("EXEC_SHELL_VERSION", Type::Array(Box::new(Type::Text))).to_frag()
     }
 }
 

--- a/src/modules/builtin/sleep.rs
+++ b/src/modules/builtin/sleep.rs
@@ -46,7 +46,8 @@ impl TypeCheckModule for Sleep {
 
 impl TranslateModule for Sleep {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        fragments!("sleep ", self.value.translate(meta))
+        let value = self.value.translate(meta);
+        fragments!("(( ", value.clone(), " > 0 )) && sleep ", value, " || exit")
     }
 }
 

--- a/src/modules/builtin/sleep.rs
+++ b/src/modules/builtin/sleep.rs
@@ -47,7 +47,7 @@ impl TypeCheckModule for Sleep {
 impl TranslateModule for Sleep {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
         let value = self.value.translate(meta);
-        fragments!("(( ", value.clone(), " > 0 )) && sleep ", value, " || exit")
+        fragments!("sleep ", value, " || exit")
     }
 }
 

--- a/src/modules/builtin/touch.rs
+++ b/src/modules/builtin/touch.rs
@@ -57,7 +57,7 @@ impl TypeCheckModule for Touch {
 
 impl TranslateModule for Touch {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        fragments!("touch ", self.value.translate(meta))
+        fragments!("touch ", self.value.translate(meta), " || exit")
     }
 }
 

--- a/src/modules/builtin/wait.rs
+++ b/src/modules/builtin/wait.rs
@@ -47,7 +47,7 @@ impl TypeCheckModule for Await {
 
 impl TranslateModule for Await {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        fragments!("wait ", self.pids.translate(meta))
+        fragments!("wait ", self.pids.translate(meta), " || exit")
     }
 }
 

--- a/src/modules/expression/interpolated_region.rs
+++ b/src/modules/expression/interpolated_region.rs
@@ -52,21 +52,15 @@ fn parse_escaped_string(string: String, region_type: &InterpolatedRegionType) ->
                 Some('r') => result.push('\r'),
                 Some('0') => result.push('\0'),
                 Some('{') => result.push('{'),
+                Some('"') if *region_type == InterpolatedRegionType::Text => result.push('"'),
                 Some('"') => {
-                    if *region_type == InterpolatedRegionType::Text {
-                        result.push('"');
-                    } else {
-                        result.push(c);
-                        continue;
-                    }
+                    result.push(c);
+                    continue;
                 }
+                Some('$') if *region_type == InterpolatedRegionType::Command => result.push('$'),
                 Some('$') => {
-                    if *region_type == InterpolatedRegionType::Command {
-                        result.push('$');
-                    } else {
-                        result.push(c);
-                        continue;
-                    }
+                    result.push(c);
+                    continue;
                 }
                 _ => {
                     result.push(c);

--- a/src/modules/expression/typeop/cast.rs
+++ b/src/modules/expression/typeop/cast.rs
@@ -65,22 +65,17 @@ impl TypeCheckModule for Cast {
                     "To suppress this warning, use '{flag_name}' compiler flag"
                 ));
             match (l_type, r_type) {
-                (Type::Array(left), Type::Array(right)) => {
+                (Type::Array(left), Type::Array(right))
                     if *left != *right
                         && !matches!(*left, Type::Bool | Type::Num)
-                        && !matches!(*right, Type::Bool | Type::Num)
-                    {
-                        meta.add_message(message);
-                    }
+                        && !matches!(*right, Type::Bool | Type::Num) =>
+                {
+                    meta.add_message(message);
                 }
                 (Type::Array(_) | Type::Null, Type::Array(_) | Type::Null) => {
                     meta.add_message(message)
                 }
-                (Type::Text, _) => {
-                    if self.kind != Type::Text {
-                        meta.add_message(message)
-                    }
-                }
+                (Type::Text, _) if self.kind != Type::Text => meta.add_message(message),
                 _ => {}
             }
         }

--- a/src/preambles/shellname-shellversion.sh
+++ b/src/preambles/shellname-shellversion.sh
@@ -3,13 +3,9 @@ if [ -n "$ZSH_VERSION" ]; then
     IFS='.' read -A EXEC_SHELL_VERSION <<< "$ZSH_VERSION"
 elif [ -n "$KSH_VERSION" ]; then
     EXEC_SHELL="ksh"
-    # In ksh, parse VERSION variable directly (format: "Version AJM 93u+ 2012-08-01")
-    _ksh_ver="${VERSION:-}"
-    if [ -n "$_ksh_ver" ]; then
-        EXEC_SHELL_VERSION=($_ksh_ver)
-    else
-        EXEC_SHELL_VERSION=("unknown" "unknown" "unknown")
-    fi
+    __exec_shell_version="${KSH_VERSION:-}"
+    __exec_shell_version="${__exec_shell_version%% *}"
+    IFS='.' read -a EXEC_SHELL_VERSION <<< "${__exec_shell_version}"
 else
     EXEC_SHELL="bash"
     EXEC_SHELL_VERSION=("${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}" "${BASH_VERSINFO[2]}")

--- a/src/preambles/shellname-shellversion.sh
+++ b/src/preambles/shellname-shellversion.sh
@@ -3,8 +3,13 @@ if [ -n "$ZSH_VERSION" ]; then
     IFS='.' read -A EXEC_SHELL_VERSION <<< "$ZSH_VERSION"
 elif [ -n "$KSH_VERSION" ]; then
     EXEC_SHELL="ksh"
-    __exec_shell_version="${.sh.version##*/}"
-    IFS='.' read -a EXEC_SHELL_VERSION <<< "${__exec_shell_version%% *}"
+    # In ksh, parse VERSION variable directly (format: "Version AJM 93u+ 2012-08-01")
+    _ksh_ver="${VERSION:-}"
+    if [ -n "$_ksh_ver" ]; then
+        EXEC_SHELL_VERSION=($_ksh_ver)
+    else
+        EXEC_SHELL_VERSION=("unknown" "unknown" "unknown")
+    fi
 else
     EXEC_SHELL="bash"
     EXEC_SHELL_VERSION=("${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}" "${BASH_VERSINFO[2]}")

--- a/src/preambles/shellname-shellversion.sh
+++ b/src/preambles/shellname-shellversion.sh
@@ -4,7 +4,7 @@ if [ -n "$ZSH_VERSION" ]; then
 elif [ -n "$KSH_VERSION" ]; then
     EXEC_SHELL="ksh"
     __exec_shell_version="${KSH_VERSION##* }"
-    IFS='-' read -A EXEC_SHELL_VERSION <<< "${__exec_shell_version%% *}"
+    IFS='-' read -A EXEC_SHELL_VERSION <<< "${__exec_shell_version}"
 else
     EXEC_SHELL="bash"
     EXEC_SHELL_VERSION=("${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}" "${BASH_VERSINFO[2]}")

--- a/src/preambles/shellname-shellversion.sh
+++ b/src/preambles/shellname-shellversion.sh
@@ -3,8 +3,8 @@ if [ -n "$ZSH_VERSION" ]; then
     IFS='.' read -A EXEC_SHELL_VERSION <<< "$ZSH_VERSION"
 elif [ -n "$KSH_VERSION" ]; then
     EXEC_SHELL="ksh"
-    __exec_shell_version="${KSH_VERSION:-}"
-    IFS='.' read -a EXEC_SHELL_VERSION <<< "${__exec_shell_version%% *}"
+    __exec_shell_version="${KSH_VERSION##* }"
+    IFS='-' read -A EXEC_SHELL_VERSION <<< "${__exec_shell_version%% *}"
 else
     EXEC_SHELL="bash"
     EXEC_SHELL_VERSION=("${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}" "${BASH_VERSINFO[2]}")

--- a/src/preambles/shellname-shellversion.sh
+++ b/src/preambles/shellname-shellversion.sh
@@ -4,8 +4,7 @@ if [ -n "$ZSH_VERSION" ]; then
 elif [ -n "$KSH_VERSION" ]; then
     EXEC_SHELL="ksh"
     __exec_shell_version="${KSH_VERSION:-}"
-    __exec_shell_version="${__exec_shell_version%% *}"
-    IFS='.' read -a EXEC_SHELL_VERSION <<< "${__exec_shell_version}"
+    IFS='.' read -a EXEC_SHELL_VERSION <<< "${__exec_shell_version%% *}"
 else
     EXEC_SHELL="bash"
     EXEC_SHELL_VERSION=("${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}" "${BASH_VERSINFO[2]}")

--- a/src/tests/compiling.rs
+++ b/src/tests/compiling.rs
@@ -235,7 +235,7 @@ main {
         "Output should contain the zsh shellversion preamble"
     );
     assert!(
-        result.contains(r#"IFS='.' read -a EXEC_SHELL_VERSION <<< "${__exec_shell_version%% *}""#),
+        result.contains(r#"IFS='-' read -A EXEC_SHELL_VERSION <<< "${__exec_shell_version}""#),
         "Output should contain the ksh shellversion preamble"
     );
     assert!(

--- a/src/tests/snapshots/amber__tests__compiling__lock.ab.snap
+++ b/src/tests/snapshots/amber__tests__compiling__lock.ab.snap
@@ -1,0 +1,14 @@
+---
+source: src/tests/compiling.rs
+assertion_line: 34
+expression: ast
+---
+__lock_file_1="$(basename $0).lock"
+if [ -f "${__lock_file_1}" ]; then
+    echo "Script is already running"
+    exit 1
+fi
+touch "${__lock_file_1"}
+trap 'rm -f "${__lock_file_1"}' EXIT
+
+echo "Hello"

--- a/src/tests/snapshots/amber__tests__compiling__shell_injection_backslash.ab__bash.snap
+++ b/src/tests/snapshots/amber__tests__compiling__shell_injection_backslash.ab__bash.snap
@@ -1,0 +1,12 @@
+---
+source: src/tests/compiling.rs
+assertion_line: 35
+expression: ast
+---
+# Test: Backslash should not break bash syntax
+# Issue #1046 - Shell injection prevention
+# 
+# Run: amber run shell_injection_backslash.ab -- '\'
+# Expected: Command succeeds, outputs literal backslash
+typeset -r args_0=("$0" "$@")
+printf '%s\n' "${args_0[1]}"

--- a/src/tests/snapshots/amber__tests__compiling__shell_injection_command_substitution.ab__bash.snap
+++ b/src/tests/snapshots/amber__tests__compiling__shell_injection_command_substitution.ab__bash.snap
@@ -1,0 +1,13 @@
+---
+source: src/tests/compiling.rs
+assertion_line: 35
+expression: ast
+---
+# Test: Command substitution $(...) should be passed literally, not executed
+# Issue #1046 - Shell injection prevention
+# 
+# Run: amber run shell_injection_command_substitution.ab -- '$(echo INJECTED)'
+# Expected output: $(echo INJECTED)
+# NOT: INJECTED
+typeset -r args_0=("$0" "$@")
+printf '%s\n' "${args_0[1]}"

--- a/src/tests/snapshots/amber__tests__compiling__shell_injection_variable_expansion.ab__bash.snap
+++ b/src/tests/snapshots/amber__tests__compiling__shell_injection_variable_expansion.ab__bash.snap
@@ -1,0 +1,13 @@
+---
+source: src/tests/compiling.rs
+assertion_line: 35
+expression: ast
+---
+# Test: Variable expansion $VAR should be passed literally, not expanded
+# Issue #1046 - Shell injection prevention
+# 
+# Run: amber run shell_injection_variable_expansion.ab -- '$HOME'
+# Expected output: $HOME
+# NOT: /home/user
+typeset -r args_0=("$0" "$@")
+printf '%s\n' "${args_0[1]}"

--- a/src/tests/snapshots/amber__tests__optimizing__unused_variables_function.ab__bash-3.2.snap
+++ b/src/tests/snapshots/amber__tests__optimizing__unused_variables_function.ab__bash-3.2.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 # foo()
 foo__0_v0() {
-    touch "file.txt"
+    touch "file.txt" || exit
 }
 
 foo__0_v0 

--- a/src/tests/snapshots/amber__tests__optimizing__unused_variables_function.ab__bash-4.3.snap
+++ b/src/tests/snapshots/amber__tests__optimizing__unused_variables_function.ab__bash-4.3.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 # foo()
 foo__0_v0() {
-    touch "file.txt"
+    touch "file.txt" || exit
 }
 
 foo__0_v0 

--- a/src/tests/snapshots/amber__tests__optimizing__unused_variables_function.ab__bash.snap
+++ b/src/tests/snapshots/amber__tests__optimizing__unused_variables_function.ab__bash.snap
@@ -3,7 +3,7 @@ source: src/tests/optimizing.rs
 expression: output
 ---
 foo__0_v0() {
-    touch "file.txt"
+    touch "file.txt" || exit
 }
 
 foo__0_v0 

--- a/src/tests/snapshots/amber__tests__optimizing__unused_variables_function.ab__ksh.snap
+++ b/src/tests/snapshots/amber__tests__optimizing__unused_variables_function.ab__ksh.snap
@@ -3,7 +3,7 @@ source: src/tests/optimizing.rs
 expression: output
 ---
 function foo__0_v0 {
-    touch "file.txt"
+    touch "file.txt" || exit
 }
 
 foo__0_v0 

--- a/src/tests/snapshots/amber__tests__optimizing__unused_variables_function.ab__zsh.snap
+++ b/src/tests/snapshots/amber__tests__optimizing__unused_variables_function.ab__zsh.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 # foo()
 foo__0_v0() {
-    touch "file.txt"
+    touch "file.txt" || exit
 }
 
 foo__0_v0 


### PR DESCRIPTION
From: https://github.com/amber-lang/amber/pull/1079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `disown` can accept an optional parenthesized, comma-separated list of job expressions
  * `nameof` and `shellversion` now optionally accept parentheses

* **Bug Fixes**
  * `sleep`, `touch`, `wait`, `disown` and loop termination now include an exit-on-failure fallback (`|| exit`)
  * `shellversion` reporting and KSH detection improved
  * Escaping inside interpolated strings handled more consistently

* **Tests**
  * Updated shellversion-related test expectations for KSH output
<!-- end of auto-generated comment: release notes by coderabbit.ai -->