### PR TITLE
feat: add support for --shebang flag

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -239,7 +239,7 @@ impl AmberCompiler {
     }
 
     fn gen_header(&self, target_shell: ShellType) -> String {
-        let header_template = if let Some(dynamic) = &self.options.header_path {
+        let mut header_template = if let Some(dynamic) = &self.options.header_path {
             fs::read_to_string(dynamic).unwrap_or_else(|_| {
                 let msg = format!("Couldn't read the dynamic header file from path '{dynamic}'");
                 Message::new_err_msg(msg).show();
@@ -248,6 +248,16 @@ impl AmberCompiler {
         } else {
             include_str!("header.sh").trim_end().to_string()
         };
+
+        if !self.options.header_path.is_some() {
+            let shebang = self
+                .options
+                .shebang
+                .clone()
+                .unwrap_or_else(|| String::from("#!/usr/bin/env {{ shell }}"));
+            header_template = format!("{}\n{}\n", shebang, header_template);
+        }
+
         let shell_name = target_shell.family_name();
         header_template
             .replace("{{ version }}", get_version())
@@ -363,10 +373,7 @@ impl AmberCompiler {
 
         Ok(format!(
             "{}\n{}\n{}",
-            self.options
-                .shebang
-                .clone()
-                .unwrap_or_else(|| self.gen_header(meta_translate.target.shell)),
+            self.gen_header(meta_translate.target.shell),
             result,
             self.gen_footer()
         ))

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -254,6 +254,7 @@ impl AmberCompiler {
                 .options
                 .shebang
                 .clone()
+                .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| String::from("#!/usr/bin/env {{ shell }}"));
             header_template = format!("{}\n{}\n", shebang, header_template);
         }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -112,9 +112,6 @@ impl CompilerOptions {
         if let Ok(path) = std::env::var("AMBER_FOOTER") {
             self.footer_path = Some(path);
         }
-        if let Ok(path) = std::env::var("AMBER_SHEBANG") {
-            self.shebang = Some(path);
-        }
         self
     }
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -49,6 +49,7 @@ pub struct CompilerOptions {
     pub no_optimize: bool,
     pub header_path: Option<String>,
     pub footer_path: Option<String>,
+    pub shebang: Option<String>,
 }
 
 impl Default for CompilerOptions {
@@ -65,6 +66,7 @@ impl Default for CompilerOptions {
             no_optimize: false,
             header_path: None,
             footer_path: None,
+            shebang: None,
         }
     }
 }
@@ -88,6 +90,7 @@ impl CompilerOptions {
             no_optimize: false,
             header_path: None,
             footer_path: None,
+            shebang: None,
         }
     }
 
@@ -108,6 +111,9 @@ impl CompilerOptions {
         }
         if let Ok(path) = std::env::var("AMBER_FOOTER") {
             self.footer_path = Some(path);
+        }
+        if let Ok(path) = std::env::var("AMBER_SHEBANG") {
+            self.shebang = Some(path);
         }
         self
     }
@@ -355,7 +361,10 @@ impl AmberCompiler {
 
         Ok(format!(
             "{}\n{}\n{}",
-            self.gen_header(meta_translate.target.shell),
+            self.options
+                .shebang
+                .clone()
+                .unwrap_or(self.gen_header(meta_translate.target.shell)),
             result,
             self.gen_footer()
         ))

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -119,6 +119,11 @@ impl CompilerOptions {
         self.target = target;
         self
     }
+
+    pub fn with_shebang(mut self, shebang: Option<String>) -> Self {
+        self.shebang = shebang;
+        self
+    }
 }
 
 pub struct AmberCompiler {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -364,7 +364,7 @@ impl AmberCompiler {
             self.options
                 .shebang
                 .clone()
-                .unwrap_or(self.gen_header(meta_translate.target.shell)),
+                .unwrap_or_else(|| self.gen_header(meta_translate.target.shell)),
             result,
             self.gen_footer()
         ))

--- a/src/header.sh
+++ b/src/header.sh
@@ -1,3 +1,2 @@
-#!/usr/bin/env {{ shell }}
 # Written in [Amber](https://amber-lang.com/)
 # version: {{ version }}

--- a/src/main.rs
+++ b/src/main.rs
@@ -518,9 +518,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             0
         }
         CommandKind::Build(command) => {
-            if let Some(shebang) = command.shebang.clone() {
-                std::env::set_var("AMBER_SHEBANG", shebang);
-            };
             handle_build(command, cli.target)?;
             0
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,9 @@ struct BuildCommand {
     /// Code generation target shell
     #[arg(long)]
     target: Option<ShellType>,
+
+    #[arg(long)]
+    shebang: Option<String>,
 }
 
 #[derive(Args, Clone, Debug)]
@@ -515,6 +518,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             0
         }
         CommandKind::Build(command) => {
+            if let Some(shebang) = command.shebang.clone() {
+                std::env::set_var("AMBER_SHEBANG", shebang);
+            };
             handle_build(command, cli.target)?;
             0
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -420,7 +420,8 @@ fn create_output_dir(command: &BuildCommand, file: &Path) -> PathBuf {
 fn build_file(command: &BuildCommand, target: &Option<ShellType>, input: PathBuf, output: PathBuf) {
     let options = CompilerOptions::from_args(&command.no_proc, command.minify, false, None)
         .with_target(*target)
-        .with_env_vars();
+        .with_env_vars()
+        .with_shebang(command.shebang.clone());
 
     let (code, _) = compile_input(input, options);
     write_output(output, code);

--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -674,3 +674,24 @@ fn test_cli_shebang_no_value() {
             "a value is required for '--shebang <SHEBANG>",
         ));
 }
+
+#[test]
+fn test_cli_shebang_empty_string() {
+    let mut cmd = Command::new(amber_bin());
+    let output = cmd
+        .args([
+            "build",
+            "src/tests/validity/hello_world.ab",
+            "-",
+            "--shebang",
+            "",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout_str = String::from_utf8(output.stdout).expect("Stdout was not UTF-8");
+
+    let first_line = stdout_str.lines().next().expect("Output was empty");
+
+  assert!(first_line.starts_with("#!/usr/bin/env"));
+}

--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -633,3 +633,28 @@ fn test_cli_param_injection() {
 
     let _ = temp_file.close();
 }
+
+#[test]
+fn test_cli_shebang() {
+    let mut cmd = Command::new(amber_bin());
+    cmd.args([
+        "build",
+        "src/tests/validity/hello_world.ab",
+        "-",
+        "--shebang",
+        "#!/usr/bin/env nu",
+    ])
+    .assert()
+    .success();
+}
+
+#[test]
+fn test_cli_shebang_no_value() {
+    let mut cmd = Command::new(amber_bin());
+    cmd.args(["build", "src/tests/validity/hello_world.ab", "--shebang"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "a value is required for '--shebang <SHEBANG>",
+        ));
+}

--- a/src/tests/cli.rs
+++ b/src/tests/cli.rs
@@ -637,15 +637,31 @@ fn test_cli_param_injection() {
 #[test]
 fn test_cli_shebang() {
     let mut cmd = Command::new(amber_bin());
-    cmd.args([
-        "build",
-        "src/tests/validity/hello_world.ab",
-        "-",
-        "--shebang",
-        "#!/usr/bin/env nu",
-    ])
-    .assert()
-    .success();
+    let output = cmd
+        .args([
+            "build",
+            "src/tests/validity/hello_world.ab",
+            "-",
+            "--shebang",
+            "#!/usr/bin/env nu",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout_str = String::from_utf8(output.stdout).expect("Stdout was not UTF-8");
+
+    let first_line = stdout_str.lines().next().expect("Output was empty");
+
+    assert_eq!(first_line, "#!/usr/bin/env nu");
+
+    let lines = stdout_str.lines();
+
+    let shebang_count = lines.filter(|line| line.starts_with("#!")).count();
+    assert_eq!(
+        shebang_count, 1,
+        "Expected only one shebang line in generated header. Got {}",
+        shebang_count
+    );
 }
 
 #[test]

--- a/src/tests/functional.rs
+++ b/src/tests/functional.rs
@@ -22,6 +22,7 @@ fn test_create_output_with_output_flag() {
         no_proc: vec![],
         minify: false,
         target: None,
+        shebang: None,
     };
 
     let result = create_output(&cmd);
@@ -39,6 +40,7 @@ fn test_create_output_with_stdin() {
         no_proc: vec![],
         minify: false,
         target: None,
+        shebang: None,
     };
 
     let result = create_output(&cmd);
@@ -56,6 +58,7 @@ fn test_create_output_default_extension() {
         no_proc: vec![],
         minify: false,
         target: None,
+        shebang: None,
     };
 
     let result = create_output(&cmd);
@@ -240,6 +243,7 @@ fn test_create_output_dir_with_output_flag() {
         no_proc: vec![],
         minify: false,
         target: None,
+        shebang: None,
     };
     
     let input_file = PathBuf::from("src/test.ab");
@@ -258,6 +262,7 @@ fn test_create_output_dir_without_output_flag() {
         no_proc: vec![],
         minify: false,
         target: None,
+        shebang: None,
     };
     
     let input_file = PathBuf::from("src/test.ab");
@@ -352,6 +357,7 @@ fn test_build_file() {
         no_proc: vec![],
         minify: false,
         target: None,
+        shebang: None,
     };
     
     let target: Option<ShellType> = None;


### PR DESCRIPTION
This feature sets the "AMBER_SHEBANG" environment variable if a `--shebang` option is supplied to `amber build`. This was recommended in an issue (ref: https://github.com/amber-lang/amber/issues/1137), so I thought I'd give it a go.

I am sure there are better or more idiomatic ways of handling this case, but my implementation has a fairly small amount of code changed (16 lines added, 1 changed).

The clones of the shebang option could likely be avoided, but in my opinion, the cost of the clone is so small it should be trivial in most cases.

I was suggested to submit a pr (ref: https://github.com/amber-lang/amber/issues/1137#issuecomment-5203617185)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom shebang in generated scripts.
  * The build command now accepts an optional `--shebang` argument.
  * Custom shebangs are included when no custom header file is configured.
  * Generated scripts continue using the default shell shebang when no value is provided or an empty value is supplied.
* **Bug Fixes**
  * Added validation to report an error when `--shebang` is missing its value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->