### PR TITLE
Add remaining error tests

### DIFF
--- a/src/tests/erroring/array_missing_separator.ab
+++ b/src/tests/erroring/array_missing_separator.ab
@@ -1,0 +1,4 @@
+// Output
+// Expected ',' or ']' after array value
+
+let a = [1 2]

--- a/src/tests/erroring/builtin_await_invalid_type.ab
+++ b/src/tests/erroring/builtin_await_invalid_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin function `await` can only be used with values of type Int or [Int]
+
+main {
+    await("pid") ?
+}

--- a/src/tests/erroring/builtin_cd_invalid_type.ab
+++ b/src/tests/erroring/builtin_cd_invalid_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin function `cd` can only be used with values of type Text
+
+main {
+    cd(1) ?
+}

--- a/src/tests/erroring/builtin_cp_force_invalid_type.ab
+++ b/src/tests/erroring/builtin_cp_force_invalid_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin function `cp` can only be used with 3rd argument of type Bool
+
+main {
+    cp("source", "destination", "force") ?
+}

--- a/src/tests/erroring/builtin_cp_source_invalid_type.ab
+++ b/src/tests/erroring/builtin_cp_source_invalid_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin function `cp` can only be used with values of type Text
+
+main {
+    cp(1, "destination") ?
+}

--- a/src/tests/erroring/builtin_disown_invalid_type.ab
+++ b/src/tests/erroring/builtin_disown_invalid_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin function `disown` can only be used with values of type Int or [Int]
+
+main {
+    disown("pid")
+}

--- a/src/tests/erroring/builtin_len_invalid_type.ab
+++ b/src/tests/erroring/builtin_len_invalid_type.ab
@@ -1,0 +1,4 @@
+// Output
+// Length can only be applied to text or array types
+
+echo(len 1)

--- a/src/tests/erroring/builtin_lock_invalid_type.ab
+++ b/src/tests/erroring/builtin_lock_invalid_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin function `lock` can only be used with values of type Text
+
+main {
+    lock(1) ?
+}

--- a/src/tests/erroring/builtin_ls_first_arg_invalid_type.ab
+++ b/src/tests/erroring/builtin_ls_first_arg_invalid_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin function `ls` can only be used with 1st argument of type Text
+
+main {
+    echo(ls(1) ?)
+}

--- a/src/tests/erroring/builtin_ls_second_arg_invalid_type.ab
+++ b/src/tests/erroring/builtin_ls_second_arg_invalid_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin function `ls` can only be used with 2nd argument of type Bool
+
+main {
+    echo(ls(".", 1) ?)
+}

--- a/src/tests/erroring/builtin_ls_silent_modifier.ab
+++ b/src/tests/erroring/builtin_ls_silent_modifier.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin `ls` can't be used with the silent modifier.
+
+main {
+    silent ls() ?
+}

--- a/src/tests/erroring/builtin_ls_third_arg_invalid_type.ab
+++ b/src/tests/erroring/builtin_ls_third_arg_invalid_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin function `ls` can only be used with 3rd argument of type Bool
+
+main {
+    echo(ls(".", true, 1) ?)
+}

--- a/src/tests/erroring/builtin_mv_source_invalid_type.ab
+++ b/src/tests/erroring/builtin_mv_source_invalid_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin function `mv` can only be used with values of type Text
+
+main {
+    mv(1, "destination") ?
+}

--- a/src/tests/erroring/builtin_rm_first_arg_invalid_type.ab
+++ b/src/tests/erroring/builtin_rm_first_arg_invalid_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin function `rm` can only be used with 1st argument of type Text
+
+main {
+    rm(1) ?
+}

--- a/src/tests/erroring/builtin_rm_second_arg_invalid_type.ab
+++ b/src/tests/erroring/builtin_rm_second_arg_invalid_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin function `rm` can only be used with optional 2nd argument of type Bool
+
+main {
+    rm("path", 1) ?
+}

--- a/src/tests/erroring/builtin_rm_third_arg_invalid_type.ab
+++ b/src/tests/erroring/builtin_rm_third_arg_invalid_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin function `rm` can only be used with 3rd argument of type Bool
+
+main {
+    rm("path", true, 1) ?
+}

--- a/src/tests/erroring/builtin_sleep_invalid_type.ab
+++ b/src/tests/erroring/builtin_sleep_invalid_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin function `sleep` can only be used with values of type Int or Num
+
+main {
+    sleep("duration") ?
+}

--- a/src/tests/erroring/builtin_touch_invalid_type.ab
+++ b/src/tests/erroring/builtin_touch_invalid_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Builtin function `touch` can only be used with values of type Text
+
+main {
+    touch(1) ?
+}

--- a/src/tests/erroring/destructuring_assignment_non_array.ab
+++ b/src/tests/erroring/destructuring_assignment_non_array.ab
@@ -1,0 +1,5 @@
+// Output
+// Destructuring assignment requires an array type, but received 'Int'
+
+let x = 1
+[x] = 2

--- a/src/tests/erroring/destructuring_assignment_unknown_array.ab
+++ b/src/tests/erroring/destructuring_assignment_unknown_array.ab
@@ -1,0 +1,6 @@
+// Output
+// Cannot destructure array because its concrete type is unknown
+
+let a = []
+let x = 1
+[x] = a

--- a/src/tests/erroring/destructuring_init_non_array.ab
+++ b/src/tests/erroring/destructuring_init_non_array.ab
@@ -1,0 +1,4 @@
+// Output
+// Destructuring initialization requires an array type, but received 'Int'
+
+let [x] = 1

--- a/src/tests/erroring/destructuring_init_unknown_array.ab
+++ b/src/tests/erroring/destructuring_init_unknown_array.ab
@@ -1,0 +1,5 @@
+// Output
+// Cannot destructure array because its concrete type is unknown
+
+let a = []
+let [x] = a

--- a/src/tests/erroring/fail_invalid_exit_code_type.ab
+++ b/src/tests/erroring/fail_invalid_exit_code_type.ab
@@ -1,0 +1,6 @@
+// Output
+// Invalid exit code
+
+main {
+    fail "not an int"
+}

--- a/src/tests/erroring/fail_outside_function_or_main.ab
+++ b/src/tests/erroring/fail_outside_function_or_main.ab
@@ -1,0 +1,4 @@
+// Output
+// Fail statement outside of function or main
+
+fail 1

--- a/src/tests/erroring/failable_cp.ab
+++ b/src/tests/erroring/failable_cp.ab
@@ -1,0 +1,6 @@
+// Output
+// The `cp` command can fail and requires explicit failure handling. Use '?', 'failed', 'succeeded', or 'exited' to manage its result.
+
+main {
+    cp("source", "destination")
+}

--- a/src/tests/erroring/failable_lock.ab
+++ b/src/tests/erroring/failable_lock.ab
@@ -1,0 +1,6 @@
+// Output
+// The `lock` builtin can fail and requires explicit failure handling. Use '?', 'failed', 'succeeded', or 'exited' to manage its result.
+
+main {
+    lock("/tmp/amber-test.lock")
+}

--- a/src/tests/erroring/failable_ls.ab
+++ b/src/tests/erroring/failable_ls.ab
@@ -1,0 +1,6 @@
+// Output
+// The `ls` command can fail and requires explicit failure handling. Use '?', 'failed', 'succeeded', or 'exited' to manage its result.
+
+main {
+    echo(ls())
+}

--- a/src/tests/erroring/failable_mv.ab
+++ b/src/tests/erroring/failable_mv.ab
@@ -1,0 +1,6 @@
+// Output
+// The `mv` command can fail and requires explicit failure handling. Use '?', 'failed', 'succeeded', or 'exited' to manage its result.
+
+main {
+    mv("source", "destination")
+}

--- a/src/tests/erroring/failable_rm.ab
+++ b/src/tests/erroring/failable_rm.ab
@@ -1,0 +1,6 @@
+// Output
+// The `rm` command can fail and requires explicit failure handling. Use '?', 'failed', 'succeeded', or 'exited' to manage its result.
+
+main {
+    rm("/tmp/amber-test")
+}

--- a/src/tests/erroring/failable_sleep.ab
+++ b/src/tests/erroring/failable_sleep.ab
@@ -1,0 +1,6 @@
+// Output
+// The `sleep` builtin can fail and requires explicit failure handling. Use '?', 'failed', 'succeeded', or 'exited' to manage its result.
+
+main {
+    sleep(1)
+}

--- a/src/tests/erroring/function_optional_arg_after_optional.ab
+++ b/src/tests/erroring/function_optional_arg_after_optional.ab
@@ -1,0 +1,6 @@
+// Output
+// All arguments following an optional argument must also be optional
+
+fun foo(a = 1, b) {
+    echo(a)
+}

--- a/src/tests/erroring/function_optional_arg_type_mismatch.ab
+++ b/src/tests/erroring/function_optional_arg_type_mismatch.ab
@@ -1,0 +1,6 @@
+// Output
+// Optional argument does not match annotated type
+
+fun foo(a: Text = 1) {
+    echo(a)
+}

--- a/src/tests/erroring/function_ref_optional_arg.ab
+++ b/src/tests/erroring/function_ref_optional_arg.ab
@@ -1,0 +1,6 @@
+// Output
+// A ref cannot be optional
+
+fun foo(ref a = 1) {
+    echo(a)
+}

--- a/src/tests/erroring/modifier_silent_after_suppress.ab
+++ b/src/tests/erroring/modifier_silent_after_suppress.ab
@@ -1,0 +1,6 @@
+// Output
+// You already declared `suppress` modifier before. You can't use them in conjunction.
+
+main {
+    suppress silent $ echo "test" $?
+}

--- a/src/tests/erroring/modifier_suppress_after_silent.ab
+++ b/src/tests/erroring/modifier_suppress_after_silent.ab
@@ -1,0 +1,6 @@
+// Output
+// You already declared `silent` modifier before. You can't use them in conjunction.
+
+main {
+    silent suppress $ echo "test" $?
+}

--- a/src/tests/erroring/public_mutable_variable.ab
+++ b/src/tests/erroring/public_mutable_variable.ab
@@ -1,0 +1,4 @@
+// Output
+// Public variables must be constants
+
+pub let foo = 1

--- a/src/tests/erroring/public_mutable_variable_destructuring.ab
+++ b/src/tests/erroring/public_mutable_variable_destructuring.ab
@@ -1,0 +1,4 @@
+// Output
+// Public variables must be constants
+
+pub let [foo] = [1]

--- a/src/tests/erroring/return_outside_function.ab
+++ b/src/tests/erroring/return_outside_function.ab
@@ -1,0 +1,4 @@
+// Output
+// Return statement outside of function
+
+return 1

--- a/src/tests/erroring/test_in_local_scope.ab
+++ b/src/tests/erroring/test_in_local_scope.ab
@@ -1,0 +1,6 @@
+// Output
+// Test must be in the global scope
+
+if true {
+    test "local" {}
+}


### PR DESCRIPTION
Relates to the closed #438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for many error cases, including invalid argument types for common built-ins, missing separators in arrays, destructuring issues, optional-argument rules, and invalid use of `return`/`fail` outside functions.
  * Added checks for command behavior when failure handling is required, including cases for file and process-related commands.
  * Added validation for public variables and test declarations to ensure they follow language rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->