### PR TITLE
fix(shellcheck): add -r to shell version prelude reads

### DIFF
--- a/src/preambles/shellname-shellversion.sh
+++ b/src/preambles/shellname-shellversion.sh
@@ -1,10 +1,10 @@
 if [ -n "$ZSH_VERSION" ]; then
     EXEC_SHELL="zsh"
-    IFS='.' read -A EXEC_SHELL_VERSION <<< "$ZSH_VERSION"
+    IFS='.' read -r -A EXEC_SHELL_VERSION <<< "$ZSH_VERSION"
 elif [ -n "$KSH_VERSION" ]; then
     EXEC_SHELL="ksh"
     __exec_shell_version="${.sh.version##*/}"
-    IFS='.' read -a EXEC_SHELL_VERSION <<< "${__exec_shell_version%% *}"
+    IFS='.' read -r -a EXEC_SHELL_VERSION <<< "${__exec_shell_version%% *}"
 else
     EXEC_SHELL="bash"
     EXEC_SHELL_VERSION=("${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}" "${BASH_VERSINFO[2]}")

--- a/src/tests/compiling.rs
+++ b/src/tests/compiling.rs
@@ -233,11 +233,12 @@ main {
         .expect("Couldn't translate Amber code");
 
     assert!(
-        result.contains(r#"IFS='.' read -A EXEC_SHELL_VERSION <<< "$ZSH_VERSION""#),
+        result.contains(r#"IFS='.' read -r -A EXEC_SHELL_VERSION <<< "$ZSH_VERSION""#),
         "Output should contain the zsh shellversion preamble"
     );
     assert!(
-        result.contains(r#"IFS='.' read -a EXEC_SHELL_VERSION <<< "${__exec_shell_version%% *}""#),
+        result
+            .contains(r#"IFS='.' read -r -a EXEC_SHELL_VERSION <<< "${__exec_shell_version%% *}""#),
         "Output should contain the ksh shellversion preamble"
     );
     assert!(


### PR DESCRIPTION
Addresses the `SC2162` (`read` without `-r`) portion of #897.

## Summary

- Add `-r` to the generated shell-version prelude `read` calls for zsh and ksh.
- Update the existing shell-version prelude translation test to expect the safer generated output.

## Validation

- `docker run --rm -v /home/rage/.local/share/pcf/amber-897:/mnt koalaman/shellcheck:stable --exclude=SC2296,SC2034 /mnt/shellversion-before.sh` (reproduces two `SC2162` findings before the fix)
- `docker run --rm -v /home/rage/.local/share/pcf/amber-897:/mnt koalaman/shellcheck:stable --exclude=SC2296,SC2034 /mnt/shellversion-after.sh`
- `cargo test test_translate_shellversion_preamble -- --nocapture`
- `cargo test test_translate_shellname_and_shellversion_share_single_preamble -- --nocapture`
- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

Note: this intentionally leaves the other ShellCheck classes from #897 for separate focused fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved shell version parsing for ZSH and KSH shells to ensure correct handling of version string formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->