### PR TITLE
chore: disable CodeRabbit review status

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,2 @@
+reviews:
+  review_status: false


### PR DESCRIPTION
## Summary

- add `.coderabbit.yaml`
- disable CodeRabbit review status messages with `reviews.review_status: false`

## Why

This keeps CodeRabbit reviews enabled while suppressing review status messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->