### PR TITLE
Fix `nameof` function caching during first-pass typecheck

### DIFF
--- a/src/modules/builtin/nameof.rs
+++ b/src/modules/builtin/nameof.rs
@@ -94,12 +94,13 @@ impl TypeCheckModule for Nameof {
                             Some(fun_instance) => fun_instance.variant_id,
                             None => {
                                 // Compile the function on demand to get the variant ID
+                                let persist = !meta.first_pass_ctx;
                                 run_function_with_args(
                                     meta,
                                     fun_decl.clone(),
                                     &args_types,
                                     self.token.clone(),
-                                    true,
+                                    persist,
                                 )?
                                 .1
                             }

--- a/src/tests/validity/nameof_function_nested.ab
+++ b/src/tests/validity/nameof_function_nested.ab
@@ -1,0 +1,16 @@
+// Output
+// helper
+
+fun helper(): Null {
+    echo("helper")
+}
+
+fun named(): Null {
+    helper()
+}
+
+fun caller(): Null {
+    trust $ {nameof(named)} $
+}
+
+caller()


### PR DESCRIPTION
Wanted to help, so took my time and fixed this small bug introduced by my previous work.

- Avoid persisting `nameof(function)`-triggered variants while the compiler is in first-pass function typechecking.
- This prevents incomplete function caches that can omit nested callees from the generated shell output.
- Add a regression test covering a nested `nameof` function call chain.

Closes #1043