### PR TITLE
Leftover fixes after recent changes

### DIFF
--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -198,19 +198,20 @@ variable_index = '[', expression, ']' ;
 variable_init_mut = { attribute }, [ VISIBILITY ], KEYWORD_LET, identifier, '=', expression ;
 variable_init_const = { attribute }, [ VISIBILITY ], KEYWORD_CONST, identifier, '=', expression ;
 variable_get = identifier ;
-variable_set = identifier, variable_index?, '=', expression ;
+variable_set = identifier, [ variable_index ], '=', expression ;
 
 (* Function *)
 function_call = command_modifier, identifier, '(', [ expression, { ',', expression } ], ')' ;
 function_call_failed = function_call, [ handler ] ;
 function_def = { attribute }, [ VISIBILITY ], KEYWORD_FUN, identifier, '(',
-    [ [ KEYWORD_REF ], identifier, [ ':', TYPE ], { ',', [ KEYWORD_REF ], identifier, [ ':', TYPE ] } ],
-    ')', [ ':', TYPE ], [ '?' ], block ;
+    [ function_arg, { ',', function_arg } ],
+    ')', [ ':', TYPE, [ '?' ] ], block ;
+function_arg = [ KEYWORD_REF ], identifier, [ ':', TYPE ], [ '=', expression ] ;
 
 (* Loop *)
 loop = KEYWORD_LOOP, block ;
-loop_array = KEYWORD_FOR | KEYWORD_LOOP, identifier, KEYWORD_IN, expression, block ;
-loop_array_iterator = KEYWORD_FOR | KEYWORD_LOOP, identifier, ',', identifier, KEYWORD_IN, expression, block ;
+loop_array = KEYWORD_FOR, identifier, KEYWORD_IN, expression, block ;
+loop_array_iterator = KEYWORD_FOR, identifier, ',', identifier, KEYWORD_IN, expression, block ;
 while_loop = KEYWORD_WHILE, expression, block ;
 
 (* Ranges *)
@@ -223,7 +224,7 @@ if_chain = KEYWORD_IF, '{', { expression, block }, [ KEYWORD_ELSE, block ],  '}'
 ternary = expression, KEYWORD_THEN, expression, KEYWORD_ELSE, expression ;
 
 (* Main *)
-main = KEYWORD_MAIN, [ '(', identifier, ')' ], [ '?' ], block ;
+main = KEYWORD_MAIN, [ '(', identifier, ')' ], block ;
 
 (* Imports *)
 import_path = '"', { ANY_CHAR }, '"' ;
@@ -268,29 +269,29 @@ comment = '//', { ANY_CHAR }, '\n' ;
 builtins_statement = builtin_await | builtin_cd | builtin_clear | builtin_cp | builtin_disown | builtin_echo | builtin_exit | builtin_lock | builtin_mv | builtin_rm | builtin_sleep | builtin_touch ;
 
 (* Builtins *)
-builtin_await = KEYWORD_AWAIT, expression ;
-builtin_cd = KEYWORD_CD, expression ;
-builtin_clear = KEYWORD_CLEAR ;
-builtin_cp = KEYWORD_CP, expression ;
-builtin_disown = KEYWORD_DISOWN, expression ;
-builtin_echo = KEYWORD_ECHO, expression ;
-builtin_exit = KEYWORD_EXIT, expression ;
-builtin_lock = KEYWORD_LOCK, expression ;
-builtin_mv = KEYWORD_MV, expression ;
-builtin_rm = KEYWORD_RM, expression ;
-builtin_sleep = KEYWORD_SLEEP, expression ;
-builtin_touch = KEYWORD_TOUCH, expression ;
+builtin_await = KEYWORD_AWAIT, '(', [ expression, { ',', expression } ], ')' ;
+builtin_cd = KEYWORD_CD, '(', [ expression, { ',', expression } ], ')' ;
+builtin_clear = KEYWORD_CLEAR, '(', ')' ;
+builtin_cp = KEYWORD_CP, '(', [ expression, { ',', expression } ], ')' ;
+builtin_disown = KEYWORD_DISOWN, '(', [ expression, { ',', expression } ], ')' ;
+builtin_echo = KEYWORD_ECHO, '(', [ expression, { ',', expression } ], ')' ;
+builtin_exit = KEYWORD_EXIT, '(', [ expression, { ',', expression } ], ')' ;
+builtin_lock = KEYWORD_LOCK, '(', [ expression, { ',', expression } ], ')' ;
+builtin_mv = KEYWORD_MV, '(', [ expression, { ',', expression } ], ')' ;
+builtin_rm = KEYWORD_RM, '(', [ expression, { ',', expression } ], ')' ;
+builtin_sleep = KEYWORD_SLEEP, '(', [ expression, { ',', expression } ], ')' ;
+builtin_touch = KEYWORD_TOUCH, '(', [ expression, { ',', expression } ], ')' ;
 
 builtins_expression = builtin_len | builtin_lines | builtin_ls | builtin_nameof | builtin_pid | builtin_pwd | builtin_shellname | builtin_shellversion ;
 
-builtin_len = KEYWORD_LEN, expression ;
-builtin_lines = KEYWORD_LINES, expression ;
-builtin_ls = KEYWORD_LS, expression ;
-builtin_nameof = KEYWORD_NAMEOF, expression ;
-builtin_pid = KEYWORD_PID ;
-builtin_pwd = KEYWORD_PWD, expression ;
-builtin_shellname = KEYWORD_SHELLNAME ;
-builtin_shellversion = KEYWORD_SHELLVERSION ;
+builtin_len = KEYWORD_LEN, '(', [ expression, { ',', expression } ], ')' ;
+builtin_lines = KEYWORD_LINES, '(', [ expression, { ',', expression } ], ')' ;
+builtin_ls = KEYWORD_LS, '(', [ expression, { ',', expression } ], ')' ;
+builtin_nameof = KEYWORD_NAMEOF, '(', [ expression, { ',', expression } ], ')' ;
+builtin_pid = KEYWORD_PID, '(', ')' ;
+builtin_pwd = KEYWORD_PWD, '(', ')' ;
+builtin_shellname = KEYWORD_SHELLNAME, '(', ')' ;
+builtin_shellversion = KEYWORD_SHELLVERSION, '(', ')' ;
 
 
 (* Test *)

--- a/src/modules/builtin/len.rs
+++ b/src/modules/builtin/len.rs
@@ -28,7 +28,15 @@ impl UnOp for Len {
     }
 
     fn parse_operator(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
+        let position = meta.get_index();
         token(meta, "len")?;
+        let has_parens = meta.get_current_token().is_some_and(|tok| tok.word == "(");
+        if !has_parens {
+            let tok = meta.get_token_at(position);
+            let warning = Message::new_warn_at_token(meta, tok)
+                .message("Calling a builtin without parentheses is deprecated");
+            meta.add_message(warning);
+        }
         Ok(())
     }
 }

--- a/src/modules/builtin/mv.rs
+++ b/src/modules/builtin/mv.rs
@@ -100,27 +100,30 @@ impl TypeCheckModule for Mv {
 
 impl TranslateModule for Mv {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        meta.with_silenced(self.modifier.is_silent || meta.silenced, |meta| {
-            meta.with_sudoed(self.modifier.is_sudo || meta.sudoed, |meta| {
-                let source = self.source.translate(meta);
-                let destination = self.destination.translate(meta);
-                let handler = self.failure_handler.translate(meta);
-                let silent = meta.gen_silent().to_frag();
-                let sudo_prefix = meta.gen_sudo_prefix().to_frag();
-                let translation = fragments!("mv ", source, " ", destination);
+        let source = self.source.translate(meta);
+        let destination = self.destination.translate(meta);
+        let handler = self.failure_handler.translate(meta);
+        let sudo_prefix = meta.with_sudoed(self.modifier.is_sudo || meta.sudoed, |meta| {
+            meta.gen_sudo_prefix().to_frag()
+        });
+        let silent = meta.with_silenced(self.modifier.is_silent || meta.silenced, |meta| {
+            meta.gen_silent().to_frag()
+        });
+        let suppress = meta.with_suppress(self.modifier.is_suppress || meta.suppress, |meta| {
+            meta.gen_suppress().to_frag()
+        });
+        let translation = fragments!("mv ", source, " ", destination);
 
-                BlockFragment::new(
-                    vec![
-                        ListFragment::new(vec![sudo_prefix, translation, silent])
-                            .with_spaces()
-                            .to_frag(),
-                        handler,
-                    ],
-                    false,
-                )
-                .to_frag()
-            })
-        })
+        BlockFragment::new(
+            vec![
+                ListFragment::new(vec![sudo_prefix, translation, suppress, silent])
+                    .with_spaces()
+                    .to_frag(),
+                handler,
+            ],
+            false,
+        )
+        .to_frag()
     }
 }
 

--- a/src/modules/expression/binop/range.rs
+++ b/src/modules/expression/binop/range.rs
@@ -105,7 +105,7 @@ impl Range {
         let from_var = meta.push_ephemeral_variable(from_var_stmt).to_frag();
 
         let to = self.to.translate(meta);
-        let to_var_stmt = VarStmtFragment::new("to", self.from.kind.clone(), to);
+        let to_var_stmt = VarStmtFragment::new("to", self.to.kind.clone(), to);
         let to_var = meta.push_ephemeral_variable(to_var_stmt).to_frag();
 
         let forward_to = self.adjust_end_for_forward_range(to_var.clone());

--- a/src/tests/compiling/mv_suppress.ab
+++ b/src/tests/compiling/mv_suppress.ab
@@ -1,0 +1,7 @@
+main {
+    trust suppress mv("source", "destination")
+
+    trust suppress {
+        mv("source", "destination")
+    }
+}

--- a/src/tests/erroring/variable_ref_length.ab
+++ b/src/tests/erroring/variable_ref_length.ab
@@ -6,4 +6,4 @@ fun foo(ref value) {
 }
 
 let array = [1, 2, 3]
-foo(len array)
+foo(len(array))

--- a/src/tests/grammar_ebnf.rs
+++ b/src/tests/grammar_ebnf.rs
@@ -141,11 +141,11 @@ fn grammar_contains_function_def_with_ref_and_failable() {
 }
 
 #[test]
-fn grammar_contains_main_with_failable() {
+fn grammar_contains_main() {
     let g = generate_grammar_ebnf();
     assert!(
-        g.contains("main = KEYWORD_MAIN, [ '(', identifier, ')' ], [ '?' ], block ;"),
-        "main should support optional failable marker"
+        g.contains("main = KEYWORD_MAIN, [ '(', identifier, ')' ], block ;"),
+        "main should support optional args identifier"
     );
 }
 
@@ -158,7 +158,7 @@ fn grammar_contains_status_expression() {
 #[test]
 fn grammar_contains_documentation_comment() {
     let g = generate_grammar_ebnf();
-    assert!(g.contains("comment_doc = '///', { ANY_CHAR } ;"));
+    assert!(g.contains(r"comment_doc = '///', { ANY_CHAR - '\n' }, '\n' ;"));
 }
 
 #[test]

--- a/src/tests/optimizing/ephemeral_vars_length.ab
+++ b/src/tests/optimizing/ephemeral_vars_length.ab
@@ -1,2 +1,2 @@
 let a = "this is interesting"
-echo(len a)
+echo(len(a))

--- a/src/tests/snapshots/amber__tests__compiling__mv_suppress.ab__bash-3.2.snap
+++ b/src/tests/snapshots/amber__tests__compiling__mv_suppress.ab__bash-3.2.snap
@@ -1,0 +1,8 @@
+---
+source: src/tests/compiling.rs
+expression: ast
+---
+mv "source" "destination" 2>/dev/null
+__status=$?
+mv "source" "destination" 2>/dev/null
+__status=$?

--- a/src/tests/snapshots/amber__tests__compiling__mv_suppress.ab__bash-4.3.snap
+++ b/src/tests/snapshots/amber__tests__compiling__mv_suppress.ab__bash-4.3.snap
@@ -1,0 +1,8 @@
+---
+source: src/tests/compiling.rs
+expression: ast
+---
+mv "source" "destination" 2>/dev/null
+__status=$?
+mv "source" "destination" 2>/dev/null
+__status=$?

--- a/src/tests/snapshots/amber__tests__compiling__mv_suppress.ab__zsh.snap
+++ b/src/tests/snapshots/amber__tests__compiling__mv_suppress.ab__zsh.snap
@@ -1,0 +1,8 @@
+---
+source: src/tests/compiling.rs
+expression: ast
+---
+mv "source" "destination" 2>/dev/null
+__status=$?
+mv "source" "destination" 2>/dev/null
+__status=$?

--- a/src/tests/validity/len.ab
+++ b/src/tests/validity/len.ab
@@ -10,13 +10,13 @@ let name = "Andrew"
 let fruits = ["apple", "banana", "cherry", "date"]
 
 fun foo(ref text, ref arr) {
-  echo("Text reference: {len text}")
-  echo("Array reference: {len arr}")
+  echo("Text reference: {len(text)}")
+  echo("Array reference: {len(arr)}")
 }
 
-echo("Text literal: {len "Hello"}")
-echo("Array literal: {len [1, 2, 3]}")
-echo("Text variable: {len name}")
-echo("Array variable: {len fruits}")
+echo("Text literal: {len("Hello")}")
+echo("Array literal: {len([1, 2, 3])}")
+echo("Text variable: {len(name)}")
+echo("Array variable: {len(fruits)}")
 
 foo(name, fruits)

--- a/src/tests/warning/deprecated_builtins.ab
+++ b/src/tests/warning/deprecated_builtins.ab
@@ -6,6 +6,7 @@ import * from "std/fs"
 // Calling a builtin without parentheses is deprecated
 // Calling a builtin without parentheses is deprecated
 // Calling a builtin without parentheses is deprecated
+// Calling a builtin without parentheses is deprecated
 // hello
 
 main {
@@ -17,4 +18,5 @@ main {
     // Enter a temporary directory for mutating builtins
     trust cd(temp_dir_create("deprecated_builtins.XXXXXX", true, false)?)
     trust touch "test.txt"
+    echo(len "abc")
 }

--- a/src/utils/grammar_ebnf.rs
+++ b/src/utils/grammar_ebnf.rs
@@ -147,19 +147,20 @@ variable_index = '[', expression, ']' ;
 variable_init_mut = { attribute }, [ VISIBILITY ], KEYWORD_LET, identifier, '=', expression ;
 variable_init_const = { attribute }, [ VISIBILITY ], KEYWORD_CONST, identifier, '=', expression ;
 variable_get = identifier ;
-variable_set = identifier, variable_index?, '=', expression ;
+variable_set = identifier, [ variable_index ], '=', expression ;
 
 (* Function *)
 function_call = command_modifier, identifier, '(', [ expression, { ',', expression } ], ')' ;
 function_call_failed = function_call, [ handler ] ;
 function_def = { attribute }, [ VISIBILITY ], KEYWORD_FUN, identifier, '(',
-    [ [ KEYWORD_REF ], identifier, [ ':', TYPE ], { ',', [ KEYWORD_REF ], identifier, [ ':', TYPE ] } ],
-    ')', [ ':', TYPE ], [ '?' ], block ;
+    [ function_arg, { ',', function_arg } ],
+    ')', [ ':', TYPE, [ '?' ] ], block ;
+function_arg = [ KEYWORD_REF ], identifier, [ ':', TYPE ], [ '=', expression ] ;
 
 (* Loop *)
 loop = KEYWORD_LOOP, block ;
-loop_array = KEYWORD_FOR | KEYWORD_LOOP, identifier, KEYWORD_IN, expression, block ;
-loop_array_iterator = KEYWORD_FOR | KEYWORD_LOOP, identifier, ',', identifier, KEYWORD_IN, expression, block ;
+loop_array = KEYWORD_FOR, identifier, KEYWORD_IN, expression, block ;
+loop_array_iterator = KEYWORD_FOR, identifier, ',', identifier, KEYWORD_IN, expression, block ;
 while_loop = KEYWORD_WHILE, expression, block ;
 
 (* Ranges *)
@@ -172,7 +173,7 @@ if_chain = KEYWORD_IF, '{', { expression, block }, [ KEYWORD_ELSE, block ],  '}'
 ternary = expression, KEYWORD_THEN, expression, KEYWORD_ELSE, expression ;
 
 (* Main *)
-main = KEYWORD_MAIN, [ '(', identifier, ')' ], [ '?' ], block ;
+main = KEYWORD_MAIN, [ '(', identifier, ')' ], block ;
 
 (* Imports *)
 import_path = '"', { ANY_CHAR }, '"' ;
@@ -200,7 +201,7 @@ return_stmt = KEYWORD_RETURN, expression ;
 fail = KEYWORD_FAIL, [ expression ] ;
 
 (* Documentation comment *)
-comment_doc = '///', { ANY_CHAR } ;
+comment_doc = '///', { ANY_CHAR - '\n' }, '\n' ;
 
 (* Type operations *)
 cast = expression, KEYWORD_AS, TYPE ;
@@ -252,11 +253,12 @@ pub fn generate_grammar_ebnf() -> String {
         let kw_upper = kw.to_uppercase();
         let builtin_name = format!("builtin_{}", kw);
         match *kw {
-            "clear" => {
-                builtin_stmt_rules.push_str(&format!("{} = KEYWORD_{} ;\n", builtin_name, kw_upper))
-            }
+            "clear" => builtin_stmt_rules.push_str(&format!(
+                "{} = KEYWORD_{}, '(', ')' ;\n",
+                builtin_name, kw_upper
+            )),
             _ => builtin_stmt_rules.push_str(&format!(
-                "{} = KEYWORD_{}, expression ;\n",
+                "{} = KEYWORD_{}, '(', [ expression, {{ ',', expression }} ], ')' ;\n",
                 builtin_name, kw_upper
             )),
         }
@@ -269,11 +271,12 @@ pub fn generate_grammar_ebnf() -> String {
         let kw_upper = kw.to_uppercase();
         let builtin_name = format!("builtin_{}", kw);
         match *kw {
-            "pid" | "shellname" | "shellversion" => {
-                builtin_expr_rules.push_str(&format!("{} = KEYWORD_{} ;\n", builtin_name, kw_upper))
-            }
+            "pid" | "pwd" | "shellname" | "shellversion" => builtin_expr_rules.push_str(&format!(
+                "{} = KEYWORD_{}, '(', ')' ;\n",
+                builtin_name, kw_upper
+            )),
             _ => builtin_expr_rules.push_str(&format!(
-                "{} = KEYWORD_{}, expression ;\n",
+                "{} = KEYWORD_{}, '(', [ expression, {{ ',', expression }} ], ')' ;\n",
                 builtin_name, kw_upper
             )),
         }


### PR DESCRIPTION
I ran Fable 5 on the codebase to check if there is anything that requires fixing. What we fixed:
- Eliminated leftover use of `loop` in a `for..in` context
- Removed `?` in `main` block in EBNF context
- `len` was treated like a prefix - changed it to work like a builtin
- `mv` now supports suppress keyword
- added left over fixes in grammar.ebnf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in commands and expressions now use consistent parenthesized call syntax, including comma-separated arguments where applicable.
  * `len(...)` is supported, with warnings for the older syntax.
  * Added support for suppressing output from `mv` commands and blocks.

* **Bug Fixes**
  * Improved parsing for assignments, function parameters, loops, and `main` declarations.
  * Corrected range handling for upper-bound values.

* **Tests**
  * Updated grammar, syntax, warning, and optimization coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->