### PR TITLE
fix(bash): shellcheck errors

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -263,32 +263,34 @@ impl AmberCompiler {
     fn gen_preamble(
         &self,
         sudo_used: bool,
-        shell_metadata_used: bool,
+        shellname_used: bool,
+        shellversion_used: bool,
         target_shell: &ShellType,
     ) -> FragmentKind {
         let mut preamble = Vec::new();
         match target_shell {
             ShellType::BashModern | ShellType::BashLegacy => (),
             ShellType::Zsh => {
-                // if the shell is ZSH:
-                // - emulate ksh (ksh arrays, word splitting, ...) which matches more with bash
-                // enable BSD_echo; prevents backslashes from being interpreted twice (causes "\\\\" to return "\")
                 preamble.push(RawFragment::new(r#"emulate ksh"#).to_frag());
                 preamble.push(RawFragment::new(r#"setopt BSD_echo"#).to_frag());
                 preamble.push(RawFragment::new(r#"__read_args='-A'"#).to_frag());
             }
             ShellType::Ksh => {
-                // if the shell is KSH:
-                // - enable job control
                 preamble.push(RawFragment::new(r#"set -m"#).to_frag());
             }
         }
         if sudo_used {
             preamble.push(RawFragment::new(include_str!("preambles/sudo.sh").trim_end()).to_frag());
         }
-        if shell_metadata_used {
+        if shellname_used {
             preamble.push(
-                RawFragment::new(include_str!("preambles/shellname-shellversion.sh").trim_end())
+                RawFragment::new(include_str!("preambles/shellname.sh").trim_end())
+                    .to_frag(),
+            );
+        }
+        if shellversion_used {
+            preamble.push(
+                RawFragment::new(include_str!("preambles/shellversion.sh").trim_end())
                     .to_frag(),
             );
         }
@@ -306,7 +308,8 @@ impl AmberCompiler {
         // Add preamble that contains all code that should be executed before the main code
         result.append(self.gen_preamble(
             sudo_used,
-            shellname_used || shellversion_used,
+            shellname_used,
+            shellversion_used,
             &meta_translate.target.shell,
         ));
 

--- a/src/modules/block.rs
+++ b/src/modules/block.rs
@@ -16,9 +16,12 @@ pub struct Block {
 }
 
 impl Block {
-    // Get whether this block is empty
     pub fn is_empty(&self) -> bool {
         self.statements.is_empty()
+    }
+
+    pub fn terminates_control_flow(&self) -> bool {
+        self.statements.iter().any(|stmt| stmt.terminates_control_flow())
     }
 
     pub fn with_condition(mut self) -> Self {
@@ -106,12 +109,17 @@ impl TypeCheckModule for Block {
 
 impl TranslateModule for Block {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        // Save the current statement queue and create a new one
         let mut new_queue = VecDeque::new();
         std::mem::swap(&mut meta.stmt_queue, &mut new_queue);
         let result = {
             let mut statements = vec![];
             for statement in &self.statements {
+                if statement.terminates_control_flow() {
+                    let statement = statement.translate(meta);
+                    statements.extend(meta.stmt_queue.drain(..));
+                    statements.push(statement);
+                    break;
+                }
                 let statement = statement.translate(meta);
                 statements.extend(meta.stmt_queue.drain(..));
                 statements.push(statement);
@@ -121,7 +129,6 @@ impl TranslateModule for Block {
                 .with_condition(self.is_conditional)
                 .to_frag()
         };
-        // Restore the old statement queue
         std::mem::swap(&mut meta.stmt_queue, &mut new_queue);
         result
     }

--- a/src/modules/condition/ifchain.rs
+++ b/src/modules/condition/ifchain.rs
@@ -21,15 +21,17 @@ crate::impl_documentation_noop!(IfChain);
 
 impl IfChain {
     pub fn terminates_control_flow(&self) -> bool {
-        if let Some((_, first_cond, first_block)) = self.cond_blocks.first() {
-            if first_cond.analyze_control_flow() == Some(true) {
-                return first_block.terminates_control_flow();
+        for (_, cond, block) in &self.cond_blocks {
+            if cond.analyze_control_flow() == Some(true) {
+                return block.terminates_control_flow();
             }
         }
-        let all_terminate = self.cond_blocks.iter().all(|(_, _, block)| block.terminates_control_flow());
+        let all_terminate = self
+            .cond_blocks
+            .iter()
+            .all(|(_, _, block)| block.terminates_control_flow());
         match (&self.false_block, all_terminate) {
             (Some((_, false_block)), true) => false_block.terminates_control_flow(),
-            (None, true) => false,
             _ => false,
         }
     }
@@ -94,7 +96,11 @@ impl SyntaxModule<ParserMetadata> for IfChain {
                 syntax(meta, &mut *false_block)?;
                 self.false_block = Some((comments, false_block));
                 if token(meta, "}").is_err() {
-                    error!(meta, meta.get_current_token(), "Expected `else` condition to be the last in the if chain")?;
+                    error!(
+                        meta,
+                        meta.get_current_token(),
+                        "Expected `else` condition to be the last in the if chain"
+                    )?;
                 }
                 return Ok(());
             }

--- a/src/modules/condition/ifchain.rs
+++ b/src/modules/condition/ifchain.rs
@@ -20,6 +20,20 @@ pub struct IfChain {
 crate::impl_documentation_noop!(IfChain);
 
 impl IfChain {
+    pub fn terminates_control_flow(&self) -> bool {
+        if let Some((_, first_cond, first_block)) = self.cond_blocks.first() {
+            if first_cond.analyze_control_flow() == Some(true) {
+                return first_block.terminates_control_flow();
+            }
+        }
+        let all_terminate = self.cond_blocks.iter().all(|(_, _, block)| block.terminates_control_flow());
+        match (&self.false_block, all_terminate) {
+            (Some((_, false_block)), true) => false_block.terminates_control_flow(),
+            (None, true) => false,
+            _ => false,
+        }
+    }
+
     fn warn_dead_code(meta: &mut ParserMetadata, pos: PositionInfo, reason: &str) {
         if meta.context.cc_flags.contains(&CCFlags::AllowDeadCode) {
             return;

--- a/src/modules/condition/ifchain.rs
+++ b/src/modules/condition/ifchain.rs
@@ -94,11 +94,7 @@ impl SyntaxModule<ParserMetadata> for IfChain {
                 syntax(meta, &mut *false_block)?;
                 self.false_block = Some((comments, false_block));
                 if token(meta, "}").is_err() {
-                    return error!(
-                        meta,
-                        meta.get_current_token(),
-                        "Expected `else` condition to be the last in the if chain"
-                    )?;
+                    error!(meta, meta.get_current_token(), "Expected `else` condition to be the last in the if chain")?;
                 }
                 return Ok(());
             }

--- a/src/modules/condition/ifcond.rs
+++ b/src/modules/condition/ifcond.rs
@@ -55,6 +55,17 @@ impl IfCondition {
             ));
         meta.add_message(message);
     }
+
+    pub fn terminates_control_flow(&self) -> bool {
+        match self.expr.analyze_control_flow() {
+            Some(true) => self.true_block.as_ref().map(|b| b.terminates_control_flow()).unwrap_or(false),
+            Some(false) => self.false_block.as_ref().map(|b| b.terminates_control_flow()).unwrap_or(false),
+            None => match (&self.true_block, &self.false_block) {
+                (Some(true_block), Some(false_block)) => true_block.terminates_control_flow() && false_block.terminates_control_flow(),
+                _ => false,
+            },
+        }
+    }
 }
 
 impl SyntaxModule<ParserMetadata> for IfCondition {
@@ -172,3 +183,4 @@ impl TranslateModule for IfCondition {
 }
 
 crate::impl_documentation_noop!(IfCondition);
+

--- a/src/modules/function/declaration.rs
+++ b/src/modules/function/declaration.rs
@@ -90,7 +90,7 @@ impl FunctionDeclaration {
                             )
                             .with_local(true)
                             .with_ref(true)
-                            .with_optimization_when_unused(false);
+                            .with_optimization_when_unused(true);
 
                             let var = VarStmtFragment::new(
                                 &name,
@@ -98,7 +98,7 @@ impl FunctionDeclaration {
                                 VarExprFragment::new(&source_name, kind.clone()).to_frag(),
                             )
                             .with_local(true)
-                            .with_optimization_when_unused(false);
+                            .with_optimization_when_unused(true);
 
                             result.push(source_ref.to_frag());
                             result.push(var.to_frag());
@@ -110,7 +110,7 @@ impl FunctionDeclaration {
 
                             let var = VarStmtFragment::new(&name, kind.clone(), val.to_frag())
                                 .with_local(true)
-                                .with_optimization_when_unused(false);
+                                .with_optimization_when_unused(true);
 
                             result.push(var.to_frag())
                         }
@@ -123,21 +123,21 @@ impl FunctionDeclaration {
                         let var = if matches!(meta.target.shell, ShellType::Zsh) {
                             VarStmtFragment::new(&name, kind.clone(), val.to_frag())
                                 .with_local(true)
-                                .with_optimization_when_unused(false)
+                                .with_optimization_when_unused(true)
                                 .with_ref(false)
                                 .with_array_ref(true)
                                 .with_declared(false)
                         } else if meta.target.shell.is_bash_legacy() {
                             VarStmtFragment::new(&name, kind.clone(), val.to_frag())
                                 .with_local(true)
-                                .with_optimization_when_unused(false)
+                                .with_optimization_when_unused(true)
                                 .with_ref(true)
                                 .with_array_ref(true)
                                 .with_declared(false)
                         } else {
                             VarStmtFragment::new(&name, kind.clone(), val.to_frag())
                                 .with_local(true)
-                                .with_optimization_when_unused(false)
+                                .with_optimization_when_unused(true)
                                 .with_ref(true)
                                 .with_array_ref(true)
                         };
@@ -151,7 +151,7 @@ impl FunctionDeclaration {
 
                         let var = VarStmtFragment::new(&name, kind.clone(), val.to_frag())
                             .with_local(true)
-                            .with_optimization_when_unused(false)
+                            .with_optimization_when_unused(true)
                             .with_declared(!arg.is_ref)
                             .with_ref(arg.is_ref);
 

--- a/src/modules/function/declaration.rs
+++ b/src/modules/function/declaration.rs
@@ -90,7 +90,7 @@ impl FunctionDeclaration {
                             )
                             .with_local(true)
                             .with_ref(true)
-                            .with_optimization_when_unused(false);
+                            .with_optimization_when_unused(true);
 
                             let var = VarStmtFragment::new(
                                 &name,

--- a/src/modules/function/declaration.rs
+++ b/src/modules/function/declaration.rs
@@ -90,7 +90,7 @@ impl FunctionDeclaration {
                             )
                             .with_local(true)
                             .with_ref(true)
-                            .with_optimization_when_unused(true);
+                            .with_optimization_when_unused(false);
 
                             let var = VarStmtFragment::new(
                                 &name,
@@ -123,24 +123,24 @@ impl FunctionDeclaration {
                         let var = if matches!(meta.target.shell, ShellType::Zsh) {
                             VarStmtFragment::new(&name, kind.clone(), val.to_frag())
                                 .with_local(true)
-                                .with_optimization_when_unused(true)
+                                .with_optimization_when_unused(false)
                                 .with_ref(false)
                                 .with_array_ref(true)
                                 .with_declared(false)
                         } else if meta.target.shell.is_bash_legacy() {
                             VarStmtFragment::new(&name, kind.clone(), val.to_frag())
                                 .with_local(true)
-                                .with_optimization_when_unused(true)
+                                .with_optimization_when_unused(false)
                                 .with_ref(true)
                                 .with_array_ref(true)
                                 .with_declared(false)
                         } else {
                             VarStmtFragment::new(&name, kind.clone(), val.to_frag())
                                 .with_local(true)
-                                .with_optimization_when_unused(true)
+                                .with_optimization_when_unused(false)
                                 .with_ref(true)
                                 .with_array_ref(true)
-                        };
+                            };
 
                         result.push(var.to_frag())
                     }
@@ -151,7 +151,7 @@ impl FunctionDeclaration {
 
                         let var = VarStmtFragment::new(&name, kind.clone(), val.to_frag())
                             .with_local(true)
-                            .with_optimization_when_unused(true)
+                            .with_optimization_when_unused(!arg.is_ref)
                             .with_declared(!arg.is_ref)
                             .with_ref(arg.is_ref);
 

--- a/src/modules/function/declaration.rs
+++ b/src/modules/function/declaration.rs
@@ -140,7 +140,7 @@ impl FunctionDeclaration {
                                 .with_optimization_when_unused(false)
                                 .with_ref(true)
                                 .with_array_ref(true)
-                            };
+                        };
 
                         result.push(var.to_frag())
                     }

--- a/src/modules/function/invocation.rs
+++ b/src/modules/function/invocation.rs
@@ -189,7 +189,7 @@ impl TypeCheckModule for FunctionInvocation {
                 self.failure_handler.typecheck(meta)?;
             } else if self.failure_handler.is_parsed && !meta.context.is_trust_ctx {
                 let message = Message::new_warn_at_token(meta, self.name_tok.clone())
-                    .message(format!("Function '{}' cannot fail", &self.name))
+                    .message(format!("Function '{}' cannot fail", self.name))
                     .comment("You can remove the failure handler block or '?' at the end");
                 meta.add_message(message);
             }

--- a/src/modules/statement/stmt.rs
+++ b/src/modules/statement/stmt.rs
@@ -181,3 +181,18 @@ impl DocumentationModule for Statement {
         self.value.as_ref().unwrap().document(meta)
     }
 }
+
+impl Statement {
+    pub fn terminates_control_flow(&self) -> bool {
+        match &self.value {
+            Some(StmtType::Return(_)) => true,
+            Some(StmtType::Exit(_)) => true,
+            Some(StmtType::Fail(_)) => true,
+            Some(StmtType::Break(_)) => true,
+            Some(StmtType::Continue(_)) => true,
+            Some(StmtType::IfCondition(if_cond)) => if_cond.terminates_control_flow(),
+            Some(StmtType::IfChain(if_chain)) => if_chain.terminates_control_flow(),
+            _ => false,
+        }
+    }
+}

--- a/src/modules/statement/stmt.rs
+++ b/src/modules/statement/stmt.rs
@@ -188,10 +188,12 @@ impl Statement {
             Some(StmtType::Return(_)) => true,
             Some(StmtType::Exit(_)) => true,
             Some(StmtType::Fail(_)) => true,
-            Some(StmtType::Break(_)) => true,
-            Some(StmtType::Continue(_)) => true,
             Some(StmtType::IfCondition(if_cond)) => if_cond.terminates_control_flow(),
             Some(StmtType::IfChain(if_chain)) => if_chain.terminates_control_flow(),
+            Some(StmtType::CommandModifier(cmd_mod)) => cmd_mod
+                .block
+                .as_ref()
+                .map_or(false, |b| b.terminates_control_flow()),
             _ => false,
         }
     }

--- a/src/modules/statement/stmt.rs
+++ b/src/modules/statement/stmt.rs
@@ -193,7 +193,7 @@ impl Statement {
             Some(StmtType::CommandModifier(cmd_mod)) => cmd_mod
                 .block
                 .as_ref()
-                .map_or(false, |b| b.terminates_control_flow()),
+                .is_some_and(|b| b.terminates_control_flow()),
             _ => false,
         }
     }

--- a/src/preambles/shellname.sh
+++ b/src/preambles/shellname.sh
@@ -1,0 +1,7 @@
+if [ -n "$ZSH_VERSION" ]; then
+    EXEC_SHELL="zsh"
+elif [ -n "$KSH_VERSION" ]; then
+    EXEC_SHELL="ksh"
+else
+    EXEC_SHELL="bash"
+fi

--- a/src/preambles/shellversion.sh
+++ b/src/preambles/shellversion.sh
@@ -1,18 +1,15 @@
 if [ -n "$ZSH_VERSION" ]; then
-    # zsh: use set -A for array assignment
     __exec_shell_version="$ZSH_VERSION"
     __exec_shell_version="${__exec_shell_version%% (}"
-    __exec_v1="${__exec_shell_version%%.*}"
-    __exec_shell_version="${__exec_shell_version#*.}"
-    __exec_v2="${__exec_shell_version%%.*}"
-    __exec_shell_version="${__exec_shell_version#*.}"
-    __exec_v3="${__exec_shell_version%% .*}"
-    __exec_v3="${__exec_v3%% *}"
+    IFS='.' read -r __exec_v1 __exec_v2 __exec_v3 <<< "${__exec_shell_version}"
     set -A EXEC_SHELL_VERSION -- "${__exec_v1:-0}" "${__exec_v2:-0}" "${__exec_v3:-0}"
 elif [ -n "$KSH_VERSION" ]; then
     __exec_shell_version="${KSH_VERSION#Version }"
+    __exec_shell_version="${__exec_shell_version#* }"
     __exec_shell_version="${__exec_shell_version%% *}"
-    IFS='.' read -r __exec_v1 __exec_v2 __exec_v3 <<< "${__exec_shell_version}"
+    __exec_v1="${__exec_shell_version%%[!0-9]*}"
+    __exec_v2=0
+    __exec_v3=0
     EXEC_SHELL_VERSION=(${__exec_v1:-0} ${__exec_v2:-0} ${__exec_v3:-0})
 else
     EXEC_SHELL_VERSION=("${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}" "${BASH_VERSINFO[2]}")

--- a/src/preambles/shellversion.sh
+++ b/src/preambles/shellversion.sh
@@ -1,8 +1,10 @@
 if [ -n "$ZSH_VERSION" ]; then
     IFS='.' read -r -A EXEC_SHELL_VERSION <<< "$ZSH_VERSION"
 elif [ -n "$KSH_VERSION" ]; then
-    __exec_shell_version="${.sh.version##*/}"
-    IFS='.' read -r -a EXEC_SHELL_VERSION <<< "${__exec_shell_version%% *}"
+    __exec_shell_version="${KSH_VERSION#Version }"
+    __exec_shell_version="${__exec_shell_version%% *}"
+    IFS='.' read -r __exec_v1 __exec_v2 __exec_v3 <<< "${__exec_shell_version}"
+    EXEC_SHELL_VERSION=(${__exec_v1:-0} ${__exec_v2:-0} ${__exec_v3:-0})
 else
     EXEC_SHELL_VERSION=("${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}" "${BASH_VERSINFO[2]}")
 fi

--- a/src/preambles/shellversion.sh
+++ b/src/preambles/shellversion.sh
@@ -1,5 +1,14 @@
 if [ -n "$ZSH_VERSION" ]; then
-    IFS='.' read -r -A EXEC_SHELL_VERSION <<< "$ZSH_VERSION"
+    # zsh: use set -A for array assignment
+    __exec_shell_version="$ZSH_VERSION"
+    __exec_shell_version="${__exec_shell_version%% (}"
+    __exec_v1="${__exec_shell_version%%.*}"
+    __exec_shell_version="${__exec_shell_version#*.}"
+    __exec_v2="${__exec_shell_version%%.*}"
+    __exec_shell_version="${__exec_shell_version#*.}"
+    __exec_v3="${__exec_shell_version%% .*}"
+    __exec_v3="${__exec_v3%% *}"
+    set -A EXEC_SHELL_VERSION -- "${__exec_v1:-0}" "${__exec_v2:-0}" "${__exec_v3:-0}"
 elif [ -n "$KSH_VERSION" ]; then
     __exec_shell_version="${KSH_VERSION#Version }"
     __exec_shell_version="${__exec_shell_version%% *}"

--- a/src/preambles/shellversion.sh
+++ b/src/preambles/shellversion.sh
@@ -1,0 +1,8 @@
+if [ -n "$ZSH_VERSION" ]; then
+    IFS='.' read -r -A EXEC_SHELL_VERSION <<< "$ZSH_VERSION"
+elif [ -n "$KSH_VERSION" ]; then
+    __exec_shell_version="${.sh.version##*/}"
+    IFS='.' read -r -a EXEC_SHELL_VERSION <<< "${__exec_shell_version%% *}"
+else
+    EXEC_SHELL_VERSION=("${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}" "${BASH_VERSINFO[2]}")
+fi

--- a/src/tests/compiling.rs
+++ b/src/tests/compiling.rs
@@ -237,9 +237,12 @@ main {
         "Output should contain the zsh shellversion preamble"
     );
     assert!(
-        result
-            .contains(r#"IFS='.' read -r -a EXEC_SHELL_VERSION <<< "${__exec_shell_version%% *}""#),
+        result.contains("__exec_shell_version=\"${KSH_VERSION#Version }\""),
         "Output should contain the ksh shellversion preamble"
+    );
+    assert!(
+        result.contains(r"EXEC_SHELL_VERSION=(${__exec_v1:-0} ${__exec_v2:-0} ${__exec_v3:-0})"),
+        "Output should contain the ksh EXEC_SHELL_VERSION assignment"
     );
     assert!(
         result.contains(
@@ -254,7 +257,7 @@ main {
 }
 
 #[test]
-fn test_translate_shellname_and_shellversion_share_single_preamble() {
+fn test_translate_shellname_and_shellversion_use_separate_preambles() {
     let code = r#"
 main {
     echo(shellname())
@@ -264,9 +267,11 @@ main {
     let result = translate_compiler_output_with_target(code, Some(ShellType::BashModern))
         .expect("Couldn't translate Amber code");
 
+    // With separate preamble files, both shellname and shellversion blocks should appear
     assert_eq!(
         result.matches(r#"if [ -n "$ZSH_VERSION" ]; then"#).count(),
-        1
+        2,
+        "Both shellname.sh and shellversion.sh should generate preamble blocks"
     );
     assert!(result.contains("EXEC_SHELL"));
     assert!(result.contains("EXEC_SHELL_VERSION"));

--- a/src/tests/compiling.rs
+++ b/src/tests/compiling.rs
@@ -254,6 +254,18 @@ main {
         result.contains("EXEC_SHELL_VERSION[0]"),
         "Output should reference the shellversion builtin variable"
     );
+    assert!(
+        result.contains("IFS='.' read -r __exec_v1 __exec_v2 __exec_v3"),
+        "Output should use IFS-based parsing for zsh version (handles 2-component versions)"
+    );
+    assert!(
+        result.contains("${__exec_shell_version#* }"),
+        "Output should skip the ksh build ID word before extracting the version"
+    );
+    assert!(
+        result.contains("[!0-9]*"),
+        "Output should extract leading digits from ksh version string"
+    );
 }
 
 #[test]

--- a/src/tests/compiling.rs
+++ b/src/tests/compiling.rs
@@ -233,8 +233,8 @@ main {
         .expect("Couldn't translate Amber code");
 
     assert!(
-        result.contains(r#"IFS='.' read -r -A EXEC_SHELL_VERSION <<< "$ZSH_VERSION""#),
-        "Output should contain the zsh shellversion preamble"
+        result.contains("set -A EXEC_SHELL_VERSION"),
+        "Output should contain the zsh shellversion preamble (set -A)"
     );
     assert!(
         result.contains("__exec_shell_version=\"${KSH_VERSION#Version }\""),

--- a/src/translate/fragments/var_stmt.rs
+++ b/src/translate/fragments/var_stmt.rs
@@ -151,7 +151,21 @@ impl VarStmtFragment {
                     assignment
                 }
             }
-            ShellType::BashLegacy | ShellType::Zsh => {
+            ShellType::Zsh => {
+                if self.is_local {
+                    if is_running_command {
+                        format!("local {var_name}\n{}{assignment}", meta.gen_indent())
+                    } else if self.is_ref {
+                        // zsh uses 'typeset -n' for namerefs, not 'local -n'
+                        format!("typeset -n {assignment}")
+                    } else {
+                        format!("local {assignment}")
+                    }
+                } else {
+                    assignment
+                }
+            }
+            ShellType::BashLegacy | ShellType::Ksh => {
                 if self.is_local {
                     if is_running_command {
                         format!("local {var_name}\n{}{assignment}", meta.gen_indent())

--- a/src/translate/fragments/var_stmt.rs
+++ b/src/translate/fragments/var_stmt.rs
@@ -151,21 +151,7 @@ impl VarStmtFragment {
                     assignment
                 }
             }
-            ShellType::Zsh => {
-                if self.is_local {
-                    if is_running_command {
-                        format!("local {var_name}\n{}{assignment}", meta.gen_indent())
-                    } else if self.is_ref {
-                        // zsh uses 'typeset -n' for namerefs, not 'local -n'
-                        format!("typeset -n {assignment}")
-                    } else {
-                        format!("local {assignment}")
-                    }
-                } else {
-                    assignment
-                }
-            }
-            ShellType::BashLegacy => {
+            ShellType::BashLegacy | ShellType::Zsh => {
                 if self.is_local {
                     if is_running_command {
                         format!("local {var_name}\n{}{assignment}", meta.gen_indent())
@@ -186,8 +172,7 @@ impl VarStmtFragment {
                     if self.kind.is_array() && value.is_empty() {
                         format!("typeset -a {assignment}")
                     } else if self.is_ref {
-                        // ksh93 supports 'nameref' as a builtin for name references
-                        format!("nameref {assignment}")
+                        format!("typeset -n {assignment}")
                     } else if self.kind.is_array() {
                         // ksh function-local arrays are required for recursive array operations to keep
                         // each frame isolated once the argument has been rebound through a nameref.

--- a/src/translate/fragments/var_stmt.rs
+++ b/src/translate/fragments/var_stmt.rs
@@ -165,7 +165,7 @@ impl VarStmtFragment {
                     assignment
                 }
             }
-            ShellType::BashLegacy | ShellType::Ksh => {
+            ShellType::BashLegacy => {
                 if self.is_local {
                     if is_running_command {
                         format!("local {var_name}\n{}{assignment}", meta.gen_indent())
@@ -186,7 +186,8 @@ impl VarStmtFragment {
                     if self.kind.is_array() && value.is_empty() {
                         format!("typeset -a {assignment}")
                     } else if self.is_ref {
-                        format!("typeset -n {assignment}")
+                        // ksh93 supports 'nameref' as a builtin for name references
+                        format!("nameref {assignment}")
                     } else if self.kind.is_array() {
                         // ksh function-local arrays are required for recursive array operations to keep
                         // each frame isolated once the argument has been rebound through a nameref.


### PR DESCRIPTION
I used `array_sorted` as reference to fix some shellcheck errors.
There are still some errors in that test because it is an huge task but removes 2317 from everywhere and helps a bit with 2034.

Also split the preamble script in 2 different files in this way loads only the part that is needed base on the compilation itself.

The code was generated by AI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved shell detection: `EXEC_SHELL` prefers Zsh when both Zsh and Ksh are present, and `EXEC_SHELL_VERSION` is now derived more robustly across Zsh, Ksh, and Bash.
  * Shell name and shell version preambles are generated independently.

* **Bug Fixes**
  * Script generation now stops immediately after terminating statements, and correctly recognizes fully-terminating `if/else` chains.

* **Performance**
  * Improved handling of function argument variables by enabling “unused argument” optimizations more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->