### PR TITLE
fix #1051: add spacing between command and modifiers

### DIFF
--- a/src/modules/builtin/cd.rs
+++ b/src/modules/builtin/cd.rs
@@ -95,7 +95,9 @@ impl TranslateModule for Cd {
         });
         BlockFragment::new(
             vec![
-                fragments!(sudo_prefix, "cd ", value, suppress, silent),
+                ListFragment::new(vec![sudo_prefix, fragments!("cd"), value, suppress, silent])
+                    .with_spaces()
+                    .to_frag(),
                 handler,
             ],
             false,

--- a/src/modules/builtin/cp.rs
+++ b/src/modules/builtin/cp.rs
@@ -144,17 +144,17 @@ impl TranslateModule for Cp {
 
         BlockFragment::new(
             vec![
-                fragments!(
-                    sudo_prefix,
-                    "cp -r ",
-                    force_frag.with_quotes(false),
-                    " ",
-                    source,
-                    " ",
-                    destination,
-                    suppress,
-                    silent
-                ),
+                ListFragment::new(
+                    vec![
+                        sudo_prefix,
+                        raw_fragment!("cp -r"),
+                        force_frag.with_quotes(false),
+                        source,
+                        destination,
+                        suppress,
+                        silent
+                    ]
+                ).with_spaces().to_frag(),
                 handler,
             ],
             false,

--- a/src/modules/builtin/lines.rs
+++ b/src/modules/builtin/lines.rs
@@ -1,4 +1,3 @@
-use crate::fragments;
 use crate::modules::command::modifier::CommandModifier;
 use crate::modules::condition::failure_handler::FailureHandler;
 use crate::modules::expression::expr::Expr;
@@ -114,17 +113,26 @@ impl TranslateModule for LinesInvocation {
         // Producer writes into the FIFO in the background so that:
         // - sudo works (process substitution `<(sudo ...)` strips sudo's TTY access)
         // - the producer's exit status is properly captured via `wait`
-        let producer = if has_sudo {
-            fragments!(
-                sudo_prefix,
-                " cat ",
-                path,
-                suppress,
-                raw_fragment!(" >\"${fifo_var}\" &")
-            )
-        } else {
-            fragments!("cat ", path, suppress, raw_fragment!(" >\"${fifo_var}\" &"))
-        };
+        let producer = ListFragment::new(
+                    if has_sudo {
+                        vec![
+                            sudo_prefix,
+                            raw_fragment!("cat"),
+                            path,
+                            suppress,
+                            raw_fragment!(">\"${fifo_var}\" &")
+                        ]
+                    } else {
+                        vec![
+                            raw_fragment!("cat"),
+                            path,
+                            suppress,
+                            raw_fragment!(">\"${fifo_var}\" &")
+                        ]
+                    }
+                )
+                .with_spaces()
+                .to_frag();
 
         meta.stmt_queue.extend([
             raw_fragment!("{fifo_var}=$(mktemp -u) || exit 1"), // panic if fifo cannot be created

--- a/src/modules/builtin/ls.rs
+++ b/src/modules/builtin/ls.rs
@@ -209,16 +209,19 @@ impl TranslateModule for Ls {
             ),
         };
         meta.stmt_queue.extend([
-            fragments!(
-                read_command,
-                sudo_prefix,
-                "IFS=$'\\n'; LC_ALL=C ls -1",
-                all_frag,
-                recursive_frag,
-                " ",
-                path_expr.to_frag().with_quotes(false),
-                suppress
-            ),
+            ListFragment::new(
+                vec![
+                    read_command,
+                    sudo_prefix,
+                    fragments!("IFS=$'\\n'; LC_ALL=C ls -1"),
+                    all_frag,
+                    recursive_frag,
+                    path_expr.to_frag().with_quotes(false),
+                    suppress
+                ]
+            )
+                .with_spaces()
+                .to_frag(),
             handler,
             fragments!(");"),
         ]);

--- a/src/modules/builtin/ls.rs
+++ b/src/modules/builtin/ls.rs
@@ -213,7 +213,7 @@ impl TranslateModule for Ls {
                 vec![
                     read_command,
                     sudo_prefix,
-                    fragments!("IFS=$'\\n'; LC_ALL=C ls -1"),
+                    fragments!("LC_ALL=C IFS=$'\\n' ls -1"),
                     all_frag,
                     recursive_frag,
                     path_expr.to_frag().with_quotes(false),

--- a/src/modules/builtin/ls.rs
+++ b/src/modules/builtin/ls.rs
@@ -212,8 +212,9 @@ impl TranslateModule for Ls {
             ListFragment::new(
                 vec![
                     read_command,
+                    raw_fragment!("IFS=$'\\n';"),
                     sudo_prefix,
-                    fragments!("LC_ALL=C IFS=$'\\n' ls -1"),
+                    fragments!("LC_ALL=C ls -1"),
                     all_frag,
                     recursive_frag,
                     path_expr.to_frag().with_quotes(false),

--- a/src/modules/builtin/ls.rs
+++ b/src/modules/builtin/ls.rs
@@ -159,7 +159,7 @@ impl TranslateModule for Ls {
                 " )) && ",
                 raw_fragment!("{}=\"-A\" || {}=\"\"", all_var_name, all_var_name)
             ));
-            raw_fragment!(" ${{{}}}", all_var_name)
+            raw_fragment!("${{{}}}", all_var_name)
         } else {
             FragmentKind::Empty
         };
@@ -177,7 +177,7 @@ impl TranslateModule for Ls {
                     recursive_var_name
                 )
             ));
-            raw_fragment!(" ${{{}}}", recursive_var_name)
+            raw_fragment!("${{{}}}", recursive_var_name)
         } else {
             FragmentKind::Empty
         };

--- a/src/modules/builtin/rm.rs
+++ b/src/modules/builtin/rm.rs
@@ -162,17 +162,19 @@ impl TranslateModule for Rm {
             meta.gen_sudo_prefix().to_frag()
         });
 
-        fragments!(
-            sudo_prefix,
-            "rm ",
-            force_frag.with_quotes(false),
-            " ",
-            recursive_frag.with_quotes(false),
-            " ",
-            self.value.translate(meta),
-            suppress,
-            silent
+        ListFragment::new(
+            vec![
+                sudo_prefix,
+                fragments!("rm"),
+                force_frag.with_quotes(false),
+                recursive_frag.with_quotes(false),
+                self.value.translate(meta),
+                suppress,
+                silent
+            ]
         )
+        .with_spaces()
+        .to_frag()
     }
 }
 

--- a/src/modules/builtin/sleep.rs
+++ b/src/modules/builtin/sleep.rs
@@ -113,7 +113,9 @@ impl TranslateModule for Sleep {
                 silent.clone(),
                 suppress.clone()
             ]
-        ).to_frag();
+        )
+        .with_spaces()
+        .to_frag();
 
         BlockFragment::new(
             vec![

--- a/src/modules/builtin/sleep.rs
+++ b/src/modules/builtin/sleep.rs
@@ -84,9 +84,6 @@ impl TranslateModule for Sleep {
         let location = position.as_deref().unwrap_or("unknown");
 
         let handler = self.failure_handler.translate(meta);
-        let sudo_prefix = meta.with_sudoed(self.modifier.is_sudo || meta.sudoed, |meta| {
-            meta.gen_sudo_prefix().to_frag()
-        });
         let silent = meta.with_silenced(self.modifier.is_silent || meta.silenced, |meta| {
             meta.gen_silent().to_frag()
         });
@@ -110,7 +107,6 @@ impl TranslateModule for Sleep {
         };
 
         let sleep_cmd = fragments!(
-            sudo_prefix,
             "sleep ",
             var_expr.to_frag(),
             silent.clone(),

--- a/src/modules/builtin/sleep.rs
+++ b/src/modules/builtin/sleep.rs
@@ -106,12 +106,14 @@ impl TranslateModule for Sleep {
             ),
         };
 
-        let sleep_cmd = fragments!(
-            "sleep ",
-            var_expr.to_frag(),
-            silent.clone(),
-            suppress.clone()
-        );
+        let sleep_cmd = ListFragment::new(
+            vec![
+                raw_fragment!("sleep"),
+                var_expr.to_frag(),
+                silent.clone(),
+                suppress.clone()
+            ]
+        ).to_frag();
 
         BlockFragment::new(
             vec![

--- a/src/modules/builtin/touch.rs
+++ b/src/modules/builtin/touch.rs
@@ -95,7 +95,9 @@ impl TranslateModule for Touch {
         });
         BlockFragment::new(
             vec![
-                fragments!(sudo_prefix, "touch ", value, suppress, silent),
+                ListFragment::new(vec![sudo_prefix, fragments!("touch"), value, suppress, silent])
+                    .with_spaces()
+                    .to_frag(),
                 handler,
             ],
             false,

--- a/src/modules/builtin/wait.rs
+++ b/src/modules/builtin/wait.rs
@@ -86,7 +86,9 @@ impl TranslateModule for Await {
         });
         BlockFragment::new(
             vec![
-                fragments!(sudo_prefix, "wait ", pids, suppress, silent),
+                ListFragment::new(vec![sudo_prefix, fragments!("wait"), pids, suppress, silent])
+                    .with_spaces()
+                    .to_frag(),
                 handler,
             ],
             false,

--- a/src/modules/command/cmd.rs
+++ b/src/modules/command/cmd.rs
@@ -1,5 +1,4 @@
 use super::modifier::CommandModifier;
-use crate::fragments;
 use crate::modules::condition::failure_handler::FailureHandler;
 use crate::modules::expression::interpolated_region::{
     parse_interpolated_region, InterpolatedRegionType,
@@ -94,7 +93,9 @@ impl TranslateModule for Command {
         let silent = meta.with_silenced(is_silenced, |meta| meta.gen_silent().to_frag());
         let suppress = meta.with_suppress(is_suppress, |meta| meta.gen_suppress().to_frag());
         let sudo_prefix = meta.with_sudoed(is_sudoed, |meta| meta.gen_sudo_prefix().to_frag());
-        let translation = fragments!(sudo_prefix, translation, suppress, silent);
+        let translation = ListFragment::new(vec![sudo_prefix, translation, suppress, silent])
+            .with_spaces()
+            .to_frag();
 
         let handler = self.failure_handler.translate(meta);
         let is_statement = !meta.expr_ctx;

--- a/src/tests/compiling.rs
+++ b/src/tests/compiling.rs
@@ -206,26 +206,6 @@ fn test_bash_32_declared_ref_array_assignment_defers_array_expansion_to_inner_ev
     assert_eq!(rendered, r#"eval "${target}=(\"\${source[@]}\")""#);
 }
 
-#[test]
-fn test_translate_sudo_preamble() {
-    let code = r#"
-main {
-    echo("test")
-}
-"#;
-    let options = CompilerOptions::default();
-    let compiler = AmberCompiler::new(code.to_string(), None, options);
-    let tokens = compiler.tokenize().expect("tokenize failed");
-    let (ast, meta) = compiler.parse(tokens).expect("parse failed");
-    let (ast, meta) = compiler.typecheck(ast, meta).expect("typecheck failed");
-    let mut translate_meta = TranslateMetadata::new(meta, &compiler.options);
-    let ast = ast.translate(&mut translate_meta);
-    let result = ast.to_string(&mut translate_meta);
-    assert!(
-        result.contains("echo \"test\""),
-        "Output should contain bash code"
-    );
-}
 
 #[test]
 fn test_translate_shellversion_preamble() {
@@ -280,18 +260,36 @@ main {
 fn test_translate_with_sudo() {
     let code = r#"
 main {
-    sudo $ echo "test" $?
+    sudo $echo "test"$?
 }
 "#;
-    let options = CompilerOptions::default();
-    let compiler = AmberCompiler::new(code.to_string(), None, options);
-    let tokens = compiler.tokenize().expect("tokenize failed");
-    let (ast, meta) = compiler.parse(tokens).expect("parse failed");
-    let (ast, meta) = compiler.typecheck(ast, meta).expect("typecheck failed");
-    let mut translate_meta = TranslateMetadata::new(meta, &compiler.options);
-    let ast = ast.translate(&mut translate_meta);
-    let result = ast.to_string(&mut translate_meta);
-    assert!(result.contains("sudo"), "Output should contain sudo");
+    let result = translate_compiler_output_with_target(code, Some(ShellType::BashModern))
+        .expect("Couldn't translate Amber code");
+
+    assert!(
+        result.contains(r#"[ "$EUID" -ne 0 ] && { { command -v sudo >/dev/null 2>&1 && __sudo=sudo; } || { command -v doas >/dev/null 2>&1 && __sudo=doas; }; }"#),
+        "Output should contain the correct sudo preamble"
+    );
+    assert!(
+        result.contains(r#"${__sudo} echo"#),
+        "Output should contain sudo echo command with spaces"
+    );
+}
+
+#[test]
+fn test_translate_with_silent() {
+    let code = r#"
+main {
+    silent $echo test$?
+}
+"#;
+    let result = translate_compiler_output_with_target(code, Some(ShellType::BashModern))
+        .expect("Couldn't translate Amber code");
+
+    assert!(
+        result.contains(r#"echo test >/dev/null"#),
+        "Output should contain echo command with separated /dev/null redirect"
+    );
 }
 
 #[test]

--- a/src/tests/compiling.rs
+++ b/src/tests/compiling.rs
@@ -280,15 +280,31 @@ main {
 fn test_translate_with_silent() {
     let code = r#"
 main {
-    silent $echo test$?
+    silent $echo 1$?
 }
 "#;
     let result = translate_compiler_output_with_target(code, Some(ShellType::BashModern))
         .expect("Couldn't translate Amber code");
 
     assert!(
-        result.contains(r#"echo test >/dev/null"#),
-        "Output should contain echo command with separated /dev/null redirect"
+        result.contains(r#"echo 1 >/dev/null"#),
+        "Output should contain echo command with separated >/dev/null redirect"
+    );
+}
+
+#[test]
+fn test_translate_with_suppress() {
+    let code = r#"
+main {
+    suppress $echo 2$?
+}
+"#;
+    let result = translate_compiler_output_with_target(code, Some(ShellType::BashModern))
+        .expect("Couldn't translate Amber code");
+
+    assert!(
+        result.contains(r#"echo 2 2>/dev/null"#),
+        "Output should contain echo command with separated 2>/dev/null redirect"
     );
 }
 

--- a/src/utils/metadata/translate.rs
+++ b/src/utils/metadata/translate.rs
@@ -183,7 +183,7 @@ impl TranslateMetadata {
 
     pub fn gen_suppress(&self) -> FragmentKind {
         if self.suppress {
-            raw_fragment!(" 2>/dev/null")
+            raw_fragment!("2>/dev/null")
         } else {
             FragmentKind::Empty
         }


### PR DESCRIPTION
Closes #1051 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Refactor**
  * Improved formatting, spacing and tokenization of generated shell commands and refined suppress/redirection formatting; behavior and public APIs remain unchanged.

* **Tests**
  * Updated tests to validate sudo preamble and echo placement, and to verify silent-mode (stdout redirected to /dev/null).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->