### PR TITLE
fix(ci): bump codecov

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -264,7 +264,7 @@ jobs:
       - name: Test coverage
         run: cargo llvm-cov --all-features --workspace --cobertura --output-path cobertura.xml
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # 6.0.1
+        uses: codecov/codecov-action@v7
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: rust,release,${{ github.event.release.tag_name }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -239,7 +239,7 @@ jobs:
       - name: Test coverage
         run: cargo build && cargo llvm-cov --all-features --workspace --cobertura --output-path cobertura.xml
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@v7
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: rust

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![License](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](http://www.gnu.org/licenses/lgpl-3.0)    [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/amber-lang/amber) 
+[![License](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)    [![Ask DeepWiki](https://deepwiki.com/badge-maker?url=https%3A%2F%2Fdeepwiki.com%2Famber-lang%2Famber)](https://deepwiki.com/amber-lang/amber)
 
 <div align="center">
     <img src="assets/amber.png" alt="amber logo" width="250" />

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![License](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](http://www.gnu.org/licenses/lgpl-3.0)    [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/amber-lang/amber) 
+
 <div align="center">
     <img src="assets/amber.png" alt="amber logo" width="250" />
 </div>


### PR DESCRIPTION
Also fix https://github.com/amber-lang/amber/issues/1095

Codecov had to do a new major release of the action because of issues with some internal key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI coverage tooling to the latest action (v7) for more reliable coverage reporting.

* **Documentation**
  * Added License (LGPL v3) and “Ask DeepWiki” badges to the README for clearer project info and support access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->