### PR TITLE
Fix while loops with boolean variables in conditions

### DIFF
--- a/src/modules/loops/while_loop.rs
+++ b/src/modules/loops/while_loop.rs
@@ -26,22 +26,7 @@ impl SyntaxModule<ParserMetadata> for WhileLoop {
 
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         token(meta, "while")?;
-        // Parse the condition expression
-        let tok = meta.get_current_token();
         syntax(meta, &mut self.condition)?;
-
-        // Validate that the condition is a boolean expression
-        if ! matches!(self.condition.get_type(), Type::Bool | Type::Text | Type::Array(_)) {
-            return error!(
-                meta,
-                tok,
-                format!(
-                    "Expected boolean expression in while condition, got {}",
-                    self.condition.get_type()
-                )
-            );
-        }
-
         syntax(meta, &mut self.block)?;
         Ok(())
     }
@@ -50,7 +35,18 @@ impl SyntaxModule<ParserMetadata> for WhileLoop {
 impl TypeCheckModule for WhileLoop {
     fn typecheck(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         self.condition.typecheck(meta)?;
-        // Save loop context state and set it to true
+
+        if ! matches!(self.condition.get_type(), Type::Bool | Type::Text | Type::Array(_)) {
+            return error_pos!(
+                meta,
+                self.condition.get_position(),
+                format!(
+                    "Expected boolean expression in while condition, got {}",
+                    self.condition.get_type()
+                )
+            );
+        }
+
         meta.with_context_fn(Context::set_is_loop_ctx, true, |meta| {
             self.block.typecheck(meta)
         })?;

--- a/src/tests/compiling/while_loop_bool_var.ab
+++ b/src/tests/compiling/while_loop_bool_var.ab
@@ -1,0 +1,11 @@
+main {
+    let my_condition = true
+    while my_condition {
+        const i = 1
+        if i <= 3: {
+            echo(i)
+            my_condition = false
+        }
+        else: { break }
+    }
+}

--- a/src/tests/erroring/while_loop_condition_int.ab
+++ b/src/tests/erroring/while_loop_condition_int.ab
@@ -1,0 +1,6 @@
+// Output
+// Expected boolean expression in while condition, got Int
+
+while 5 {
+    echo 1
+}

--- a/src/tests/snapshots/amber__tests__compiling__while_loop_bool_var.ab__bash-3.2.snap
+++ b/src/tests/snapshots/amber__tests__compiling__while_loop_bool_var.ab__bash-3.2.snap
@@ -1,0 +1,15 @@
+---
+source: src/tests/compiling.rs
+assertion_line: 79
+expression: ast
+---
+my_condition_0=1
+while [[ "${my_condition_0}" != 0 ]]; do
+    i_1=1
+    if (( i_1 <= 3 )); then
+        echo "${i_1}"
+        my_condition_0=0
+    else
+        break
+    fi
+done

--- a/src/tests/snapshots/amber__tests__compiling__while_loop_bool_var.ab__bash-4.3.snap
+++ b/src/tests/snapshots/amber__tests__compiling__while_loop_bool_var.ab__bash-4.3.snap
@@ -1,0 +1,15 @@
+---
+source: src/tests/compiling.rs
+assertion_line: 65
+expression: ast
+---
+my_condition_0=1
+while [[ "${my_condition_0}" != 0 ]]; do
+    i_1=1
+    if (( i_1 <= 3 )); then
+        echo "${i_1}"
+        my_condition_0=0
+    else
+        break
+    fi
+done

--- a/src/tests/snapshots/amber__tests__compiling__while_loop_bool_var.ab__ksh.snap
+++ b/src/tests/snapshots/amber__tests__compiling__while_loop_bool_var.ab__ksh.snap
@@ -1,0 +1,15 @@
+---
+source: src/tests/compiling.rs
+assertion_line: 79
+expression: ast
+---
+my_condition_0=1
+while [[ "${my_condition_0}" != 0 ]]; do
+    i_1=1
+    if (( i_1 <= 3 )); then
+        echo "${i_1}"
+        my_condition_0=0
+    else
+        break
+    fi
+done

--- a/src/tests/snapshots/amber__tests__compiling__while_loop_bool_var.ab__zsh.snap
+++ b/src/tests/snapshots/amber__tests__compiling__while_loop_bool_var.ab__zsh.snap
@@ -1,0 +1,15 @@
+---
+source: src/tests/compiling.rs
+assertion_line: 79
+expression: ast
+---
+my_condition_0=1
+while [[ "${my_condition_0}" != 0 ]]; do
+    i_1=1
+    if (( i_1 <= 3 )); then
+        echo "${i_1}"
+        my_condition_0=0
+    else
+        break
+    fi
+done


### PR DESCRIPTION
Reopens the work from #1150 after its accidental merge was rolled back from `staging` in #1151.

## Summary

- Move while-condition validation into type checking.
- Report invalid condition errors at the condition’s source position.
- Add a compiling regression test for boolean variables in while conditions.
- Include snapshots for all supported shell targets.

## Testing

- Added and updated compilation snapshot coverage for the regression case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for `while` loop conditions.
  * Invalid non-boolean conditions now produce clearer errors pointing to the condition’s location.
  * Loop bodies are checked only after the condition is validated, improving compilation feedback.

* **Tests**
  * Added coverage for loops controlled by boolean variables, including normal completion and alternate exit paths.
  * Added coverage confirming that integer conditions are rejected with the expected error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->