### PR TITLE
feat: add compile time parameters

### DIFF
--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -102,6 +102,7 @@ KEYWORD_MV = 'mv' ;
 KEYWORD_NAMEOF = 'nameof' ;
 KEYWORD_NOT = 'not' ;
 KEYWORD_OR = 'or' ;
+KEYWORD_PARAM = 'param' ;
 KEYWORD_PID = 'pid' ;
 KEYWORD_PUB = 'pub' ;
 KEYWORD_PWD = 'pwd' ;
@@ -282,12 +283,13 @@ builtin_rm = KEYWORD_RM, '(', [ expression, { ',', expression } ], ')' ;
 builtin_sleep = KEYWORD_SLEEP, '(', [ expression, { ',', expression } ], ')' ;
 builtin_touch = KEYWORD_TOUCH, '(', [ expression, { ',', expression } ], ')' ;
 
-builtins_expression = builtin_len | builtin_lines | builtin_ls | builtin_nameof | builtin_pid | builtin_pwd | builtin_shellname | builtin_shellversion ;
+builtins_expression = builtin_len | builtin_lines | builtin_ls | builtin_nameof | builtin_param | builtin_pid | builtin_pwd | builtin_shellname | builtin_shellversion ;
 
 builtin_len = KEYWORD_LEN, '(', [ expression, { ',', expression } ], ')' ;
 builtin_lines = KEYWORD_LINES, '(', [ expression, { ',', expression } ], ')' ;
 builtin_ls = KEYWORD_LS, '(', [ expression, { ',', expression } ], ')' ;
 builtin_nameof = KEYWORD_NAMEOF, '(', [ expression, { ',', expression } ], ')' ;
+builtin_param = KEYWORD_PARAM, '(', [ expression, { ',', expression } ], ')' ;
 builtin_pid = KEYWORD_PID, '(', ')' ;
 builtin_pwd = KEYWORD_PWD, '(', ')' ;
 builtin_shellname = KEYWORD_SHELLNAME, '(', ')' ;

--- a/src/modules/builtin/mod.rs
+++ b/src/modules/builtin/mod.rs
@@ -10,6 +10,7 @@ pub mod lock;
 pub mod ls;
 pub mod mv;
 pub mod nameof;
+pub mod param;
 pub mod pid;
 pub mod pwd;
 pub mod rm;

--- a/src/modules/builtin/param.rs
+++ b/src/modules/builtin/param.rs
@@ -1,0 +1,91 @@
+use crate::modules::expression::interpolated_region::{InterpolatedRegionType, parse_interpolated_region};
+use crate::modules::expression::literal::text::TextPart;
+
+use crate::modules::prelude::*;
+use crate::modules::types::{Type, Typed};
+use crate::translate::fragments::interpolable::InterpolablePart;
+use crate::translate::module::TranslateModule;
+use crate::utils::{ParserMetadata, TranslateMetadata};
+use heraclitus_compiler::prelude::*;
+
+#[derive(Debug, Clone, AutoKeyword)]
+#[keyword = "param"]
+#[kind = "builtin_expr"]
+pub struct Param {
+    value: String,
+    token: Option<Token>,
+}
+
+impl Typed for Param {
+    fn get_type(&self) -> Type {
+        Type::Text
+    }
+}
+
+impl Param {
+    fn parse_name(&self, meta: &mut ParserMetadata) -> Result<String, Failure> {
+        let mut r = String::new();
+        for p in parse_interpolated_region(meta, &InterpolatedRegionType::Text)? {
+            if let TextPart::String(s) = p {
+                r += s.as_str();
+            } else {
+                let m = Message::new_err_at_token(meta, self.token.clone()).message("Only plain strings are allowed in param()");
+                return Err(Failure::Loud(m))
+            }
+        }
+        Ok(r)
+    }
+}
+
+impl SyntaxModule<ParserMetadata> for Param {
+    syntax_name!("Param");
+
+    fn new() -> Self {
+        Param {
+            value: String::new(),
+            token: None,
+        }
+    }
+
+    fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
+        token(meta, "param")?;
+        self.token = meta.get_current_token();
+        token(meta, "(")?;
+        let n = self.parse_name(meta)?;
+        let d = if token(meta, ",").is_ok() {
+            Some(self.parse_name(meta)?)
+        } else {
+            None
+        };
+        self.value = match std::env::var(&n) {
+            Ok(v) => v,
+            Err(e) => match e {
+                std::env::VarError::NotPresent => {
+                    d.ok_or_else(|| {
+                        Failure::Loud(Message::new_err_at_token(meta, self.token.clone()).message(format!("{}: no such environment variable", n)))
+                    })?
+                },
+                std::env::VarError::NotUnicode(_) => {
+                    return Err(Failure::Loud(Message::new_err_at_token(meta, self.token.clone()).message(format!("{}: unreadable environment variable", n))))
+                }
+            }
+        };
+        token(meta, ")")?;
+        Ok(())
+    }
+}
+
+impl TypeCheckModule for Param {
+    fn typecheck(&mut self, _: &mut ParserMetadata) -> SyntaxResult {
+        // Just plain Text
+        Ok(())
+    }
+}
+
+impl TranslateModule for Param {
+    fn translate(&self, _: &mut TranslateMetadata) -> FragmentKind {
+        InterpolableFragment::new(vec![InterpolablePart::String(self.value.clone())], InterpolableRenderType::StringLiteral).to_frag()
+    }
+}
+
+crate::impl_documentation_noop!(Param);

--- a/src/modules/expression/expr.rs
+++ b/src/modules/expression/expr.rs
@@ -13,7 +13,7 @@ use super::unop::{neg::Neg, not::Not};
 use crate::docs::module::DocumentationModule;
 use crate::modules::builtin::len::Len;
 use crate::modules::builtin::{
-    lines::LinesInvocation, ls::Ls, nameof::Nameof, pid::Pid, pwd::Pwd, shellname::Shellname,
+    lines::LinesInvocation, ls::Ls, nameof::Nameof, param::Param, pid::Pid, pwd::Pwd, shellname::Shellname,
     shellversion::Shellversion,
 };
 use crate::modules::command::cmd::Command;
@@ -75,6 +75,7 @@ pub enum ExprType {
     Access(Access),
     Pwd(Pwd),
     Ls(Ls),
+    Param(Param),
     Pid(Pid),
     Shellname(Shellname),
     Shellversion(Shellversion),
@@ -187,7 +188,7 @@ impl SyntaxModule<ParserMetadata> for Expr {
                 Parentheses, Bool, Number, Integer, Text,
                 Array, Null, Status, Nameof,
                 // Builtin invocation
-                LinesInvocation, Pwd, Ls, Pid, Shellname, Shellversion,
+                LinesInvocation, Pwd, Ls, Param, Pid, Shellname, Shellversion,
                 // Function invocation
                 FunctionInvocation, Command,
                 // Variable access
@@ -241,6 +242,7 @@ impl TypeCheckModule for Expr {
                 Access,
                 Pwd,
                 Ls,
+                Param,
                 Pid,
                 Shellname,
                 Shellversion
@@ -293,6 +295,7 @@ impl TranslateModule for Expr {
                     Access,
                     Pwd,
                     Ls,
+                    Param,
                     Pid,
                     Shellname,
                     Shellversion
@@ -344,6 +347,7 @@ impl DocumentationModule for Expr {
                 Access,
                 Pwd,
                 Ls,
+                Param,
                 Pid,
                 Shellname,
                 Shellversion

--- a/src/tests/extra.rs
+++ b/src/tests/extra.rs
@@ -3,6 +3,7 @@ extern crate test_generator;
 use super::test_amber;
 use super::TestOutcomeTarget;
 use crate::compiler::AmberCompiler;
+use crate::compiler::CompilerOptions;
 use crate::tests::compile_code;
 use std::fs;
 use std::process::Stdio;
@@ -75,4 +76,30 @@ fn download() {
 
     std::thread::sleep(Duration::from_millis(150));
     assert!(server.is_finished(), "Server has not stopped!");
+}
+
+#[test]
+fn invalid_parameter() {
+    let options = CompilerOptions::default();
+    let compiler = AmberCompiler::new(r#"param("my")"#.to_string(), None, options);
+    compiler.compile().unwrap_err();
+}
+
+#[test]
+fn parameter_use_default_value() {
+    let code = r#"echo(param("my", "parameter"))"#;
+    test_amber(&code, "parameter", TestOutcomeTarget::Success);
+}
+
+#[test]
+fn get_parameter() {
+    let code = r#"echo(param("your"))"#;
+    unsafe {
+        std::env::set_var("your", "value");
+    }
+    test_amber(&code, "value", TestOutcomeTarget::Success);
+    // Clear the variable for next tests
+    unsafe {
+        std::env::remove_var("your");
+    }
 }


### PR DESCRIPTION
Hello !

I am a big fan of this project, and I am looking forward to use it in production.

Here is my use case:

* For now I have a lot of scripts deployed by Ansible, with jinja parameters
* I want to use amber to generate these scripts locally, then deploy them using Ansible

I want to set custom parameters at **compile time**.
The easiest solution would be:

```
MODE={{ script_mode }}
...
if MODE == "debug" {
    echo("A lot of output because its debug")
}
```

But I prefer to work with clean amber files.
So instead I propose this:

* Add `--parameter` flags to `build` `eval` and `run` command
* Add a `param(name [, default])` builtin function to retreive these during compilation time
* This builtin `translate` will write the parameter as plain text

```bash
# Will print DEBUG
amber eval --parameter MODE=DEBUG 'echo(param("MODE"))'
# Will print PRODUCTION
amber eval 'echo(param("MODE", "PRODUCTION"))'
# Will fail (at compile time)
amber eval 'echo(param("MODE"))'
```

The PR does that plus:
* `param` takes only plain text as parameter.
* the resolution is done during `SyntaxModule<Param>::parse`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `param(...)` expressions for retrieving values from environment variables.
  * Supports optional default values when parameters are unavailable.
  * Allows zero or more comma-separated expressions as arguments.

* **Bug Fixes**
  * Added validation and clear errors for missing or unreadable required parameters.

* **Tests**
  * Added coverage for valid parameters, defaults, and invalid usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->