### PR TITLE
Quality: Panic on non-UTF8 stdlib file content via `.unwrap()`

### DIFF
--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -5,8 +5,7 @@ pub fn resolve<T: Into<String>>(path: T) -> Option<String> {
     let path = path.into();
 
     if let Some(module) = STDLIB.get_file(path + ".ab") {
-        let module = module.contents_utf8().unwrap().to_string();
-        Some(module)
+        module.contents_utf8().ok().map(|s| s.to_string())
     } else {
         None
     }


### PR DESCRIPTION
## Problem

`module.contents_utf8().unwrap()` will panic if the embedded file contains non-UTF8 bytes. While unlikely for `.ab` source files, this is a library — callers have no way to handle this gracefully, and a panic in a library is a hard crash for any embedding application. The `resolve` function returns `Option<String>` (the idiomatic pattern), so a failure here should return `None` instead of panicking.


**Severity**: `high`
**File**: `src/stdlib.rs`

## Solution

pub fn resolve<T: Into<String>>(path: T) -> Option<String> {
    let path = path.into();
    if let Some(module) = STDLIB.get_file(path + ".ab") {
        module.contents_utf8().ok().map(|s| s.to_string())
    } else {
        None
    }
}


## Changes

- `src/stdlib.rs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid text content so the app no longer crashes when a module cannot be converted to UTF-8.
  * If content decoding fails, the result is now safely treated as unavailable instead of triggering a panic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->