### PR TITLE
Refactor fail calls to use parentheses

### DIFF
--- a/src/std/fs.ab
+++ b/src/std/fs.ab
@@ -74,7 +74,7 @@ pub fun symlink_create(origin: Text, destination: Text): Null? {
     }
 
     echo("The file {origin} doesn't exist!")
-    fail 1
+    fail(1)
 }
 
 /// Creates a directory with all parent directories as required.
@@ -112,7 +112,7 @@ pub fun temp_dir_create(
 ): Text? {
     if trim(template) == "" {
         echo("The template cannot be an empty string!")
-        fail 1
+        fail(1)
     }
 
     let filename = ""
@@ -125,7 +125,7 @@ pub fun temp_dir_create(
     }
     if filename == "" {
         echo("Failed to make a temporary directory")
-        fail 1
+        fail(1)
     }
     if auto_delete and shellname() != "ksh"  {
         if force_delete {
@@ -156,7 +156,7 @@ pub fun file_chmod(path: Text, mode: Text): Null? {
     }
 
     echo("The file {path} doesn't exist!")
-    fail 1
+    fail(1)
 }
 
 /// Changes the owner of a file.
@@ -174,7 +174,7 @@ pub fun file_chown(path: Text, user: Text): Null? {
     }
 
     echo("The file {path} doesn't exist!")
-    fail 1
+    fail(1)
 }
 
 /// Finds all files or directories matching multiple file globs. When
@@ -234,12 +234,12 @@ pub fun file_extract(path: Text, target: Text): Null? {
             match_regex(path, "\.(zip|war|jar)$", true): $ unzip -q "{path}" -d "{target}" $?
             else {
                 echo("Error: Unsupported file type")
-                fail 3
+                fail(3)
             }
         }
     } else {
         echo("Error: File not found")
-        fail 2
+        fail(2)
     }
 }
 
@@ -256,18 +256,18 @@ pub fun file_compress(files: [Text], target: Text): Null? {
         match_regex(target, "\.(tar\.bz2|tbz|tbz2)$", true): silent $ tar -cjf "{target}" {files} $?
         match_regex(target, "\.(tar\.gz|tgz)$", true): silent $ tar -czf "{target}" {files} $?
         match_regex(target, "\.(tar\.xz|txz)$", true): silent $ tar -cJf "{target}" {files} $?
-        match_regex(target, "\.tar$", true): $ tar -cf "{target}" {files} $?
         match_regex(target, "\.bz2$"): $ bzip2 -k -c {files} > "{target}" $?
+        match_regex(target, "\.deb$"): $ dpkg-deb --build {files} "{target}" $?
         match_regex(target, "\.gz$"): $ gzip -k -c {files} > "{target}" $?
+        match_regex(target, "\.rar$"): silent $ rar a -y "{target}" {files} $?
+        match_regex(target, "\.rpm$"): $ rpmbuild -bb --buildroot="{files}" -D "_rpmdir=\$(dirname "{target}")" specfile.spec $?
+        match_regex(target, "\.tar$", true): $ tar -cf "{target}" {files} $?
         match_regex(target, "\.xz$"): $ xz -k -c {files} > "{target}" $?
         match_regex(target, "\.7z$"): silent $ 7z a -y "{target}" {files} $?
         match_regex(target, "\.(zip|war|jar)$", true): silent $ zip -r "{target}" {files} $?
-        match_regex(target, "\.rar$"): silent $ rar a -y "{target}" {files} $?
-        match_regex(target, "\.deb$"): $ dpkg-deb --build {files} "{target}" $?
-        match_regex(target, "\.rpm$"): $ rpmbuild -bb --buildroot="{files}" -D "_rpmdir=\$(dirname "{target}")" specfile.spec $?
-    else {
+        else {
             echo("Error: Unsupported file type")
-            fail 3
+            fail(3)
         }
     }
 }


### PR DESCRIPTION
Adjusting the built-in `fail` function to a function-call syntax with parentheses and reordering the formats in the `file_extract` and `file_compress` functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across filesystem operations, including temporary-directory creation and file permission or ownership changes.
  * Improved failure handling during archive extraction and compression.
  * Preserved existing archive format behavior while improving consistency across supported operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->