### PR TITLE
Clippy warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -242,7 +242,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-          flags: rust
+          flags: rust,${{ github.sha }}
           fail_ci_if_error: true
           verbose: true
   release-coverage:
@@ -267,6 +267,6 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-          flags: rust,release,${{ github.event.release.tag_name }}
+          flags: rust,release,${{ github.event.release.tag_name }},${{ github.sha }}
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -239,7 +239,7 @@ jobs:
       - name: Test coverage
         run: cargo build && cargo llvm-cov --all-features --workspace --cobertura --output-path cobertura.xml
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: rust
@@ -264,7 +264,7 @@ jobs:
       - name: Test coverage
         run: cargo llvm-cov --all-features --workspace --cobertura --output-path cobertura.xml
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           flags: rust,release,${{ github.event.release.tag_name }}

--- a/src/main.rs
+++ b/src/main.rs
@@ -265,7 +265,7 @@ fn execute_output(
     Ok(exit_status.code().unwrap_or(1))
 }
 
-fn resolve_command_target(
+pub(crate) fn resolve_command_target(
     command_target: Option<ShellType>,
     cli_target: Option<ShellType>,
 ) -> Option<ShellType> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -384,7 +384,7 @@ fn handle_build(
 }
 
 /// Validates the existence of the provided input file.
-fn validate_input_existence(input: &PathBuf) -> Result<(), Box<dyn Error>> {
+fn validate_input_existence(input: &Path) -> Result<(), Box<dyn Error>> {
     if !input.exists() {
         return Err("Input does not exist".into());
     }
@@ -404,7 +404,7 @@ fn validate_output_dir(output: &Option<PathBuf>) -> Result<(), Box<dyn Error>> {
 }
 
 /// Determines the output path that should be used in directory mode for the given input.
-fn create_output_dir(command: &BuildCommand, file: &PathBuf) -> PathBuf {
+fn create_output_dir(command: &BuildCommand, file: &Path) -> PathBuf {
     if let Some(output) = &command.output {
         let relative = file.strip_prefix(&command.input).ok().unwrap();
         output.join(relative).with_extension("sh")
@@ -416,7 +416,7 @@ fn create_output_dir(command: &BuildCommand, file: &PathBuf) -> PathBuf {
 /// Compiles the input file and writes the result to the output path.
 fn build_file(command: &BuildCommand, target: &Option<ShellType>, input: PathBuf, output: PathBuf) {
     let options = CompilerOptions::from_args(&command.no_proc, command.minify, false, None)
-        .with_target(target.clone())
+        .with_target(*target)
         .with_env_vars();
 
     let (code, _) = compile_input(input, options);

--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -527,8 +527,8 @@ fn test_cli_build_dir_no_output() {
         .assert()
         .success();
 
-    assert_eq!(variable_path.with_extension("sh").is_file(), true);
-    assert_eq!(while_loop_path.with_extension("sh").is_file(), true);
+    assert!(variable_path.with_extension("sh").is_file());
+    assert!(while_loop_path.with_extension("sh").is_file());
 
     let _ = tmp_dir.close();
 }
@@ -547,10 +547,10 @@ fn test_cli_build_dir_with_output_dir() {
         .assert()
         .success();
 
-    assert_eq!(tmp_dir.path().join(Path::new("str/trim.sh")).is_file(), true);
-    assert_eq!(tmp_dir.path().join(Path::new("import_mutable_attribute_source.sh")).is_file(), true);
-    assert_eq!(tmp_dir.path().join(Path::new("import_public_variable_source.sh")).is_file(), true);
-    assert_eq!(tmp_dir.path().join(Path::new("is_even.sh")).is_file(), true);
+    assert!(tmp_dir.path().join(Path::new("str/trim.sh")).is_file());
+    assert!(tmp_dir.path().join(Path::new("import_mutable_attribute_source.sh")).is_file());
+    assert!(tmp_dir.path().join(Path::new("import_public_variable_source.sh")).is_file());
+    assert!(tmp_dir.path().join(Path::new("is_even.sh")).is_file());
 
     let _ = tmp_dir.close();
 }
@@ -598,6 +598,7 @@ fn test_cli_build_stdin() {
         .stdout(predicate::str::contains("Hello from stdin"));
 }
 
+#[test]
 fn test_cli_eval() {
     let mut cmd = Command::new(amber_bin());
     cmd.args([

--- a/src/tests/functional.rs
+++ b/src/tests/functional.rs
@@ -157,6 +157,14 @@ fn test_execute_output_with_messages() {
 }
 
 #[test]
+fn test_execute_output_without_messages() {
+    let code = "exit 0".to_string();
+    let result = execute_output(code, vec![], false, None);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), 0);
+}
+
+#[test]
 fn test_handle_completion_does_not_panic() {
     let mut output = Vec::new();
     handle_completion_with_output(&mut output);
@@ -294,4 +302,32 @@ fn test_resolve_command_target_both_some() {
     assert!(result.is_some());
     // Command target takes precedence
     assert_eq!(result.unwrap(), ShellType::BashModern);
+}
+
+#[test]
+#[cfg(not(windows))]
+fn test_set_file_permission() {
+    use crate::set_file_permission;
+    use std::fs;
+    use std::os::unix::prelude::PermissionsExt;
+    
+    let temp_dir = tempdir().unwrap();
+    let test_file_path = temp_dir.path().join("test_script.sh");
+    
+    // Create a test file
+    fs::write(&test_file_path, "#!/bin/bash\necho test").unwrap();
+    
+    // Open the file as set_file_permission expects
+    let file = fs::File::open(&test_file_path).unwrap();
+    let path = test_file_path.to_string_lossy().to_string();
+    
+    // Set permissions
+    set_file_permission(&file, path);
+    
+    // Verify permissions are set to 0o755
+    let metadata = fs::metadata(&test_file_path).unwrap();
+    let mode = metadata.permissions().mode();
+    
+    // Check that execute bits are set (0o755 = rwxr-xr-x)
+    assert_eq!(mode & 0o777, 0o755);
 }

--- a/src/tests/functional.rs
+++ b/src/tests/functional.rs
@@ -176,3 +176,122 @@ fn test_handle_completion_main() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("_amber"));
 }
+
+#[test]
+fn test_validate_input_existence_existing_file() {
+    use crate::validate_input_existence;
+    let input = PathBuf::from("src/tests/functional/test.ab");
+    let result = validate_input_existence(&input);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_validate_input_existence_missing_file() {
+    use crate::validate_input_existence;
+    let input = PathBuf::from("nonexistent_file.ab");
+    let result = validate_input_existence(&input);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().to_string(), "Input does not exist");
+}
+
+#[test]
+fn test_validate_output_dir_none() {
+    use crate::validate_output_dir;
+    let output: Option<PathBuf> = None;
+    let result = validate_output_dir(&output);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_validate_output_dir_existing_dir() {
+    use crate::validate_output_dir;
+    let temp_dir = tempdir().unwrap();
+    let output = Some(temp_dir.path().to_path_buf());
+    let result = validate_output_dir(&output);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_validate_output_dir_not_a_dir() {
+    use crate::validate_output_dir;
+    let temp_dir = tempdir().unwrap();
+    let output = Some(temp_dir.path().join("file.txt"));
+    let result = validate_output_dir(&output);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().to_string(), "Output is not a directory");
+}
+
+#[test]
+fn test_create_output_dir_with_output_flag() {
+    use crate::BuildCommand;
+    use crate::create_output_dir;
+    
+    let cmd = BuildCommand {
+        input: PathBuf::from("src/"),
+        output: Some(PathBuf::from("out")),
+        no_proc: vec![],
+        minify: false,
+        target: None,
+    };
+    
+    let input_file = PathBuf::from("src/test.ab");
+    let result = create_output_dir(&cmd, &input_file);
+    assert_eq!(result, PathBuf::from("out/test.sh"));
+}
+
+#[test]
+fn test_create_output_dir_without_output_flag() {
+    use crate::BuildCommand;
+    use crate::create_output_dir;
+    
+    let cmd = BuildCommand {
+        input: PathBuf::from("src/"),
+        output: None,
+        no_proc: vec![],
+        minify: false,
+        target: None,
+    };
+    
+    let input_file = PathBuf::from("src/test.ab");
+    let result = create_output_dir(&cmd, &input_file);
+    assert_eq!(result, PathBuf::from("src/test.sh"));
+}
+
+#[test]
+fn test_resolve_command_target_both_none() {
+    use crate::resolve_command_target;
+    let result = resolve_command_target(None, None);
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_resolve_command_target_command_some() {
+    use crate::resolve_command_target;
+    use crate::ShellType;
+    let cmd_target = Some(ShellType::BashModern);
+    let result = resolve_command_target(cmd_target, None);
+    assert!(result.is_some());
+    assert_eq!(result.unwrap(), ShellType::BashModern);
+}
+
+#[test]
+fn test_resolve_command_target_cli_some() {
+    use crate::resolve_command_target;
+    use crate::ShellType;
+    let cli_target = Some(ShellType::Zsh);
+    let result = resolve_command_target(None, cli_target);
+    assert!(result.is_some());
+    assert_eq!(result.unwrap(), ShellType::Zsh);
+}
+
+#[test]
+fn test_resolve_command_target_both_some() {
+    use crate::resolve_command_target;
+    use crate::ShellType;
+    let cmd_target = Some(ShellType::BashModern);
+    let cli_target = Some(ShellType::Zsh);
+    let result = resolve_command_target(cmd_target, cli_target);
+    assert!(result.is_some());
+    // Command target takes precedence
+    assert_eq!(result.unwrap(), ShellType::BashModern);
+}

--- a/src/tests/functional.rs
+++ b/src/tests/functional.rs
@@ -331,3 +331,39 @@ fn test_set_file_permission() {
     // Check that execute bits are set (0o755 = rwxr-xr-x)
     assert_eq!(mode & 0o777, 0o755);
 }
+
+#[test]
+fn test_build_file() {
+    use crate::build_file;
+    use crate::BuildCommand;
+    use crate::ShellType;
+    use std::fs;
+    
+    let temp_dir = tempdir().unwrap();
+    let input_file = temp_dir.path().join("test.ab");
+    let output_file = temp_dir.path().join("test.sh");
+    
+    // Create a simple Amber input file
+    fs::write(&input_file, "echo(\"Hello World\")").unwrap();
+    
+    let command = BuildCommand {
+        input: temp_dir.path().to_path_buf(),
+        output: None,
+        no_proc: vec![],
+        minify: false,
+        target: None,
+    };
+    
+    let target: Option<ShellType> = None;
+    
+    // Build the file
+    build_file(&command, &target, input_file, output_file.clone());
+    
+    // Verify output file was created
+    assert!(output_file.exists());
+    
+    // Verify output contains expected shell code
+    let content = fs::read_to_string(&output_file).unwrap();
+    assert!(content.contains("echo"));
+    assert!(content.contains("Hello World"));
+}


### PR DESCRIPTION
Ref: #1118, #1124

Fixes also clippy errors and add few tests for `main.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI coverage upload workflow to use a pinned Codecov action and improved reporting by including the current commit SHA in coverage flags.

* **Tests**
  * Added a functional test ensuring `execute_output` with message output disabled returns `Ok(0)` for `exit 0`.
  * Expanded coverage for input/output validation, output directory creation (including `--output`), and command target precedence.
  * Added Unix-only file permission and `build_file` content tests.
  * Improved CLI test assertions and ensured a previously missing CLI test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->