### PR TITLE
Shellcheck: the last PR

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -164,26 +164,14 @@ jobs:
         shell: /bin/zsh {0}
         run: |
           cargo build # the binary will be used by the cargo test
-          # Per-target constant-folding tests are bash-target specific; the bash docker
-          # matrix above and the bash 3.2 step below cover them.
-          cargo test --all-targets --all-features -- \
-            --skip shellname_eq_ \
-            --skip shellname_neq_ \
-            --skip shellname_standalone \
-            --skip ifchain_constant_ \
-            --skip ifchain_multiple_conditions \
-            --skip expr_try_fold_constant \
-            --skip env_var_test
-      - name: Run bash-target folding tests
+          cargo test --all-targets --all-features
+      - name: Run bash-target tests
         env:
             AMBER_SHELL: '/bin/bash'
             AMBER_TEST_TARGET: bash-3.2
         shell: /bin/bash {0}
         run: |
-          cargo test --all-targets --all-features -- \
-            shellname_eq_ shellname_neq_ shellname_standalone \
-            ifchain_constant_ ifchain_multiple_conditions \
-            expr_try_fold_constant env_var_test
+          cargo test --all-targets --all-features
   clippy:
     name: Clippy tests
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -141,7 +141,7 @@ jobs:
           docker stop test_container -t 0
           docker rm --force test_container
   macos-test:
-    name: Rust tests on a native macOS zsh
+    name: Rust tests on native macOS (zsh + bash 3.2)
     runs-on: macos-latest
     if: github.event_name != 'release'
     steps:
@@ -157,13 +157,33 @@ jobs:
             ./target/deps
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
-      - name: Run tests
+      - name: Run zsh-target tests
         env:
             AMBER_SHELL: '/bin/zsh'
+            AMBER_TEST_TARGET: zsh
         shell: /bin/zsh {0}
         run: |
           cargo build # the binary will be used by the cargo test
-          cargo test --all-targets --all-features
+          # Per-target constant-folding tests are bash-target specific; the bash docker
+          # matrix above and the bash 3.2 step below cover them.
+          cargo test --all-targets --all-features -- \
+            --skip shellname_eq_ \
+            --skip shellname_neq_ \
+            --skip shellname_standalone \
+            --skip ifchain_constant_ \
+            --skip ifchain_multiple_conditions \
+            --skip expr_try_fold_constant \
+            --skip env_var_test
+      - name: Run bash-target folding tests
+        env:
+            AMBER_SHELL: '/bin/bash'
+            AMBER_TEST_TARGET: bash-3.2
+        shell: /bin/bash {0}
+        run: |
+          cargo test --all-targets --all-features -- \
+            shellname_eq_ shellname_neq_ shellname_standalone \
+            ifchain_constant_ ifchain_multiple_conditions \
+            expr_try_fold_constant env_var_test
   clippy:
     name: Clippy tests
     runs-on: ubuntu-latest

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -455,6 +455,7 @@ impl AmberCompiler {
         mut meta: ParserMetadata,
     ) -> Result<(Block, ParserMetadata), Message> {
         let time = Instant::now();
+        meta.with_target_shell(&self.options);
 
         // Perform type checking on the block
         if let Err(failure) = block.typecheck(&mut meta) {

--- a/src/modules/block.rs
+++ b/src/modules/block.rs
@@ -24,6 +24,10 @@ impl Block {
         self.statements.iter().any(|stmt| stmt.terminates_control_flow())
     }
 
+    pub fn set_no_indent(&mut self) {
+        self.should_indent = false;
+    }
+
     pub fn with_condition(mut self) -> Self {
         self.is_conditional = true;
         self

--- a/src/modules/builtin/shellname.rs
+++ b/src/modules/builtin/shellname.rs
@@ -1,3 +1,4 @@
+use crate::modules::expression::expr::{Expr, ExprType};
 use crate::modules::prelude::*;
 use crate::modules::typecheck::TypeCheckModule;
 use crate::modules::types::{Type, Typed};
@@ -37,8 +38,38 @@ impl TypeCheckModule for Shellname {
     }
 }
 
+impl Shellname {
+    /// Check if this shellname() call is being compared to a literal string.
+    /// Returns the literal value if found, or None if it's a standalone usage.
+    pub fn try_fold_comparison(&self, meta: &TranslateMetadata, other: &Expr, operator_eq: bool) -> Option<FragmentKind> {
+        // Get the target shell's family name
+        let target_family = meta.target.shell.family_name();
+        
+        // Check if the other side is a literal string (single TextPart::String)
+        let literal = match &other.value {
+            Some(ExprType::Text(text)) => text.as_simple_string()?,
+            _ => return None,
+        };
+        
+        // Compare target family with the literal
+        let matches = target_family == literal;
+        
+        // Return constant "1" for true, "0" for false
+        // For != operator, we invert the result
+        let result = if operator_eq {
+            if matches { "1" } else { "0" }
+        } else {
+            if matches { "0" } else { "1" }
+        };
+        
+        Some(RawFragment::from(result.to_string()).to_frag())
+    }
+}
+
 impl TranslateModule for Shellname {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
+        // Only set shellname_used flag for standalone usage
+        // (not when it's being folded via try_fold_comparison)
         meta.shellname_used = true;
         VarExprFragment::new("EXEC_SHELL", Type::Text).to_frag()
     }

--- a/src/modules/builtin/shellname.rs
+++ b/src/modules/builtin/shellname.rs
@@ -1,4 +1,3 @@
-use crate::modules::expression::expr::{Expr, ExprType};
 use crate::modules::prelude::*;
 use crate::modules::typecheck::TypeCheckModule;
 use crate::modules::types::{Type, Typed};
@@ -35,34 +34,6 @@ impl SyntaxModule<ParserMetadata> for Shellname {
 impl TypeCheckModule for Shellname {
     fn typecheck(&mut self, _meta: &mut ParserMetadata) -> SyntaxResult {
         Ok(())
-    }
-}
-
-impl Shellname {
-    /// Check if this shellname() call is being compared to a literal string.
-    /// Returns the literal value if found, or None if it's a standalone usage.
-    pub fn try_fold_comparison(&self, meta: &TranslateMetadata, other: &Expr, operator_eq: bool) -> Option<FragmentKind> {
-        // Get the target shell's family name
-        let target_family = meta.target.shell.family_name();
-        
-        // Check if the other side is a literal string (single TextPart::String)
-        let literal = match &other.value {
-            Some(ExprType::Text(text)) => text.as_simple_string()?,
-            _ => return None,
-        };
-        
-        // Compare target family with the literal
-        let matches = target_family == literal;
-        
-        // Return constant "1" for true, "0" for false
-        // For != operator, we invert the result
-        let result = if operator_eq {
-            if matches { "1" } else { "0" }
-        } else {
-            if matches { "0" } else { "1" }
-        };
-        
-        Some(RawFragment::from(result.to_string()).to_frag())
     }
 }
 

--- a/src/modules/condition/ifchain.rs
+++ b/src/modules/condition/ifchain.rs
@@ -8,30 +8,50 @@ use amber_meta::AutoKeyword;
 use heraclitus_compiler::prelude::*;
 
 use std::collections::HashMap;
+use crate::modules::expression::BoolAnalysis;
+
+#[derive(Debug, Clone)]
+struct IfChainBranch {
+    comments: Vec<Comment>,
+    cond: Expr,
+    control_flow_analysis: BoolAnalysis,
+    block: Block,
+}
+
+impl IfChainBranch {
+    pub fn new(comments: Vec<Comment>, cond: Expr, block: Block) -> Self {
+        IfChainBranch { comments, cond, control_flow_analysis: BoolAnalysis::default(), block }
+    }
+
+    pub fn with_control_flow_analysis(mut self, cfa: BoolAnalysis) -> Self {
+        self.control_flow_analysis = cfa;
+        self
+    }
+}
 
 #[derive(Debug, Clone, AutoKeyword)]
 #[keyword = "if"]
 #[kind = "stmt"]
 pub struct IfChain {
-    cond_blocks: Vec<(Vec<Comment>, Expr, Block)>,
-    pub false_block: Option<(Vec<Comment>, Box<Block>)>,
+    cond_blocks: Vec<IfChainBranch>,
+    false_block: Option<IfChainBranch>,
 }
 
 crate::impl_documentation_noop!(IfChain);
 
 impl IfChain {
     pub fn terminates_control_flow(&self) -> bool {
-        for (_, cond, block) in &self.cond_blocks {
-            if cond.analyze_control_flow() == Some(true) {
-                return block.terminates_control_flow();
+        for branch in &self.cond_blocks {
+            if branch.control_flow_analysis.known_value == Some(true) {
+                return branch.block.terminates_control_flow();
             }
         }
         let all_terminate = self
             .cond_blocks
             .iter()
-            .all(|(_, _, block)| block.terminates_control_flow());
+            .all(|branch| branch.block.terminates_control_flow());
         match (&self.false_block, all_terminate) {
-            (Some((_, false_block)), true) => false_block.terminates_control_flow(),
+            (Some(branch), true) => branch.block.terminates_control_flow(),
             _ => false,
         }
     }
@@ -92,9 +112,9 @@ impl SyntaxModule<ParserMetadata> for IfChain {
 
             // Handle else keyword
             if token(meta, "else").is_ok() {
-                let mut false_block = Box::new(Block::new().with_needs_noop().with_condition());
-                syntax(meta, &mut *false_block)?;
-                self.false_block = Some((comments, false_block));
+                let mut else_block = Block::new().with_needs_noop().with_condition();
+                syntax(meta, &mut else_block)?;
+                self.false_block = Some(IfChainBranch::new(comments, cond, else_block));
                 if token(meta, "}").is_err() {
                     error!(
                         meta,
@@ -111,7 +131,7 @@ impl SyntaxModule<ParserMetadata> for IfChain {
             syntax(meta, &mut cond)?;
             syntax(meta, &mut block)?;
 
-            self.cond_blocks.push((comments, cond, block));
+            self.cond_blocks.push(IfChainBranch::new(comments, cond, block));
         }
     }
 }
@@ -123,55 +143,62 @@ impl TypeCheckModule for IfChain {
         let mut chain_deadcode = false;
         // Used for warning about unreachable conditions
         let mut first_true_pos: Option<PositionInfo> = None;
+        let mut first_true_depends_on_target = false;
         let mut accumulated_neg_facts = HashMap::new();
 
-        for (mut comments, mut cond, mut block) in old_chain {
-            for comment in comments.iter_mut() {
+        for mut branch in old_chain {
+            for comment in branch.comments.iter_mut() {
                 comment.typecheck(meta)?;
             }
             // Typecheck condition with accumulated negative facts
-            meta.with_narrowed_scope(accumulated_neg_facts.clone(), |meta| cond.typecheck(meta))?;
-            let pos = cond.get_position();
+            meta.with_narrowed_scope(accumulated_neg_facts.clone(), |meta| branch.cond.typecheck(meta))?;
+            let pos = branch.cond.get_position();
 
             if chain_deadcode {
-                Self::warn_dead_code(
-                    meta,
-                    pos,
-                    "Condition is unreachable, previous condition is always true",
-                );
-                continue;
-            }
-
-            match cond.analyze_control_flow() {
-                Some(true) => {
-                    let (facts, _) = cond.extract_facts();
-                    // Merge accumulated negative facts with current positive facts for the block
-                    let mut block_facts = accumulated_neg_facts.clone();
-                    block_facts.extend(facts);
-
-                    meta.with_narrowed_scope(block_facts, |meta| block.typecheck(meta))?;
-                    new_chain.push((comments, cond, block));
-                    chain_deadcode = true;
-                    first_true_pos = Some(pos);
-                }
-                Some(false) => {
+                if !first_true_depends_on_target {
                     Self::warn_dead_code(
                         meta,
                         pos,
-                        "Condition is always false, block will never execute",
+                        "Condition is unreachable, previous condition is always true",
                     );
                 }
-                None => {
-                    let (facts, neg_facts) = cond.extract_facts();
+                continue;
+            }
+
+            let cfa = branch.cond.analyze_control_flow();
+            match (cfa.known_value, cfa.has_side_effects) {
+                (Some(true), false) => {
+                    let (facts, _) = branch.cond.extract_facts();
                     // Merge accumulated negative facts with current positive facts for the block
                     let mut block_facts = accumulated_neg_facts.clone();
                     block_facts.extend(facts);
 
-                    meta.with_narrowed_scope(block_facts, |meta| block.typecheck(meta))?;
+                    meta.with_narrowed_scope(block_facts, |meta| branch.block.typecheck(meta))?;
+                    new_chain.push(branch.with_control_flow_analysis(cfa));
+                    chain_deadcode = true;
+                    first_true_pos = Some(pos);
+                    first_true_depends_on_target = cfa.depends_on_target;
+                }
+                (Some(false), false) => {
+                    if !cfa.depends_on_target {
+                        Self::warn_dead_code(
+                            meta,
+                            pos,
+                            "Condition is always false, block will never execute",
+                        );
+                    }
+                }
+                _ => {
+                    let (facts, neg_facts) = branch.cond.extract_facts();
+                    // Merge accumulated negative facts with current positive facts for the block
+                    let mut block_facts = accumulated_neg_facts.clone();
+                    block_facts.extend(facts);
+
+                    meta.with_narrowed_scope(block_facts, |meta| branch.block.typecheck(meta))?;
                     // Add current negative facts to the accumulated set for next branches
                     accumulated_neg_facts.extend(neg_facts);
 
-                    new_chain.push((comments, cond, block));
+                    new_chain.push(branch.with_control_flow_analysis(cfa));
                 }
             }
         }
@@ -179,7 +206,7 @@ impl TypeCheckModule for IfChain {
         self.cond_blocks = new_chain;
 
         if chain_deadcode {
-            if self.false_block.is_some() {
+            if self.false_block.is_some() && !first_true_depends_on_target {
                 if let Some(pos) = first_true_pos {
                     Self::warn_dead_code(
                         meta,
@@ -189,11 +216,11 @@ impl TypeCheckModule for IfChain {
                 }
             }
             self.false_block = None;
-        } else if let Some((comments, false_block)) = &mut self.false_block {
-            for comment in comments {
+        } else if let Some(branch) = &mut self.false_block {
+            for comment in &mut branch.comments {
                 comment.typecheck(meta)?;
             }
-            meta.with_narrowed_scope(accumulated_neg_facts, |meta| false_block.typecheck(meta))?;
+            meta.with_narrowed_scope(accumulated_neg_facts, |meta| branch.block.typecheck(meta))?;
         }
 
         Ok(())
@@ -201,106 +228,51 @@ impl TypeCheckModule for IfChain {
 }
 
 impl TranslateModule for IfChain {
-    fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        if self.cond_blocks.is_empty() {
-            if let Some((_, false_block)) = &self.false_block {
-                return false_block.translate(meta);
-            }
-            return FragmentKind::Empty;
-        }
+  fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
+      if self.cond_blocks.is_empty() {
+          if let Some(false_branch) = &self.false_block {
+              return false_branch.block.translate(meta);
+          }
+          return FragmentKind::Empty;
+      }
 
-        // Check if the first condition can be folded to a constant
-        if let Some((_, first_cond, first_block)) = self.cond_blocks.first() {
-            if first_cond.try_fold_bool_constant(meta) == Some(true) {
-                return first_block.translate(meta);
-            }
-        }
+      // In case of when only the first condition is true, we can just leave the truth block without any condition
+      if let Some(first_branch) = self.cond_blocks.first() {
+          let analysis = first_branch.control_flow_analysis;
+          if analysis.known_value == Some(true) && !analysis.has_side_effects {
+              return first_branch.block.translate(meta);
+          }
+      }
 
-        let mut result = vec![];
-        let mut has_emitted_any_branch = false;
-        let mut first_taken_block = None;
-        
-        for (comments, cond, block) in self.cond_blocks.iter() {
-            for comment in comments {
-                result.push(comment.translate(meta));
-            }
-            
-            // Try to fold this condition to a constant
-            if let Some(constant_value) = cond.try_fold_bool_constant(meta) {
-                if constant_value {
-                    // This branch is always taken - save it as the first taken block
-                    if first_taken_block.is_none() {
-                        first_taken_block = Some((comments, block));
-                    }
-                    // Stop processing later branches - constant true dominates
-                    break;
-                }
-                // If false, skip this branch entirely
-                continue;
-            }
-            
-            // Non-constant condition - emit normally
-            let condition = cond.translate(meta)
-                .with_quotes(
-                    matches!(cond.value, Some(ExprType::Text(_)))
-                )
-                .with_condition(true);
-                
-            if !has_emitted_any_branch {
-                result.push(fragments!("if ", condition, "; then"));
-                has_emitted_any_branch = true;
-            } else {
-                result.push(fragments!("elif ", condition, "; then"));
-            }
-            result.push(block.translate(meta));
-        }
-        
-        // Handle the first taken constant-true block
-        if let Some((comments, block)) = first_taken_block {
-            if !has_emitted_any_branch {
-                // This is the only taken branch, emit it without if/elif/fi
-                for comment in comments {
-                    result.push(comment.translate(meta));
-                }
-                result.push(block.translate(meta));
-                // No fi needed since there's no if
-            } else {
-                // Constant-true after dynamic branches becomes else block
-                for comment in comments {
-                    result.push(comment.translate(meta));
-                }
-                result.push(fragments!("else"));
-                result.push(block.translate(meta));
-                result.push(fragments!("fi"));
-                return BlockFragment::new(result, false).to_frag();
-            }
-        }
-        
-        if let Some((comments, false_block)) = &self.false_block {
-            // Suppress else when we have a constant-true branch (it already handled else)
-            if first_taken_block.is_some() {
-                // Constant-true dominates, else is dead code
-            } else if has_emitted_any_branch {
-                for comment in comments {
-                    result.push(comment.translate(meta));
-                }
-                result.push(fragments!("else"));
-                result.push(false_block.translate(meta));
-                result.push(fragments!("fi"));
-            } else {
-                // No branches at all, just emit the else block
-                for comment in comments {
-                    result.push(comment.translate(meta));
-                }
-                result.push(false_block.translate(meta));
-            }
-        } else if has_emitted_any_branch {
-            // No else block but we have if/elif
-            result.push(fragments!("fi"));
-        }
-        // If first_taken_block is Some and has_emitted_any_branch is false,
-        // we already emitted without fi, so nothing more to do
-        
-        BlockFragment::new(result, false).to_frag()
-    }
+      let mut result = vec![];
+      let mut is_first = true;
+      for branch in self.cond_blocks.iter() {
+          for comment in &branch.comments {
+              result.push(comment.translate(meta));
+          }
+          let condition = branch.cond.translate(meta)
+              .with_quotes(
+                  matches!(branch.cond.value, Some(ExprType::Text(_)))
+              )
+              .with_condition(true);
+
+          if is_first {
+              result.push(fragments!("if ", condition, "; then"));
+              result.push(branch.block.translate(meta));
+              is_first = false;
+          } else {
+              result.push(fragments!("elif ", condition, "; then"));
+              result.push(branch.block.translate(meta));
+          }
+      }
+      if let Some(false_branch) = &self.false_block {
+          for comment in &false_branch.comments {
+              result.push(comment.translate(meta));
+          }
+          result.push(fragments!("else"));
+          result.push(false_branch.block.translate(meta));
+      }
+      result.push(fragments!("fi"));
+      BlockFragment::new(result, false).to_frag()
+  }
 }

--- a/src/modules/condition/ifchain.rs
+++ b/src/modules/condition/ifchain.rs
@@ -245,13 +245,21 @@ impl TranslateModule for IfChain {
       let mut result = vec![];
       let mut is_first = true;
       for branch in self.cond_blocks.iter() {
+          // If a non-first branch is always true then it's an `else` clause
+          if !is_first && branch.cfa.known_value == Some(true) && !branch.cfa.has_side_effects {
+              result.push(fragments!("else"));
+              result.push(branch.block.translate(meta));
+              result.push(fragments!("fi"));
+              return BlockFragment::new(result, false).to_frag()
+          }
+
           for comment in &branch.comments {
               result.push(comment.translate(meta));
           }
+
+          let is_text = matches!(branch.cond.value, Some(ExprType::Text(_)));
           let condition = branch.cond.translate(meta)
-              .with_quotes(
-                  matches!(branch.cond.value, Some(ExprType::Text(_)))
-              )
+              .with_quotes(is_text)
               .with_condition(true);
 
           if is_first {

--- a/src/modules/condition/ifchain.rs
+++ b/src/modules/condition/ifchain.rs
@@ -209,42 +209,88 @@ impl TranslateModule for IfChain {
             return FragmentKind::Empty;
         }
 
-        // In case of when only the first condition is true, we can just leave the truth block without any condition
+        // Check if the first condition can be folded to a constant
         if let Some((_, first_cond, first_block)) = self.cond_blocks.first() {
-            if first_cond.analyze_control_flow() == Some(true) {
+            if first_cond.try_fold_bool_constant(meta) == Some(true) {
                 return first_block.translate(meta);
             }
         }
 
         let mut result = vec![];
-        let mut is_first = true;
+        let mut has_emitted_any_branch = false;
+        let mut first_taken_block = None;
+        
         for (comments, cond, block) in self.cond_blocks.iter() {
             for comment in comments {
                 result.push(comment.translate(meta));
             }
+            
+            // Try to fold this condition to a constant
+            if let Some(constant_value) = cond.try_fold_bool_constant(meta) {
+                if constant_value {
+                    // This branch is always taken - save it as the first taken block
+                    if first_taken_block.is_none() {
+                        first_taken_block = Some((comments, block));
+                    }
+                    // If we already have a first taken block, this is dead code (shouldn't happen)
+                }
+                // If false, skip this branch entirely
+                continue;
+            }
+            
+            // Non-constant condition - emit normally
             let condition = cond.translate(meta)
                 .with_quotes(
                     matches!(cond.value, Some(ExprType::Text(_)))
                 )
                 .with_condition(true);
                 
-            if is_first {
+            if !has_emitted_any_branch {
                 result.push(fragments!("if ", condition, "; then"));
-                result.push(block.translate(meta));
-                is_first = false;
+                has_emitted_any_branch = true;
             } else {
                 result.push(fragments!("elif ", condition, "; then"));
+            }
+            result.push(block.translate(meta));
+        }
+        
+        // Handle the first taken constant-true block
+        if let Some((comments, block)) = first_taken_block {
+            if !has_emitted_any_branch {
+                // This is the only taken branch, emit it without if/elif/fi
+                for comment in comments {
+                    result.push(comment.translate(meta));
+                }
                 result.push(block.translate(meta));
+                // No fi needed since there's no if
+            } else {
+                // We already have if/elif, so this constant-true branch is dead code
+                // (shouldn't happen in valid code, but ignore it)
             }
         }
+        
         if let Some((comments, false_block)) = &self.false_block {
             for comment in comments {
                 result.push(comment.translate(meta));
             }
-            result.push(fragments!("else"));
-            result.push(false_block.translate(meta));
+            // Only emit else if we have an if/elif before it
+            if has_emitted_any_branch {
+                result.push(fragments!("else"));
+                result.push(false_block.translate(meta));
+                result.push(fragments!("fi"));
+            } else if first_taken_block.is_none() {
+                // No branches at all, just emit the else block
+                result.push(false_block.translate(meta));
+            }
+            // If first_taken_block is Some and has_emitted_any_branch is false,
+            // we already emitted the constant-true block without fi, so no else
+        } else if has_emitted_any_branch {
+            // No else block but we have if/elif
+            result.push(fragments!("fi"));
         }
-        result.push(fragments!("fi"));
+        // If first_taken_block is Some and has_emitted_any_branch is false,
+        // we already emitted without fi, so nothing more to do
+        
         BlockFragment::new(result, false).to_frag()
     }
 }

--- a/src/modules/condition/ifchain.rs
+++ b/src/modules/condition/ifchain.rs
@@ -14,17 +14,17 @@ use crate::modules::expression::BoolAnalysis;
 struct IfChainBranch {
     comments: Vec<Comment>,
     cond: Expr,
-    control_flow_analysis: BoolAnalysis,
+    cfa: BoolAnalysis,
     block: Block,
 }
 
 impl IfChainBranch {
     pub fn new(comments: Vec<Comment>, cond: Expr, block: Block) -> Self {
-        IfChainBranch { comments, cond, control_flow_analysis: BoolAnalysis::default(), block }
+        IfChainBranch { comments, cond, cfa: BoolAnalysis::default(), block }
     }
 
-    pub fn with_control_flow_analysis(mut self, cfa: BoolAnalysis) -> Self {
-        self.control_flow_analysis = cfa;
+    pub fn with_cfa(mut self, cfa: BoolAnalysis) -> Self {
+        self.cfa = cfa;
         self
     }
 }
@@ -42,7 +42,7 @@ crate::impl_documentation_noop!(IfChain);
 impl IfChain {
     pub fn terminates_control_flow(&self) -> bool {
         for branch in &self.cond_blocks {
-            if branch.control_flow_analysis.known_value == Some(true) {
+            if branch.cfa.known_value == Some(true) {
                 return branch.block.terminates_control_flow();
             }
         }
@@ -174,7 +174,7 @@ impl TypeCheckModule for IfChain {
                     block_facts.extend(facts);
 
                     meta.with_narrowed_scope(block_facts, |meta| branch.block.typecheck(meta))?;
-                    new_chain.push(branch.with_control_flow_analysis(cfa));
+                    new_chain.push(branch.with_cfa(cfa));
                     chain_deadcode = true;
                     first_true_pos = Some(pos);
                     first_true_depends_on_target = cfa.depends_on_target;
@@ -198,7 +198,7 @@ impl TypeCheckModule for IfChain {
                     // Add current negative facts to the accumulated set for next branches
                     accumulated_neg_facts.extend(neg_facts);
 
-                    new_chain.push(branch.with_control_flow_analysis(cfa));
+                    new_chain.push(branch.with_cfa(cfa));
                 }
             }
         }
@@ -238,8 +238,8 @@ impl TranslateModule for IfChain {
 
       // In case of when only the first condition is true, we can just leave the truth block without any condition
       if let Some(first_branch) = self.cond_blocks.first() {
-          let analysis = first_branch.control_flow_analysis;
-          if analysis.known_value == Some(true) && !analysis.has_side_effects {
+          let cfa = first_branch.cfa;
+          if cfa.known_value == Some(true) && !cfa.has_side_effects {
               return first_branch.block.translate(meta);
           }
       }

--- a/src/modules/condition/ifchain.rs
+++ b/src/modules/condition/ifchain.rs
@@ -232,7 +232,8 @@ impl TranslateModule for IfChain {
                     if first_taken_block.is_none() {
                         first_taken_block = Some((comments, block));
                     }
-                    // If we already have a first taken block, this is dead code (shouldn't happen)
+                    // Stop processing later branches - constant true dominates
+                    break;
                 }
                 // If false, skip this branch entirely
                 continue;
@@ -264,26 +265,35 @@ impl TranslateModule for IfChain {
                 result.push(block.translate(meta));
                 // No fi needed since there's no if
             } else {
-                // We already have if/elif, so this constant-true branch is dead code
-                // (shouldn't happen in valid code, but ignore it)
+                // Constant-true after dynamic branches becomes else block
+                for comment in comments {
+                    result.push(comment.translate(meta));
+                }
+                result.push(fragments!("else"));
+                result.push(block.translate(meta));
+                result.push(fragments!("fi"));
+                return BlockFragment::new(result, false).to_frag();
             }
         }
         
         if let Some((comments, false_block)) = &self.false_block {
-            for comment in comments {
-                result.push(comment.translate(meta));
-            }
-            // Only emit else if we have an if/elif before it
-            if has_emitted_any_branch {
+            // Suppress else when we have a constant-true branch (it already handled else)
+            if first_taken_block.is_some() {
+                // Constant-true dominates, else is dead code
+            } else if has_emitted_any_branch {
+                for comment in comments {
+                    result.push(comment.translate(meta));
+                }
                 result.push(fragments!("else"));
                 result.push(false_block.translate(meta));
                 result.push(fragments!("fi"));
-            } else if first_taken_block.is_none() {
+            } else {
                 // No branches at all, just emit the else block
+                for comment in comments {
+                    result.push(comment.translate(meta));
+                }
                 result.push(false_block.translate(meta));
             }
-            // If first_taken_block is Some and has_emitted_any_branch is false,
-            // we already emitted the constant-true block without fi, so no else
         } else if has_emitted_any_branch {
             // No else block but we have if/elif
             result.push(fragments!("fi"));

--- a/src/modules/condition/ifchain.rs
+++ b/src/modules/condition/ifchain.rs
@@ -41,16 +41,14 @@ crate::impl_documentation_noop!(IfChain);
 
 impl IfChain {
     pub fn terminates_control_flow(&self) -> bool {
+        let mut all_previously_terminated = true;
         for branch in &self.cond_blocks {
             if branch.cfa.known_value == Some(true) {
-                return branch.block.terminates_control_flow();
+                return all_previously_terminated && branch.block.terminates_control_flow();
             }
+            all_previously_terminated &= branch.block.terminates_control_flow();
         }
-        let all_terminate = self
-            .cond_blocks
-            .iter()
-            .all(|branch| branch.block.terminates_control_flow());
-        match (&self.false_block, all_terminate) {
+        match (&self.false_block, all_previously_terminated) {
             (Some(branch), true) => branch.block.terminates_control_flow(),
             _ => false,
         }

--- a/src/modules/condition/ifcond.rs
+++ b/src/modules/condition/ifcond.rs
@@ -123,6 +123,7 @@ impl TypeCheckModule for IfCondition {
 
                 let (true_facts, _) = self.expr.extract_facts();
                 if let Some(true_block) = &mut self.true_block {
+                    true_block.set_no_indent();
                     meta.with_narrowed_scope(true_facts, |meta| true_block.typecheck(meta))?;
                 }
             }
@@ -136,6 +137,7 @@ impl TypeCheckModule for IfCondition {
 
                 let (_, false_facts) = self.expr.extract_facts();
                 if let Some(false_block) = &mut self.false_block {
+                    false_block.set_no_indent();
                     meta.with_narrowed_scope(false_facts, |meta| false_block.typecheck(meta))?;
                 }
             }

--- a/src/modules/condition/ifcond.rs
+++ b/src/modules/condition/ifcond.rs
@@ -156,7 +156,7 @@ impl TypeCheckModule for IfCondition {
 
 impl TranslateModule for IfCondition {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        // Try to fold the condition to a constant during translation
+        // Reuse the stored folded value
         match (self.cfa.known_value, self.cfa.has_side_effects) {
             (Some(true), false) => self
                 .true_block

--- a/src/modules/condition/ifcond.rs
+++ b/src/modules/condition/ifcond.rs
@@ -1,6 +1,7 @@
 use crate::fragments;
 use crate::modules::block::Block;
 use crate::modules::expression::expr::{Expr, ExprType};
+use crate::modules::expression::BoolAnalysis;
 use crate::modules::prelude::*;
 use crate::modules::statement::stmt::{Statement, StmtType};
 use crate::utils::cc_flags::{get_ccflag_name, CCFlags};
@@ -12,6 +13,7 @@ use heraclitus_compiler::prelude::*;
 #[kind = "stmt"]
 pub struct IfCondition {
     expr: Box<Expr>,
+    cfa: BoolAnalysis,
     true_block: Option<Box<Block>>,
     false_block: Option<Box<Block>>,
 }
@@ -57,7 +59,7 @@ impl IfCondition {
     }
 
     pub fn terminates_control_flow(&self) -> bool {
-        match self.expr.analyze_control_flow() {
+        match self.expr.analyze_control_flow().known_value {
             Some(true) => self.true_block.as_ref().map(|b| b.terminates_control_flow()).unwrap_or(false),
             Some(false) => self.false_block.as_ref().map(|b| b.terminates_control_flow()).unwrap_or(false),
             None => match (&self.true_block, &self.false_block) {
@@ -74,6 +76,7 @@ impl SyntaxModule<ParserMetadata> for IfCondition {
     fn new() -> Self {
         IfCondition {
             expr: Box::new(Expr::new()),
+            cfa: BoolAnalysis::default(),
             true_block: None,
             false_block: None,
         }
@@ -108,10 +111,11 @@ impl SyntaxModule<ParserMetadata> for IfCondition {
 impl TypeCheckModule for IfCondition {
     fn typecheck(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         self.expr.typecheck(meta)?;
-        match self.expr.analyze_control_flow() {
-            Some(true) => {
+        self.cfa = self.expr.analyze_control_flow();
+        match (self.cfa.known_value, self.cfa.has_side_effects) {
+            (Some(true), false) => {
                 // Condition always true
-                if self.false_block.is_some() {
+                if self.false_block.is_some() && !self.cfa.depends_on_target {
                     let pos = self.expr.get_position();
                     Self::warn_dead_code(meta, pos, false);
                 }
@@ -122,10 +126,12 @@ impl TypeCheckModule for IfCondition {
                     meta.with_narrowed_scope(true_facts, |meta| true_block.typecheck(meta))?;
                 }
             }
-            Some(false) => {
+            (Some(false), false) => {
                 // Condition always false
                 let pos = self.expr.get_position();
-                Self::warn_dead_code(meta, pos, true);
+                if !self.cfa.depends_on_target {
+                    Self::warn_dead_code(meta, pos, true);
+                }
                 self.true_block = None;
 
                 let (_, false_facts) = self.expr.extract_facts();
@@ -133,7 +139,7 @@ impl TypeCheckModule for IfCondition {
                     meta.with_narrowed_scope(false_facts, |meta| false_block.typecheck(meta))?;
                 }
             }
-            None => {
+            _ => {
                 let (true_facts, false_facts) = self.expr.extract_facts();
                 if let Some(true_block) = &mut self.true_block {
                     meta.with_narrowed_scope(true_facts, |meta| true_block.typecheck(meta))?;
@@ -151,18 +157,18 @@ impl TypeCheckModule for IfCondition {
 impl TranslateModule for IfCondition {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
         // Try to fold the condition to a constant during translation
-        match self.expr.try_fold_bool_constant(meta) {
-            Some(true) => self
+        match (self.cfa.known_value, self.cfa.has_side_effects) {
+            (Some(true), false) => self
                 .true_block
                 .as_ref()
                 .map(|b| b.translate(meta))
                 .unwrap_or(FragmentKind::Empty),
-            Some(false) => self
+            (Some(false), false) => self
                 .false_block
                 .as_ref()
                 .map(|b| b.translate(meta))
                 .unwrap_or(FragmentKind::Empty),
-            None => {
+            _ => {
                 let mut result = vec![];
 
                 let expression = self.expr.translate(meta)
@@ -188,4 +194,3 @@ impl TranslateModule for IfCondition {
 }
 
 crate::impl_documentation_noop!(IfCondition);
-

--- a/src/modules/condition/ifcond.rs
+++ b/src/modules/condition/ifcond.rs
@@ -150,7 +150,8 @@ impl TypeCheckModule for IfCondition {
 
 impl TranslateModule for IfCondition {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        match self.expr.analyze_control_flow() {
+        // Try to fold the condition to a constant during translation
+        match self.expr.try_fold_bool_constant(meta) {
             Some(true) => self
                 .true_block
                 .as_ref()

--- a/src/modules/condition/ifcond.rs
+++ b/src/modules/condition/ifcond.rs
@@ -59,7 +59,7 @@ impl IfCondition {
     }
 
     pub fn terminates_control_flow(&self) -> bool {
-        match self.expr.analyze_control_flow().known_value {
+        match self.cfa.known_value {
             Some(true) => self.true_block.as_ref().map(|b| b.terminates_control_flow()).unwrap_or(false),
             Some(false) => self.false_block.as_ref().map(|b| b.terminates_control_flow()).unwrap_or(false),
             None => match (&self.true_block, &self.false_block) {

--- a/src/modules/expression/binop/and.rs
+++ b/src/modules/expression/binop/and.rs
@@ -30,10 +30,8 @@ impl And {
         BoolAnalysis {
             known_value,
             depends_on_target: match known_value {
-                Some(false) => !(
-                    (left.known_value == Some(false) && !left.depends_on_target)
-                        || (right.known_value == Some(false) && !right.depends_on_target)
-                ),
+                Some(false) => (left.depends_on_target || left.known_value != Some(false))
+                    && (right.depends_on_target || right.known_value != Some(false)),
                 Some(true) => left.depends_on_target || right.depends_on_target,
                 None => false,
             },

--- a/src/modules/expression/binop/and.rs
+++ b/src/modules/expression/binop/and.rs
@@ -7,6 +7,7 @@ use crate::translate::compare::ComparisonOperator;
 use amber_meta::AutoKeyword;
 use heraclitus_compiler::prelude::*;
 use std::collections::HashMap;
+use crate::modules::expression::BoolAnalysis;
 
 #[derive(Debug, Clone, AutoKeyword)]
 #[keyword = "and"]
@@ -17,20 +18,27 @@ pub struct And {
 }
 
 impl And {
-    pub fn analyze_control_flow(&self) -> Option<bool> {
+    pub fn analyze_control_flow(&self) -> BoolAnalysis {
         let left = self.left.analyze_control_flow();
         let right = self.right.analyze_control_flow();
-        match (left, right) {
+        let known_value = match (left.known_value, right.known_value) {
             (Some(false), _) => Some(false),
             (_, Some(false)) => Some(false),
             (Some(true), Some(true)) => Some(true),
             _ => None,
+        };
+        BoolAnalysis {
+            known_value,
+            depends_on_target: match known_value {
+                Some(false) => !(
+                    (left.known_value == Some(false) && !left.depends_on_target)
+                        || (right.known_value == Some(false) && !right.depends_on_target)
+                ),
+                Some(true) => left.depends_on_target || right.depends_on_target,
+                None => false,
+            },
+            has_side_effects: left.has_side_effects || right.has_side_effects,
         }
-    }
-
-    /// Check if this expression has side effects (function calls, commands, etc.)
-    pub fn has_side_effects(&self) -> bool {
-        self.left.has_side_effects() || self.right.has_side_effects()
     }
 
     pub fn extract_facts(&self) -> (HashMap<String, Type>, HashMap<String, Type>) {
@@ -101,8 +109,8 @@ impl TypeCheckModule for And {
             &mut self.left,
             &mut self.right,
             &[
-                Type::Bool, 
-                Type::Text, 
+                Type::Bool,
+                Type::Text,
                 Type::Array(Box::new(Type::Generic))
             ],
         )?;
@@ -113,10 +121,10 @@ impl TypeCheckModule for And {
 impl TranslateModule for And {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
         match self.analyze_control_flow() {
-            Some(value) if !self.has_side_effects() => {
+            BoolAnalysis { known_value: Some(value), has_side_effects: false, .. } => {
                 RawFragment::from((if value { "1" } else { "0" }).to_string()).to_frag()
             }
-            Some(_) | None => {
+            _ => {
                 let left = self.left.translate(meta);
                 let right = self.right.translate(meta);
                 ConditionFragment::new(left, ComparisonOperator::And, right).to_frag()

--- a/src/modules/expression/binop/and.rs
+++ b/src/modules/expression/binop/and.rs
@@ -15,13 +15,18 @@ use crate::modules::expression::BoolAnalysis;
 pub struct And {
     left: Box<Expr>,
     right: Box<Expr>,
+    cfa: BoolAnalysis,
 }
 
 impl And {
     pub fn analyze_control_flow(&self) -> BoolAnalysis {
-        let left = self.left.analyze_control_flow();
-        let right = self.right.analyze_control_flow();
-        let known_value = match (left.known_value, right.known_value) {
+        self.cfa
+    }
+
+    fn compute_cfa(&self) -> BoolAnalysis {
+        let left_cfa = self.left.analyze_control_flow();
+        let right_cfa = self.right.analyze_control_flow();
+        let known_value = match (left_cfa.known_value, right_cfa.known_value) {
             (Some(false), _) => Some(false),
             (_, Some(false)) => Some(false),
             (Some(true), Some(true)) => Some(true),
@@ -30,12 +35,12 @@ impl And {
         BoolAnalysis {
             known_value,
             depends_on_target: match known_value {
-                Some(false) => (left.depends_on_target || left.known_value != Some(false))
-                    && (right.depends_on_target || right.known_value != Some(false)),
-                Some(true) => left.depends_on_target || right.depends_on_target,
+                Some(false) => (left_cfa.depends_on_target || left_cfa.known_value != Some(false))
+                    && (right_cfa.depends_on_target || right_cfa.known_value != Some(false)),
+                Some(true) => left_cfa.depends_on_target || right_cfa.depends_on_target,
                 None => false,
             },
-            has_side_effects: left.has_side_effects || right.has_side_effects,
+            has_side_effects: left_cfa.has_side_effects || right_cfa.has_side_effects,
         }
     }
 
@@ -89,6 +94,7 @@ impl SyntaxModule<ParserMetadata> for And {
         And {
             left: Box::new(Expr::new()),
             right: Box::new(Expr::new()),
+            cfa: BoolAnalysis::default(),
         }
     }
 
@@ -112,13 +118,14 @@ impl TypeCheckModule for And {
                 Type::Array(Box::new(Type::Generic))
             ],
         )?;
+        self.cfa = self.compute_cfa();
         Ok(())
     }
 }
 
 impl TranslateModule for And {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        match self.analyze_control_flow() {
+        match self.cfa {
             BoolAnalysis { known_value: Some(value), has_side_effects: false, .. } => {
                 RawFragment::from((if value { "1" } else { "0" }).to_string()).to_frag()
             }

--- a/src/modules/expression/binop/eq.rs
+++ b/src/modules/expression/binop/eq.rs
@@ -55,6 +55,7 @@ impl Eq {
     /// Check if this equality comparison can be folded to a constant.
     pub fn analyze_constant_folding(&self, meta: &ParserMetadata) -> Option<bool> {
         let target_family = meta.target.as_ref().unwrap().shell.family_name();
+
         // Optimize away `shellname() == "<shell>"` if possible at compile time
         match (&self.left.value, &self.right.value) {
             (Some(ExprType::Shellname(_)), Some(ExprType::Text(text))) => {

--- a/src/modules/expression/binop/eq.rs
+++ b/src/modules/expression/binop/eq.rs
@@ -4,9 +4,9 @@ use crate::modules::expression::expr::{Expr, ExprType};
 use crate::modules::prelude::*;
 use crate::modules::types::{Type, Typed};
 use crate::translate::compare::translate_array_equality;
+use crate::translate::compare::ComparisonOperator;
 use crate::translate::compute::{translate_float_computation, ArithOp};
 use crate::translate::fragments::condition::ConditionFragment;
-use crate::translate::compare::ComparisonOperator;
 use crate::utils::TranslateMetadata;
 use amber_meta::AutoKeyword;
 use heraclitus_compiler::prelude::*;
@@ -21,24 +21,15 @@ pub struct Eq {
 
 impl Eq {
     /// Check if this equality comparison can be folded to a constant.
-    /// Returns Some(true) if always true, Some(false) if always false, None otherwise.
     pub fn analyze_control_flow(&self, meta: &TranslateMetadata) -> Option<bool> {
-        // Check for shellname() == "literal" or "literal" == shellname() pattern
-        let get_literal = |expr: &Expr| -> Option<String> {
-            match &expr.value {
-                Some(ExprType::Text(text)) => text.as_simple_string().map(|s| s.to_string()),
-                _ => None,
-            }
-        };
-        
         let target_family = meta.target.shell.family_name();
-        
+        // Optimize away `shellname() == "<shell>"` if possible at compile time
         match (&self.left.value, &self.right.value) {
-            (Some(ExprType::Shellname(_)), _) => {
-                get_literal(&self.right).map(|lit| target_family == lit.as_str())
+            (Some(ExprType::Shellname(_)), Some(ExprType::Text(text))) => {
+                text.as_simple_string().map(|str| str == target_family)
             }
-            (_, Some(ExprType::Shellname(_))) => {
-                get_literal(&self.left).map(|lit| target_family == lit.as_str())
+            (Some(ExprType::Text(text)), Some(ExprType::Shellname(_))) => {
+                text.as_simple_string().map(|str| str == target_family)
             }
             _ => None,
         }
@@ -104,7 +95,7 @@ impl TranslateModule for Eq {
             }
             _ => None,
         };
-        
+
         if let Some(frag) = shellname_result {
             // Don't set shellname_used since we're folding to a constant
             return frag;
@@ -120,7 +111,7 @@ impl TranslateModule for Eq {
 
         match (self.left.get_type(), self.right.get_type()) {
             (Type::Num, _) | (_, Type::Num) => translate_float_computation(meta, ArithOp::Eq, Some(left), Some(right)),
-            (Type::Int, _) | (Type::Bool, _)=>  ArithmeticFragment::new(left, ArithOp::Eq, right).to_frag(),  
+            (Type::Int, _) | (Type::Bool, _)=>  ArithmeticFragment::new(left, ArithOp::Eq, right).to_frag(),
             (Type::Array(_), _) => {
                 if let (FragmentKind::VarExpr(left), FragmentKind::VarExpr(right)) = (left, right) {
                     translate_array_equality(left, right, false)

--- a/src/modules/expression/binop/eq.rs
+++ b/src/modules/expression/binop/eq.rs
@@ -1,5 +1,4 @@
 use super::BinOp;
-use crate::modules::builtin::shellname::Shellname;
 use crate::modules::expression::expr::{Expr, ExprType};
 use crate::modules::prelude::*;
 use crate::modules::types::{Type, Typed};
@@ -83,25 +82,7 @@ impl TypeCheckModule for Eq {
 
 impl TranslateModule for Eq {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        // Check for shellname() == "literal" or "literal" == shellname() pattern
-        let shellname_result = match (&self.left.value, &self.right.value) {
-            (Some(ExprType::Shellname(_)), Some(ExprType::Text(_))) => {
-                // shellname() == "literal"
-                Shellname {}.try_fold_comparison(meta, &self.right, true)
-            }
-            (Some(ExprType::Text(_)), Some(ExprType::Shellname(_))) => {
-                // "literal" == shellname()
-                Shellname {}.try_fold_comparison(meta, &self.left, true)
-            }
-            _ => None,
-        };
-
-        if let Some(frag) = shellname_result {
-            // Don't set shellname_used since we're folding to a constant
-            return frag;
-        }
-
-        // Check for constant folding via analyze_control_flow
+        // Check for constant folding
         if let Some(constant_value) = self.analyze_control_flow(meta) {
             return RawFragment::from((if constant_value { "1" } else { "0" }).to_string()).to_frag();
         }

--- a/src/modules/expression/binop/eq.rs
+++ b/src/modules/expression/binop/eq.rs
@@ -9,6 +9,7 @@ use crate::translate::fragments::condition::ConditionFragment;
 use crate::utils::TranslateMetadata;
 use amber_meta::AutoKeyword;
 use heraclitus_compiler::prelude::*;
+use crate::modules::expression::BoolAnalysis;
 
 #[derive(Debug, Clone, AutoKeyword)]
 #[keyword = "eq"]
@@ -16,6 +17,7 @@ use heraclitus_compiler::prelude::*;
 pub struct Eq {
     left: Box<Expr>,
     right: Box<Expr>,
+    folded_value: Option<bool>
 }
 
 impl Typed for Eq {
@@ -39,6 +41,33 @@ impl BinOp for Eq {
     }
 }
 
+impl Eq {
+    pub fn analyze_control_flow(&self) -> BoolAnalysis {
+        BoolAnalysis {
+            known_value: self.folded_value,
+            depends_on_target: self.folded_value.is_some(),
+            has_side_effects: self.folded_value.is_none()
+                && (self.left.analyze_control_flow().has_side_effects
+                    || self.right.analyze_control_flow().has_side_effects),
+        }
+    }
+
+    /// Check if this equality comparison can be folded to a constant.
+    pub fn analyze_constant_folding(&self, meta: &ParserMetadata) -> Option<bool> {
+        let target_family = meta.target.as_ref().unwrap().shell.family_name();
+        // Optimize away `shellname() == "<shell>"` if possible at compile time
+        match (&self.left.value, &self.right.value) {
+            (Some(ExprType::Shellname(_)), Some(ExprType::Text(text))) => {
+                text.as_simple_string().map(|str| str == target_family)
+            }
+            (Some(ExprType::Text(text)), Some(ExprType::Shellname(_))) => {
+                text.as_simple_string().map(|str| str == target_family)
+            }
+            _ => None,
+        }
+    }
+}
+
 impl SyntaxModule<ParserMetadata> for Eq {
     syntax_name!("Eq");
 
@@ -46,6 +75,7 @@ impl SyntaxModule<ParserMetadata> for Eq {
         Eq {
             left: Box::new(Expr::new()),
             right: Box::new(Expr::new()),
+            folded_value: None
         }
     }
 
@@ -59,6 +89,7 @@ impl TypeCheckModule for Eq {
         self.left.typecheck(meta)?;
         self.right.typecheck(meta)?;
         Self::typecheck_equality(meta, &mut self.left, &mut self.right)?;
+        self.folded_value = self.analyze_constant_folding(meta);
         Ok(())
     }
 }
@@ -66,7 +97,7 @@ impl TypeCheckModule for Eq {
 impl TranslateModule for Eq {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
         // Check for constant folding
-        if let Some(constant_value) = self.analyze_constant_folding(meta) {
+        if let Some(constant_value) = self.folded_value {
             return RawFragment::from((if constant_value { "1" } else { "0" }).to_string()).to_frag();
         }
 
@@ -92,20 +123,3 @@ impl TranslateModule for Eq {
 }
 
 crate::impl_documentation_noop!(Eq);
-
-impl Eq {
-    /// Check if this equality comparison can be folded to a constant.
-    pub fn analyze_constant_folding(&self, meta: &TranslateMetadata) -> Option<bool> {
-        let target_family = meta.target.shell.family_name();
-        // Optimize away `shellname() == "<shell>"` if possible at compile time
-        match (&self.left.value, &self.right.value) {
-            (Some(ExprType::Shellname(_)), Some(ExprType::Text(text))) => {
-                text.as_simple_string().map(|str| str == target_family)
-            }
-            (Some(ExprType::Text(text)), Some(ExprType::Shellname(_))) => {
-                text.as_simple_string().map(|str| str == target_family)
-            }
-            _ => None,
-        }
-    }
-}

--- a/src/modules/expression/binop/eq.rs
+++ b/src/modules/expression/binop/eq.rs
@@ -18,23 +18,6 @@ pub struct Eq {
     right: Box<Expr>,
 }
 
-impl Eq {
-    /// Check if this equality comparison can be folded to a constant.
-    pub fn analyze_control_flow(&self, meta: &TranslateMetadata) -> Option<bool> {
-        let target_family = meta.target.shell.family_name();
-        // Optimize away `shellname() == "<shell>"` if possible at compile time
-        match (&self.left.value, &self.right.value) {
-            (Some(ExprType::Shellname(_)), Some(ExprType::Text(text))) => {
-                text.as_simple_string().map(|str| str == target_family)
-            }
-            (Some(ExprType::Text(text)), Some(ExprType::Shellname(_))) => {
-                text.as_simple_string().map(|str| str == target_family)
-            }
-            _ => None,
-        }
-    }
-}
-
 impl Typed for Eq {
     fn get_type(&self) -> Type {
         Type::Bool
@@ -83,7 +66,7 @@ impl TypeCheckModule for Eq {
 impl TranslateModule for Eq {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
         // Check for constant folding
-        if let Some(constant_value) = self.analyze_control_flow(meta) {
+        if let Some(constant_value) = self.analyze_constant_folding(meta) {
             return RawFragment::from((if constant_value { "1" } else { "0" }).to_string()).to_frag();
         }
 
@@ -109,3 +92,20 @@ impl TranslateModule for Eq {
 }
 
 crate::impl_documentation_noop!(Eq);
+
+impl Eq {
+    /// Check if this equality comparison can be folded to a constant.
+    pub fn analyze_constant_folding(&self, meta: &TranslateMetadata) -> Option<bool> {
+        let target_family = meta.target.shell.family_name();
+        // Optimize away `shellname() == "<shell>"` if possible at compile time
+        match (&self.left.value, &self.right.value) {
+            (Some(ExprType::Shellname(_)), Some(ExprType::Text(text))) => {
+                text.as_simple_string().map(|str| str == target_family)
+            }
+            (Some(ExprType::Text(text)), Some(ExprType::Shellname(_))) => {
+                text.as_simple_string().map(|str| str == target_family)
+            }
+            _ => None,
+        }
+    }
+}

--- a/src/modules/expression/binop/eq.rs
+++ b/src/modules/expression/binop/eq.rs
@@ -1,11 +1,13 @@
 use super::BinOp;
-use crate::modules::expression::expr::Expr;
+use crate::modules::builtin::shellname::Shellname;
+use crate::modules::expression::expr::{Expr, ExprType};
 use crate::modules::prelude::*;
 use crate::modules::types::{Type, Typed};
 use crate::translate::compare::translate_array_equality;
 use crate::translate::compute::{translate_float_computation, ArithOp};
 use crate::translate::fragments::condition::ConditionFragment;
 use crate::translate::compare::ComparisonOperator;
+use crate::utils::TranslateMetadata;
 use amber_meta::AutoKeyword;
 use heraclitus_compiler::prelude::*;
 
@@ -15,6 +17,32 @@ use heraclitus_compiler::prelude::*;
 pub struct Eq {
     left: Box<Expr>,
     right: Box<Expr>,
+}
+
+impl Eq {
+    /// Check if this equality comparison can be folded to a constant.
+    /// Returns Some(true) if always true, Some(false) if always false, None otherwise.
+    pub fn analyze_control_flow(&self, meta: &TranslateMetadata) -> Option<bool> {
+        // Check for shellname() == "literal" or "literal" == shellname() pattern
+        let get_literal = |expr: &Expr| -> Option<String> {
+            match &expr.value {
+                Some(ExprType::Text(text)) => text.as_simple_string().map(|s| s.to_string()),
+                _ => None,
+            }
+        };
+        
+        let target_family = meta.target.shell.family_name();
+        
+        match (&self.left.value, &self.right.value) {
+            (Some(ExprType::Shellname(_)), _) => {
+                get_literal(&self.right).map(|lit| target_family == lit.as_str())
+            }
+            (_, Some(ExprType::Shellname(_))) => {
+                get_literal(&self.left).map(|lit| target_family == lit.as_str())
+            }
+            _ => None,
+        }
+    }
 }
 
 impl Typed for Eq {
@@ -64,6 +92,29 @@ impl TypeCheckModule for Eq {
 
 impl TranslateModule for Eq {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
+        // Check for shellname() == "literal" or "literal" == shellname() pattern
+        let shellname_result = match (&self.left.value, &self.right.value) {
+            (Some(ExprType::Shellname(_)), Some(ExprType::Text(_))) => {
+                // shellname() == "literal"
+                Shellname {}.try_fold_comparison(meta, &self.right, true)
+            }
+            (Some(ExprType::Text(_)), Some(ExprType::Shellname(_))) => {
+                // "literal" == shellname()
+                Shellname {}.try_fold_comparison(meta, &self.left, true)
+            }
+            _ => None,
+        };
+        
+        if let Some(frag) = shellname_result {
+            // Don't set shellname_used since we're folding to a constant
+            return frag;
+        }
+
+        // Check for constant folding via analyze_control_flow
+        if let Some(constant_value) = self.analyze_control_flow(meta) {
+            return RawFragment::from((if constant_value { "1" } else { "0" }).to_string()).to_frag();
+        }
+
         let left = self.left.translate(meta).with_quotes(false);
         let right = self.right.translate(meta).with_quotes(false);
 

--- a/src/modules/expression/binop/neq.rs
+++ b/src/modules/expression/binop/neq.rs
@@ -1,10 +1,12 @@
 use super::BinOp;
-use crate::modules::expression::expr::Expr;
+use crate::modules::builtin::shellname::Shellname;
+use crate::modules::expression::expr::{Expr, ExprType};
 use crate::modules::prelude::*;
 use crate::modules::types::{Type, Typed};
 use crate::translate::compare::{translate_array_equality, ComparisonOperator};
 use crate::translate::compute::{translate_float_computation, ArithOp};
 use crate::translate::fragments::condition::ConditionFragment;
+use crate::utils::TranslateMetadata;
 use amber_meta::AutoKeyword;
 use heraclitus_compiler::prelude::*;
 
@@ -14,6 +16,32 @@ use heraclitus_compiler::prelude::*;
 pub struct Neq {
     left: Box<Expr>,
     right: Box<Expr>,
+}
+
+impl Neq {
+    /// Check if this inequality comparison can be folded to a constant.
+    /// Returns Some(true) if always true, Some(false) if always false, None otherwise.
+    pub fn analyze_control_flow(&self, meta: &TranslateMetadata) -> Option<bool> {
+        // Check for shellname() != "literal" or "literal" != shellname() pattern
+        let get_literal = |expr: &Expr| -> Option<String> {
+            match &expr.value {
+                Some(ExprType::Text(text)) => text.as_simple_string().map(|s| s.to_string()),
+                _ => None,
+            }
+        };
+        
+        let target_family = meta.target.shell.family_name();
+        
+        match (&self.left.value, &self.right.value) {
+            (Some(ExprType::Shellname(_)), _) => {
+                get_literal(&self.right).map(|lit| target_family != lit.as_str())
+            }
+            (_, Some(ExprType::Shellname(_))) => {
+                get_literal(&self.left).map(|lit| target_family != lit.as_str())
+            }
+            _ => None,
+        }
+    }
 }
 
 impl Typed for Neq {
@@ -63,6 +91,29 @@ impl TypeCheckModule for Neq {
 
 impl TranslateModule for Neq {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
+        // Check for shellname() != "literal" or "literal" != shellname() pattern
+        let shellname_result = match (&self.left.value, &self.right.value) {
+            (Some(ExprType::Shellname(_)), Some(ExprType::Text(_))) => {
+                // shellname() != "literal"
+                Shellname {}.try_fold_comparison(meta, &self.right, false)
+            }
+            (Some(ExprType::Text(_)), Some(ExprType::Shellname(_))) => {
+                // "literal" != shellname()
+                Shellname {}.try_fold_comparison(meta, &self.left, false)
+            }
+            _ => None,
+        };
+        
+        if let Some(frag) = shellname_result {
+            // Don't set shellname_used since we're folding to a constant
+            return frag;
+        }
+
+        // Check for constant folding via analyze_control_flow
+        if let Some(constant_value) = self.analyze_control_flow(meta) {
+            return RawFragment::from((if constant_value { "1" } else { "0" }).to_string()).to_frag();
+        }
+
         let left = self.left.translate(meta).with_quotes(false);
         let right = self.right.translate(meta).with_quotes(false);
         match (self.left.get_type(), self.right.get_type()) {

--- a/src/modules/expression/binop/neq.rs
+++ b/src/modules/expression/binop/neq.rs
@@ -20,24 +20,16 @@ pub struct Neq {
 
 impl Neq {
     /// Check if this inequality comparison can be folded to a constant.
-    /// Returns Some(true) if always true, Some(false) if always false, None otherwise.
     pub fn analyze_control_flow(&self, meta: &TranslateMetadata) -> Option<bool> {
-        // Check for shellname() != "literal" or "literal" != shellname() pattern
-        let get_literal = |expr: &Expr| -> Option<String> {
-            match &expr.value {
-                Some(ExprType::Text(text)) => text.as_simple_string().map(|s| s.to_string()),
-                _ => None,
-            }
-        };
-        
         let target_family = meta.target.shell.family_name();
-        
+
+        // Optimize away `shellname() != "<shell>"` if possible at compile time
         match (&self.left.value, &self.right.value) {
-            (Some(ExprType::Shellname(_)), _) => {
-                get_literal(&self.right).map(|lit| target_family != lit.as_str())
+            (Some(ExprType::Shellname(_)), Some(ExprType::Text(text))) => {
+                text.as_simple_string().map(|str| str != target_family)
             }
-            (_, Some(ExprType::Shellname(_))) => {
-                get_literal(&self.left).map(|lit| target_family != lit.as_str())
+            (Some(ExprType::Text(text)), Some(ExprType::Shellname(_))) => {
+                text.as_simple_string().map(|str| str != target_family)
             }
             _ => None,
         }
@@ -103,7 +95,7 @@ impl TranslateModule for Neq {
             }
             _ => None,
         };
-        
+
         if let Some(frag) = shellname_result {
             // Don't set shellname_used since we're folding to a constant
             return frag;

--- a/src/modules/expression/binop/neq.rs
+++ b/src/modules/expression/binop/neq.rs
@@ -96,7 +96,7 @@ impl TypeCheckModule for Neq {
 
 impl TranslateModule for Neq {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        // Check for constant folding
+        // Reuse the stored folded value
         if let Some(constant_value) = self.folded_value {
             return RawFragment::from((if constant_value { "1" } else { "0" }).to_string()).to_frag();
         }

--- a/src/modules/expression/binop/neq.rs
+++ b/src/modules/expression/binop/neq.rs
@@ -17,24 +17,6 @@ pub struct Neq {
     right: Box<Expr>,
 }
 
-impl Neq {
-    /// Check if this inequality comparison can be folded to a constant.
-    pub fn analyze_control_flow(&self, meta: &TranslateMetadata) -> Option<bool> {
-        let target_family = meta.target.shell.family_name();
-
-        // Optimize away `shellname() != "<shell>"` if possible at compile time
-        match (&self.left.value, &self.right.value) {
-            (Some(ExprType::Shellname(_)), Some(ExprType::Text(text))) => {
-                text.as_simple_string().map(|str| str != target_family)
-            }
-            (Some(ExprType::Text(text)), Some(ExprType::Shellname(_))) => {
-                text.as_simple_string().map(|str| str != target_family)
-            }
-            _ => None,
-        }
-    }
-}
-
 impl Typed for Neq {
     fn get_type(&self) -> Type {
         Type::Bool
@@ -83,7 +65,7 @@ impl TypeCheckModule for Neq {
 impl TranslateModule for Neq {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
         // Check for constant folding
-        if let Some(constant_value) = self.analyze_control_flow(meta) {
+        if let Some(constant_value) = self.analyze_constant_folding(meta) {
             return RawFragment::from((if constant_value { "1" } else { "0" }).to_string()).to_frag();
         }
 
@@ -108,3 +90,21 @@ impl TranslateModule for Neq {
 }
 
 crate::impl_documentation_noop!(Neq);
+
+impl Neq {
+    /// Check if this inequality comparison can be folded to a constant.
+    pub fn analyze_constant_folding(&self, meta: &TranslateMetadata) -> Option<bool> {
+        let target_family = meta.target.shell.family_name();
+
+        // Optimize away `shellname() != "<shell>"` if possible at compile time
+        match (&self.left.value, &self.right.value) {
+            (Some(ExprType::Shellname(_)), Some(ExprType::Text(text))) => {
+                text.as_simple_string().map(|str| str != target_family)
+            }
+            (Some(ExprType::Text(text)), Some(ExprType::Shellname(_))) => {
+                text.as_simple_string().map(|str| str != target_family)
+            }
+            _ => None,
+        }
+    }
+}

--- a/src/modules/expression/binop/neq.rs
+++ b/src/modules/expression/binop/neq.rs
@@ -8,6 +8,7 @@ use crate::translate::fragments::condition::ConditionFragment;
 use crate::utils::TranslateMetadata;
 use amber_meta::AutoKeyword;
 use heraclitus_compiler::prelude::*;
+use crate::modules::expression::BoolAnalysis;
 
 #[derive(Debug, Clone, AutoKeyword)]
 #[keyword = "neq"]
@@ -15,6 +16,7 @@ use heraclitus_compiler::prelude::*;
 pub struct Neq {
     left: Box<Expr>,
     right: Box<Expr>,
+    folded_value: Option<bool>
 }
 
 impl Typed for Neq {
@@ -38,6 +40,34 @@ impl BinOp for Neq {
     }
 }
 
+impl Neq {
+    pub fn analyze_control_flow(&self) -> BoolAnalysis {
+        BoolAnalysis {
+            known_value: self.folded_value,
+            depends_on_target: self.folded_value.is_some(),
+            has_side_effects: self.folded_value.is_none()
+                && (self.left.analyze_control_flow().has_side_effects
+                    || self.right.analyze_control_flow().has_side_effects),
+        }
+    }
+
+    /// Check if this inequality comparison can be folded to a constant.
+    pub fn analyze_constant_folding(&self, meta: &ParserMetadata) -> Option<bool> {
+        let target_family = meta.target.as_ref().unwrap().shell.family_name();
+
+        // Optimize away `shellname() != "<shell>"` if possible at compile time
+        match (&self.left.value, &self.right.value) {
+            (Some(ExprType::Shellname(_)), Some(ExprType::Text(text))) => {
+                text.as_simple_string().map(|str| str != target_family)
+            }
+            (Some(ExprType::Text(text)), Some(ExprType::Shellname(_))) => {
+                text.as_simple_string().map(|str| str != target_family)
+            }
+            _ => None,
+        }
+    }
+}
+
 impl SyntaxModule<ParserMetadata> for Neq {
     syntax_name!("Neq");
 
@@ -45,6 +75,7 @@ impl SyntaxModule<ParserMetadata> for Neq {
         Neq {
             left: Box::new(Expr::new()),
             right: Box::new(Expr::new()),
+            folded_value: None
         }
     }
 
@@ -58,6 +89,7 @@ impl TypeCheckModule for Neq {
         self.left.typecheck(meta)?;
         self.right.typecheck(meta)?;
         Self::typecheck_equality(meta, &mut self.left, &mut self.right)?;
+        self.folded_value = self.analyze_constant_folding(meta);
         Ok(())
     }
 }
@@ -65,7 +97,7 @@ impl TypeCheckModule for Neq {
 impl TranslateModule for Neq {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
         // Check for constant folding
-        if let Some(constant_value) = self.analyze_constant_folding(meta) {
+        if let Some(constant_value) = self.folded_value {
             return RawFragment::from((if constant_value { "1" } else { "0" }).to_string()).to_frag();
         }
 
@@ -90,21 +122,3 @@ impl TranslateModule for Neq {
 }
 
 crate::impl_documentation_noop!(Neq);
-
-impl Neq {
-    /// Check if this inequality comparison can be folded to a constant.
-    pub fn analyze_constant_folding(&self, meta: &TranslateMetadata) -> Option<bool> {
-        let target_family = meta.target.shell.family_name();
-
-        // Optimize away `shellname() != "<shell>"` if possible at compile time
-        match (&self.left.value, &self.right.value) {
-            (Some(ExprType::Shellname(_)), Some(ExprType::Text(text))) => {
-                text.as_simple_string().map(|str| str != target_family)
-            }
-            (Some(ExprType::Text(text)), Some(ExprType::Shellname(_))) => {
-                text.as_simple_string().map(|str| str != target_family)
-            }
-            _ => None,
-        }
-    }
-}

--- a/src/modules/expression/binop/neq.rs
+++ b/src/modules/expression/binop/neq.rs
@@ -1,5 +1,4 @@
 use super::BinOp;
-use crate::modules::builtin::shellname::Shellname;
 use crate::modules::expression::expr::{Expr, ExprType};
 use crate::modules::prelude::*;
 use crate::modules::types::{Type, Typed};
@@ -83,25 +82,7 @@ impl TypeCheckModule for Neq {
 
 impl TranslateModule for Neq {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        // Check for shellname() != "literal" or "literal" != shellname() pattern
-        let shellname_result = match (&self.left.value, &self.right.value) {
-            (Some(ExprType::Shellname(_)), Some(ExprType::Text(_))) => {
-                // shellname() != "literal"
-                Shellname {}.try_fold_comparison(meta, &self.right, false)
-            }
-            (Some(ExprType::Text(_)), Some(ExprType::Shellname(_))) => {
-                // "literal" != shellname()
-                Shellname {}.try_fold_comparison(meta, &self.left, false)
-            }
-            _ => None,
-        };
-
-        if let Some(frag) = shellname_result {
-            // Don't set shellname_used since we're folding to a constant
-            return frag;
-        }
-
-        // Check for constant folding via analyze_control_flow
+        // Check for constant folding
         if let Some(constant_value) = self.analyze_control_flow(meta) {
             return RawFragment::from((if constant_value { "1" } else { "0" }).to_string()).to_frag();
         }

--- a/src/modules/expression/binop/or.rs
+++ b/src/modules/expression/binop/or.rs
@@ -9,6 +9,7 @@ use heraclitus_compiler::prelude::*;
 use super::BinOp;
 
 use std::collections::HashMap;
+use crate::modules::expression::BoolAnalysis;
 
 #[derive(Debug, Clone, AutoKeyword)]
 #[keyword = "or"]
@@ -19,20 +20,27 @@ pub struct Or {
 }
 
 impl Or {
-    pub fn analyze_control_flow(&self) -> Option<bool> {
+    pub fn analyze_control_flow(&self) -> BoolAnalysis {
         let left = self.left.analyze_control_flow();
         let right = self.right.analyze_control_flow();
-        match (left, right) {
+        let known_value = match (left.known_value, right.known_value) {
             (Some(true), _) => Some(true),
             (_, Some(true)) => Some(true),
             (Some(false), Some(false)) => Some(false),
             _ => None,
+        };
+        BoolAnalysis {
+            known_value,
+            depends_on_target: match known_value {
+                Some(true) => !(
+                    (left.known_value == Some(true) && !left.depends_on_target)
+                        || (right.known_value == Some(true) && !right.depends_on_target)
+                ),
+                Some(false) => left.depends_on_target || right.depends_on_target,
+                None => false,
+            },
+            has_side_effects: left.has_side_effects || right.has_side_effects,
         }
-    }
-
-    /// Check if this expression has side effects (function calls, commands, etc.)
-    pub fn has_side_effects(&self) -> bool {
-        self.left.has_side_effects() || self.right.has_side_effects()
     }
 
     pub fn extract_facts(&self) -> (HashMap<String, Type>, HashMap<String, Type>) {
@@ -103,8 +111,8 @@ impl TypeCheckModule for Or {
             &mut self.left,
             &mut self.right,
             &[
-                Type::Bool, 
-                Type::Text, 
+                Type::Bool,
+                Type::Text,
                 Type::Array(Box::new(Type::Generic))
             ],
         )?;
@@ -115,10 +123,10 @@ impl TypeCheckModule for Or {
 impl TranslateModule for Or {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
         match self.analyze_control_flow() {
-            Some(value) if !self.has_side_effects() => {
+            BoolAnalysis { known_value: Some(value), has_side_effects: false, .. } => {
                 RawFragment::from((if value { "1" } else { "0" }).to_string()).to_frag()
             }
-            Some(_) | None => {
+            _ => {
                 let left = self.left.translate(meta);
                 let right = self.right.translate(meta);
                 ConditionFragment::new(left, ComparisonOperator::Or, right).to_frag()

--- a/src/modules/expression/binop/or.rs
+++ b/src/modules/expression/binop/or.rs
@@ -17,13 +17,18 @@ use crate::modules::expression::BoolAnalysis;
 pub struct Or {
     left: Box<Expr>,
     right: Box<Expr>,
+    cfa: BoolAnalysis,
 }
 
 impl Or {
     pub fn analyze_control_flow(&self) -> BoolAnalysis {
-        let left = self.left.analyze_control_flow();
-        let right = self.right.analyze_control_flow();
-        let known_value = match (left.known_value, right.known_value) {
+        self.cfa
+    }
+
+    fn compute_cfa(&self) -> BoolAnalysis {
+        let left_cfa = self.left.analyze_control_flow();
+        let right_cfa = self.right.analyze_control_flow();
+        let known_value = match (left_cfa.known_value, right_cfa.known_value) {
             (Some(true), _) => Some(true),
             (_, Some(true)) => Some(true),
             (Some(false), Some(false)) => Some(false),
@@ -32,12 +37,12 @@ impl Or {
         BoolAnalysis {
             known_value,
             depends_on_target: match known_value {
-                Some(true) => (left.depends_on_target || left.known_value != Some(true))
-                    && (right.depends_on_target || right.known_value != Some(true)),
-                Some(false) => left.depends_on_target || right.depends_on_target,
+                Some(true) => (left_cfa.depends_on_target || left_cfa.known_value != Some(true))
+                    && (right_cfa.depends_on_target || right_cfa.known_value != Some(true)),
+                Some(false) => left_cfa.depends_on_target || right_cfa.depends_on_target,
                 None => false,
             },
-            has_side_effects: left.has_side_effects || right.has_side_effects,
+            has_side_effects: left_cfa.has_side_effects || right_cfa.has_side_effects,
         }
     }
 
@@ -91,6 +96,7 @@ impl SyntaxModule<ParserMetadata> for Or {
         Or {
             left: Box::new(Expr::new()),
             right: Box::new(Expr::new()),
+            cfa: BoolAnalysis::default(),
         }
     }
 
@@ -114,13 +120,14 @@ impl TypeCheckModule for Or {
                 Type::Array(Box::new(Type::Generic))
             ],
         )?;
+        self.cfa = self.compute_cfa();
         Ok(())
     }
 }
 
 impl TranslateModule for Or {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        match self.analyze_control_flow() {
+        match self.cfa {
             BoolAnalysis { known_value: Some(value), has_side_effects: false, .. } => {
                 RawFragment::from((if value { "1" } else { "0" }).to_string()).to_frag()
             }

--- a/src/modules/expression/binop/or.rs
+++ b/src/modules/expression/binop/or.rs
@@ -32,10 +32,8 @@ impl Or {
         BoolAnalysis {
             known_value,
             depends_on_target: match known_value {
-                Some(true) => !(
-                    (left.known_value == Some(true) && !left.depends_on_target)
-                        || (right.known_value == Some(true) && !right.depends_on_target)
-                ),
+                Some(true) => (left.depends_on_target || left.known_value != Some(true))
+                    && (right.depends_on_target || right.known_value != Some(true)),
                 Some(false) => left.depends_on_target || right.depends_on_target,
                 None => false,
             },

--- a/src/modules/expression/expr.rs
+++ b/src/modules/expression/expr.rs
@@ -184,8 +184,8 @@ impl Expr {
             Some(ExprType::Or(or)) => or.analyze_control_flow(),
             Some(ExprType::Not(not)) => not.analyze_control_flow(),
             Some(ExprType::Parentheses(p)) => p.get_expr().try_fold_bool_constant(meta),
-            Some(ExprType::Eq(eq)) => eq.analyze_control_flow(meta),
-            Some(ExprType::Neq(neq)) => neq.analyze_control_flow(meta),
+            Some(ExprType::Eq(eq)) => eq.analyze_constant_folding(meta),
+            Some(ExprType::Neq(neq)) => neq.analyze_constant_folding(meta),
             Some(ExprType::Is(is)) => is.analyze_control_flow(),
             _ => None,
         }

--- a/src/modules/expression/expr.rs
+++ b/src/modules/expression/expr.rs
@@ -36,6 +36,7 @@ use crate::{
 };
 use heraclitus_compiler::prelude::*;
 use std::collections::HashMap;
+use super::BoolAnalysis;
 
 #[derive(Debug, Clone)]
 pub enum ExprType {
@@ -81,7 +82,7 @@ pub enum ExprType {
 }
 
 impl ExprType {
-    pub fn analyze_control_flow(&self) -> Option<bool> {
+    pub fn analyze_control_flow(&self) -> BoolAnalysis {
         match self {
             ExprType::Bool(v) => v.analyze_control_flow(),
             ExprType::And(v) => v.analyze_control_flow(),
@@ -89,7 +90,20 @@ impl ExprType {
             ExprType::Not(v) => v.analyze_control_flow(),
             ExprType::Parentheses(v) => v.analyze_control_flow(),
             ExprType::Is(v) => v.analyze_control_flow(),
-            _ => None,
+            ExprType::Eq(v) => v.analyze_control_flow(),
+            ExprType::Neq(v) => v.analyze_control_flow(),
+            // Nodes that are ambiguous from the point of CFA
+            ExprType::VariableGet(_) => BoolAnalysis::default(),
+            ExprType::Number(_) => BoolAnalysis::default(),
+            ExprType::Integer(_) => BoolAnalysis::default(),
+            ExprType::Text(_) => BoolAnalysis::default(),
+            ExprType::Null(_) => BoolAnalysis::default(),
+            ExprType::Status(_) => BoolAnalysis::default(),
+            ExprType::Nameof(_) => BoolAnalysis::default(),
+            ExprType::Shellname(_) => BoolAnalysis::default(),
+            ExprType::Shellversion(_) => BoolAnalysis::default(),
+            // Treat other expression types as if they could have side effects
+            _ => BoolAnalysis::with_side_effects(),
         }
     }
 
@@ -139,10 +153,11 @@ impl Expr {
         Message::new_err_at_position(meta, pos)
     }
 
-    pub fn analyze_control_flow(&self) -> Option<bool> {
+    pub fn analyze_control_flow(&self) -> BoolAnalysis {
         self.value
             .as_ref()
-            .and_then(|val| val.analyze_control_flow())
+            .map(|val| val.analyze_control_flow())
+            .unwrap_or_default()
     }
 
     pub fn extract_facts(
@@ -155,40 +170,6 @@ impl Expr {
             .as_ref()
             .map(|val| val.extract_facts())
             .unwrap_or_default()
-    }
-
-    /// Returns true if the expression MUST be evaluated even if its value
-    /// is not needed. Only called by boolean constant-folding (And, Or, Not),
-    /// so the reachable arms are limited to types the type checker accepts
-    /// as Bool operands.
-    pub fn has_side_effects(&self) -> bool {
-        match &self.value {
-            Some(ExprType::FunctionInvocation(_)) => true,
-            Some(ExprType::And(and)) => and.has_side_effects(),
-            Some(ExprType::Or(or)) => or.has_side_effects(),
-            Some(ExprType::Not(not)) => not.has_side_effects(),
-            Some(ExprType::Bool(_)) => false,
-            Some(ExprType::VariableGet(_)) => false,
-            Some(_) => true,
-            None => false,
-        }
-    }
-
-    /// Check if this expression can be folded to a constant boolean value during translation.
-    /// This is similar to analyze_control_flow but has access to TranslateMetadata for
-    /// shellname() comparisons.
-    pub fn try_fold_bool_constant(&self, meta: &TranslateMetadata) -> Option<bool> {
-        match &self.value {
-            Some(ExprType::Bool(b)) => b.analyze_control_flow(),
-            Some(ExprType::And(and)) => and.analyze_control_flow(),
-            Some(ExprType::Or(or)) => or.analyze_control_flow(),
-            Some(ExprType::Not(not)) => not.analyze_control_flow(),
-            Some(ExprType::Parentheses(p)) => p.get_expr().try_fold_bool_constant(meta),
-            Some(ExprType::Eq(eq)) => eq.analyze_constant_folding(meta),
-            Some(ExprType::Neq(neq)) => neq.analyze_constant_folding(meta),
-            Some(ExprType::Is(is)) => is.analyze_control_flow(),
-            _ => None,
-        }
     }
 }
 

--- a/src/modules/expression/expr.rs
+++ b/src/modules/expression/expr.rs
@@ -173,6 +173,23 @@ impl Expr {
             None => false,
         }
     }
+
+    /// Check if this expression can be folded to a constant boolean value during translation.
+    /// This is similar to analyze_control_flow but has access to TranslateMetadata for
+    /// shellname() comparisons.
+    pub fn try_fold_bool_constant(&self, meta: &TranslateMetadata) -> Option<bool> {
+        match &self.value {
+            Some(ExprType::Bool(b)) => b.analyze_control_flow(),
+            Some(ExprType::And(and)) => and.analyze_control_flow(),
+            Some(ExprType::Or(or)) => or.analyze_control_flow(),
+            Some(ExprType::Not(not)) => not.analyze_control_flow(),
+            Some(ExprType::Parentheses(p)) => p.get_expr().try_fold_bool_constant(meta),
+            Some(ExprType::Eq(eq)) => eq.analyze_control_flow(meta),
+            Some(ExprType::Neq(neq)) => neq.analyze_control_flow(meta),
+            Some(ExprType::Is(is)) => is.analyze_control_flow(),
+            _ => None,
+        }
+    }
 }
 
 impl SyntaxModule<ParserMetadata> for Expr {

--- a/src/modules/expression/expr.rs
+++ b/src/modules/expression/expr.rs
@@ -92,11 +92,11 @@ impl ExprType {
             ExprType::Is(v) => v.analyze_control_flow(),
             ExprType::Eq(v) => v.analyze_control_flow(),
             ExprType::Neq(v) => v.analyze_control_flow(),
+            ExprType::Text(v) => v.analyze_control_flow(),
             // Nodes that do not generate side effects from the point of CFA
             ExprType::VariableGet(_) => BoolAnalysis::default(),
             ExprType::Number(_) => BoolAnalysis::default(),
             ExprType::Integer(_) => BoolAnalysis::default(),
-            ExprType::Text(_) => BoolAnalysis::default(),
             ExprType::Null(_) => BoolAnalysis::default(),
             ExprType::Status(_) => BoolAnalysis::default(),
             ExprType::Nameof(_) => BoolAnalysis::default(),

--- a/src/modules/expression/expr.rs
+++ b/src/modules/expression/expr.rs
@@ -92,7 +92,7 @@ impl ExprType {
             ExprType::Is(v) => v.analyze_control_flow(),
             ExprType::Eq(v) => v.analyze_control_flow(),
             ExprType::Neq(v) => v.analyze_control_flow(),
-            // Nodes that are ambiguous from the point of CFA
+            // Nodes that do not generate side effects from the point of CFA
             ExprType::VariableGet(_) => BoolAnalysis::default(),
             ExprType::Number(_) => BoolAnalysis::default(),
             ExprType::Integer(_) => BoolAnalysis::default(),

--- a/src/modules/expression/literal/bool.rs
+++ b/src/modules/expression/literal/bool.rs
@@ -2,6 +2,7 @@ use crate::modules::prelude::*;
 use crate::modules::types::{Type, Typed};
 use crate::raw_fragment;
 use heraclitus_compiler::prelude::*;
+use crate::modules::expression::BoolAnalysis;
 
 #[derive(Debug, Clone)]
 pub struct Bool {
@@ -9,8 +10,12 @@ pub struct Bool {
 }
 
 impl Bool {
-    pub fn analyze_control_flow(&self) -> Option<bool> {
-        Some(self.value)
+    pub fn analyze_control_flow(&self) -> BoolAnalysis {
+        BoolAnalysis {
+            known_value: Some(self.value),
+            depends_on_target: false,
+            has_side_effects: false,
+        }
     }
 }
 

--- a/src/modules/expression/literal/text.rs
+++ b/src/modules/expression/literal/text.rs
@@ -49,6 +49,22 @@ pub struct Text {
     parts: Vec<TextPart>,
 }
 
+impl Text {
+    /// Returns the string content if this is a simple string literal.
+    /// Returns None if the text is interpolated or empty.
+    pub fn as_simple_string(&self) -> Option<&str> {
+        if self.parts.len() == 1 {
+            if let TextPart::String(s) = &self.parts[0] {
+                Some(s)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+}
+
 impl Typed for Text {
     fn get_type(&self) -> Type {
         Type::Text

--- a/src/modules/expression/literal/text.rs
+++ b/src/modules/expression/literal/text.rs
@@ -2,6 +2,7 @@ use crate::modules::expression::expr::Expr;
 use crate::modules::expression::interpolated_region::{
     parse_interpolated_region, InterpolatedRegionType,
 };
+use crate::modules::expression::BoolAnalysis;
 use crate::modules::prelude::*;
 use crate::modules::types::{Type, Typed};
 use crate::translate::fragments::interpolable::InterpolablePart;
@@ -50,6 +51,16 @@ pub struct Text {
 }
 
 impl Text {
+    pub fn analyze_control_flow(&self) -> BoolAnalysis {
+        BoolAnalysis {
+            has_side_effects: self.parts.iter().any(|part| match part {
+                TextPart::String(_) => false,
+                TextPart::Expr(expr) => expr.analyze_control_flow().has_side_effects,
+            }),
+            ..BoolAnalysis::default()
+        }
+    }
+
     /// Returns the string content if this is a simple string literal.
     /// Returns None if the text is interpolated or empty.
     pub fn as_simple_string(&self) -> Option<&str> {

--- a/src/modules/expression/mod.rs
+++ b/src/modules/expression/mod.rs
@@ -8,3 +8,23 @@ pub mod parentheses;
 pub mod ternop;
 pub mod typeop;
 pub mod unop;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BoolAnalysis {
+    pub known_value: Option<bool>,
+    /// Whether establishing the known value requires the selected target shell.
+    pub depends_on_target: bool,
+    /// Conservatively includes effects from both operands, even when the
+    /// boolean result is already known. A known result alone cannot elide them.
+    pub has_side_effects: bool,
+}
+
+impl BoolAnalysis {
+  pub fn with_side_effects() -> Self {
+    BoolAnalysis {
+      known_value: None,
+      depends_on_target: false,
+      has_side_effects: true
+    }
+  }
+}

--- a/src/modules/expression/mod.rs
+++ b/src/modules/expression/mod.rs
@@ -12,10 +12,10 @@ pub mod unop;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct BoolAnalysis {
     pub known_value: Option<bool>,
-    /// Whether establishing the known value requires the selected target shell.
+    /// Whether the known value depends on the selected target shell
     pub depends_on_target: bool,
-    /// Conservatively includes effects from both operands, even when the
-    /// boolean result is already known. A known result alone cannot elide them.
+    /// Whether evaluating this expression may contain side effects
+    /// Function calls, commands need to be preserved as they can mutate the environment
     pub has_side_effects: bool,
 }
 

--- a/src/modules/expression/parentheses.rs
+++ b/src/modules/expression/parentheses.rs
@@ -22,6 +22,11 @@ impl Parentheses {
     pub fn extract_facts(&self) -> (HashMap<String, Type>, HashMap<String, Type>) {
         self.value.extract_facts()
     }
+
+    /// Get the inner expression
+    pub fn get_expr(&self) -> &Expr {
+        &self.value
+    }
 }
 
 impl Typed for Parentheses {

--- a/src/modules/expression/parentheses.rs
+++ b/src/modules/expression/parentheses.rs
@@ -7,6 +7,7 @@ use crate::utils::metadata::ParserMetadata;
 use heraclitus_compiler::prelude::*;
 
 use std::collections::HashMap;
+use super::BoolAnalysis;
 
 #[derive(Debug, Clone)]
 pub struct Parentheses {
@@ -15,7 +16,7 @@ pub struct Parentheses {
 }
 
 impl Parentheses {
-    pub fn analyze_control_flow(&self) -> Option<bool> {
+    pub fn analyze_control_flow(&self) -> BoolAnalysis {
         self.value.analyze_control_flow()
     }
 
@@ -23,10 +24,6 @@ impl Parentheses {
         self.value.extract_facts()
     }
 
-    /// Get the inner expression
-    pub fn get_expr(&self) -> &Expr {
-        &self.value
-    }
 }
 
 impl Typed for Parentheses {

--- a/src/modules/expression/ternop/ternary.rs
+++ b/src/modules/expression/ternop/ternary.rs
@@ -11,6 +11,7 @@ pub struct Ternary {
     cond: Box<Expr>,
     true_expr: Option<Box<Expr>>,
     false_expr: Option<Box<Expr>>,
+    control_flow_analysis: Option<bool>,
     kind: Type,
 }
 
@@ -52,6 +53,7 @@ impl SyntaxModule<ParserMetadata> for Ternary {
             cond: Box::new(Expr::new()),
             true_expr: Some(Box::new(Expr::new())),
             false_expr: Some(Box::new(Expr::new())),
+            control_flow_analysis: None,
             kind: Type::Null,
         }
     }
@@ -64,7 +66,10 @@ impl SyntaxModule<ParserMetadata> for Ternary {
 impl TypeCheckModule for Ternary {
     fn typecheck(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         self.cond.typecheck(meta)?;
-        if ! matches!(self.cond.get_type(), Type::Bool | Type::Text | Type::Array(_)) {
+        if !matches!(
+            self.cond.get_type(),
+            Type::Bool | Type::Text | Type::Array(_)
+        ) {
             let msg = self
                 .cond
                 .get_error_message(meta)
@@ -73,7 +78,8 @@ impl TypeCheckModule for Ternary {
         }
 
         // Handle static cases
-        match self.cond.analyze_control_flow() {
+        self.control_flow_analysis = self.cond.analyze_control_flow();
+        match self.control_flow_analysis {
             Some(true) => {
                 let (facts, _) = self.cond.extract_facts();
                 let true_expr = self.true_expr.as_mut().unwrap();
@@ -138,7 +144,7 @@ impl TypeCheckModule for Ternary {
 
 impl TranslateModule for Ternary {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        match self.cond.analyze_control_flow() {
+        match self.control_flow_analysis {
             Some(true) => self
                 .true_expr
                 .as_ref()
@@ -156,10 +162,7 @@ impl TranslateModule for Ternary {
                     .map(|e| e.get_type())
                     .unwrap_or(Type::Null);
                 let is_array = true_type.is_array();
-                let cond = self
-                    .cond
-                    .translate(meta)
-                    .with_condition(true);
+                let cond = self.cond.translate(meta).with_condition(true);
                 let true_expr = self
                     .true_expr
                     .as_ref()
@@ -171,14 +174,14 @@ impl TranslateModule for Ternary {
                     .map(|e| e.translate(meta))
                     .unwrap_or(FragmentKind::Empty);
                 let expr = fragments!(
-                        "if ",
-                        cond,
-                        "; then printf '%s\n' ",
-                        true_expr,
-                        "; else printf '%s\n' ",
-                        false_expr,
-                        "; fi"
-                    );
+                    "if ",
+                    cond,
+                    "; then printf '%s\n' ",
+                    true_expr,
+                    "; else printf '%s\n' ",
+                    false_expr,
+                    "; fi"
+                );
                 if is_array {
                     let id = meta.gen_value_id();
                     let value = SubprocessFragment::new(expr).with_quotes(false).to_frag();

--- a/src/modules/expression/ternop/ternary.rs
+++ b/src/modules/expression/ternop/ternary.rs
@@ -2,6 +2,7 @@ use super::TernOp;
 use crate::fragments;
 use crate::modules::expression::binop::get_binop_position_info;
 use crate::modules::expression::expr::Expr;
+use crate::modules::expression::BoolAnalysis;
 use crate::modules::prelude::*;
 use crate::modules::types::{Type, Typed};
 use heraclitus_compiler::prelude::*;
@@ -11,7 +12,7 @@ pub struct Ternary {
     cond: Box<Expr>,
     true_expr: Option<Box<Expr>>,
     false_expr: Option<Box<Expr>>,
-    control_flow_analysis: Option<bool>,
+    control_flow_analysis: BoolAnalysis,
     kind: Type,
 }
 
@@ -53,7 +54,7 @@ impl SyntaxModule<ParserMetadata> for Ternary {
             cond: Box::new(Expr::new()),
             true_expr: Some(Box::new(Expr::new())),
             false_expr: Some(Box::new(Expr::new())),
-            control_flow_analysis: None,
+            control_flow_analysis: BoolAnalysis::default(),
             kind: Type::Null,
         }
     }
@@ -79,8 +80,11 @@ impl TypeCheckModule for Ternary {
 
         // Handle static cases
         self.control_flow_analysis = self.cond.analyze_control_flow();
-        match self.control_flow_analysis {
-            Some(true) => {
+        match (
+            self.control_flow_analysis.known_value,
+            self.control_flow_analysis.has_side_effects,
+        ) {
+            (Some(true), false) => {
                 let (facts, _) = self.cond.extract_facts();
                 let true_expr = self.true_expr.as_mut().unwrap();
                 meta.with_narrowed_scope(facts, |meta| true_expr.typecheck(meta))?;
@@ -88,7 +92,7 @@ impl TypeCheckModule for Ternary {
                 self.false_expr = None;
                 return Ok(());
             }
-            Some(false) => {
+            (Some(false), false) => {
                 let (_, facts) = self.cond.extract_facts();
                 let false_expr = self.false_expr.as_mut().unwrap();
                 meta.with_narrowed_scope(facts, |meta| false_expr.typecheck(meta))?;
@@ -144,18 +148,21 @@ impl TypeCheckModule for Ternary {
 
 impl TranslateModule for Ternary {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        match self.control_flow_analysis {
-            Some(true) => self
+        match (
+            self.control_flow_analysis.known_value,
+            self.control_flow_analysis.has_side_effects,
+        ) {
+            (Some(true), false) => self
                 .true_expr
                 .as_ref()
                 .map(|e| e.translate(meta))
                 .unwrap_or(FragmentKind::Empty),
-            Some(false) => self
+            (Some(false), false) => self
                 .false_expr
                 .as_ref()
                 .map(|e| e.translate(meta))
                 .unwrap_or(FragmentKind::Empty),
-            None => {
+            _ => {
                 let true_type = self
                     .true_expr
                     .as_ref()

--- a/src/modules/expression/ternop/ternary.rs
+++ b/src/modules/expression/ternop/ternary.rs
@@ -12,7 +12,7 @@ pub struct Ternary {
     cond: Box<Expr>,
     true_expr: Option<Box<Expr>>,
     false_expr: Option<Box<Expr>>,
-    control_flow_analysis: BoolAnalysis,
+    cfa: BoolAnalysis,
     kind: Type,
 }
 
@@ -54,7 +54,7 @@ impl SyntaxModule<ParserMetadata> for Ternary {
             cond: Box::new(Expr::new()),
             true_expr: Some(Box::new(Expr::new())),
             false_expr: Some(Box::new(Expr::new())),
-            control_flow_analysis: BoolAnalysis::default(),
+            cfa: BoolAnalysis::default(),
             kind: Type::Null,
         }
     }
@@ -79,10 +79,10 @@ impl TypeCheckModule for Ternary {
         }
 
         // Handle static cases
-        self.control_flow_analysis = self.cond.analyze_control_flow();
+        self.cfa = self.cond.analyze_control_flow();
         match (
-            self.control_flow_analysis.known_value,
-            self.control_flow_analysis.has_side_effects,
+            self.cfa.known_value,
+            self.cfa.has_side_effects,
         ) {
             (Some(true), false) => {
                 let (facts, _) = self.cond.extract_facts();
@@ -149,8 +149,8 @@ impl TypeCheckModule for Ternary {
 impl TranslateModule for Ternary {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
         match (
-            self.control_flow_analysis.known_value,
-            self.control_flow_analysis.has_side_effects,
+            self.cfa.known_value,
+            self.cfa.has_side_effects,
         ) {
             (Some(true), false) => self
                 .true_expr

--- a/src/modules/expression/typeop/is.rs
+++ b/src/modules/expression/typeop/is.rs
@@ -9,6 +9,7 @@ use super::TypeOp;
 use std::collections::HashMap;
 
 use crate::modules::expression::expr::ExprType;
+use crate::modules::expression::BoolAnalysis;
 
 #[derive(Debug, Clone)]
 pub struct Is {
@@ -17,20 +18,20 @@ pub struct Is {
 }
 
 impl Is {
-    pub fn analyze_control_flow(&self) -> Option<bool> {
+    pub fn analyze_control_flow(&self) -> BoolAnalysis {
         let expr_type = self.expr.get_type();
 
         // If types are identical, it's always true
         if expr_type == self.kind {
-            return Some(true);
+            return BoolAnalysis { known_value: Some(true), ..BoolAnalysis::default() };
         }
 
         // If types cannot possibly intersect, it's always false
         if !expr_type.can_intersect(&self.kind) {
-            return Some(false);
+            return BoolAnalysis { known_value: Some(false), ..BoolAnalysis::default() };
         }
 
-        None
+        BoolAnalysis::default()
     }
 
     pub fn extract_facts(&self) -> (HashMap<String, Type>, HashMap<String, Type>) {

--- a/src/modules/expression/unop/not.rs
+++ b/src/modules/expression/unop/not.rs
@@ -15,15 +15,20 @@ use crate::modules::expression::BoolAnalysis;
 #[keyword = "not"]
 pub struct Not {
     expr: Box<Expr>,
+    cfa: BoolAnalysis,
 }
 
 impl Not {
     pub fn analyze_control_flow(&self) -> BoolAnalysis {
-        let analysis = self.expr.analyze_control_flow();
+        self.cfa
+    }
+
+    fn compute_cfa(&self) -> BoolAnalysis {
+        let cfa = self.expr.analyze_control_flow();
         BoolAnalysis {
-            known_value: analysis.known_value.map(|value| !value),
-            depends_on_target: analysis.depends_on_target,
-            has_side_effects: analysis.has_side_effects,
+            known_value: cfa.known_value.map(|value| !value),
+            depends_on_target: cfa.depends_on_target,
+            has_side_effects: cfa.has_side_effects,
         }
     }
 
@@ -56,6 +61,7 @@ impl SyntaxModule<ParserMetadata> for Not {
     fn new() -> Self {
         Not {
             expr: Box::new(Expr::new()),
+            cfa: BoolAnalysis::default(),
         }
     }
 
@@ -77,14 +83,15 @@ impl TypeCheckModule for Not {
                 Type::Array(Box::new(Type::Generic))
             ]
         )?;
+        self.cfa = self.compute_cfa();
         Ok(())
     }
 }
 
 impl TranslateModule for Not {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        let analysis = self.analyze_control_flow();
-        if let (Some(const_value), false) = (analysis.known_value, analysis.has_side_effects) {
+        let cfa = self.cfa;
+        if let (Some(const_value), false) = (cfa.known_value, cfa.has_side_effects) {
             RawFragment::from((if const_value { "1" } else { "0" }).to_string()).to_frag()
         } else {
             let is_iterable = matches!(self.expr.kind, Type::Text | Type::Array(_));

--- a/src/modules/expression/unop/not.rs
+++ b/src/modules/expression/unop/not.rs
@@ -9,6 +9,7 @@ use amber_meta::AutoKeyword;
 use heraclitus_compiler::prelude::*;
 
 use std::collections::HashMap;
+use crate::modules::expression::BoolAnalysis;
 
 #[derive(Debug, Clone, AutoKeyword)]
 #[keyword = "not"]
@@ -17,13 +18,13 @@ pub struct Not {
 }
 
 impl Not {
-    pub fn analyze_control_flow(&self) -> Option<bool> {
-        self.expr.analyze_control_flow().map(|b| !b)
-    }
-
-    /// Check if this expression has side effects (function calls, commands, etc.)
-    pub fn has_side_effects(&self) -> bool {
-        self.expr.has_side_effects()
+    pub fn analyze_control_flow(&self) -> BoolAnalysis {
+        let analysis = self.expr.analyze_control_flow();
+        BoolAnalysis {
+            known_value: analysis.known_value.map(|value| !value),
+            depends_on_target: analysis.depends_on_target,
+            has_side_effects: analysis.has_side_effects,
+        }
     }
 
     pub fn extract_facts(&self) -> (HashMap<String, Type>, HashMap<String, Type>) {
@@ -67,12 +68,12 @@ impl TypeCheckModule for Not {
     fn typecheck(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         self.expr.typecheck(meta)?;
         Self::typecheck_allowed_types(
-            meta, 
-            "logical negation", 
-            &self.expr, 
+            meta,
+            "logical negation",
+            &self.expr,
             &[
-                Type::Bool, 
-                Type::Text, 
+                Type::Bool,
+                Type::Text,
                 Type::Array(Box::new(Type::Generic))
             ]
         )?;
@@ -82,14 +83,9 @@ impl TypeCheckModule for Not {
 
 impl TranslateModule for Not {
     fn translate(&self, meta: &mut TranslateMetadata) -> FragmentKind {
-        if let Some(const_value) = self.analyze_control_flow() {
-            // Only fold if the expression is effect-free
-            if !self.expr.has_side_effects() {
-                RawFragment::from((if const_value { "1" } else { "0" }).to_string()).to_frag()
-            } else {
-                let expr = self.expr.translate(meta).with_condition(false);
-                ArithmeticFragment::new(None, ArithOp::Not, expr).to_frag()
-            }
+        let analysis = self.analyze_control_flow();
+        if let (Some(const_value), false) = (analysis.known_value, analysis.has_side_effects) {
+            RawFragment::from((if const_value { "1" } else { "0" }).to_string()).to_frag()
         } else {
             let is_iterable = matches!(self.expr.kind, Type::Text | Type::Array(_));
             let expr = self.expr.translate(meta).with_condition(is_iterable);

--- a/src/std/env.ab
+++ b/src/std/env.ab
@@ -14,7 +14,7 @@ import * from "std/text"
 /// ```
 pub fun env_var_test(name: Text): Bool {
     if {
-        shellname() == "zsh": $ [[ -v \$\{(P){nameof(name)}} ]] $ failed { return false }
+        shellname() == "zsh": $ [[ -v "{name}" ]] $ failed { return false }
         shellname() == "bash": $ declare -p -- "{name}" > /dev/null 2> /dev/null $ failed { return false }
         shellname() == "ksh": $ eval "[ \"\\\$\{\${nameof(name)}+x}\" = x ]" $ failed { return false }
     }

--- a/src/std/env.ab
+++ b/src/std/env.ab
@@ -14,7 +14,7 @@ import * from "std/text"
 /// ```
 pub fun env_var_test(name: Text): Bool {
     if {
-        shellname() == "zsh": $ [[ ! -z \$\{(P){nameof(name)}+z} ]] $ failed { return false }
+        shellname() == "zsh": $ eval "[[ ! -z \"\$\{\$\{{nameof(name)}}+z}\" ]]" $ failed { return false }
         shellname() == "bash": $ declare -p -- "{name}" > /dev/null 2> /dev/null $ failed { return false }
         shellname() == "ksh": $ eval "[ \"\\\$\{\${nameof(name)}+x}\" = x ]" $ failed { return false }
     }
@@ -52,7 +52,7 @@ pub fun env_var_set(name: Text, val: Text | Int | Bool): Null? {
 pub fun env_var_get(name: Text): Text? {
     if {
         shellname() == "bash": return $ printf "%s\n" "\$\{!{nameof(name)}}" $?
-        shellname() == "zsh": return $ printf "%s\n" "\$\{(P){nameof(name)}}" $?
+        shellname() == "zsh": return $ eval "printf \"%s\\n\" \"\$\{\$\{{nameof(name)}}}\"" $?
         shellname() == "ksh": return  $ eval "echo \\\$\{\${nameof(name)}}" $?
     }
 }

--- a/src/std/env.ab
+++ b/src/std/env.ab
@@ -14,7 +14,7 @@ import * from "std/text"
 /// ```
 pub fun env_var_test(name: Text): Bool {
     if {
-        shellname() == "zsh": $ eval "[[ ! -z \"\$\{\$\{{nameof(name)}}+z}\" ]]" $ failed { return false }
+        shellname() == "zsh": $ [[ -v \$\{(P){nameof(name)}} ]] $ failed { return false }
         shellname() == "bash": $ declare -p -- "{name}" > /dev/null 2> /dev/null $ failed { return false }
         shellname() == "ksh": $ eval "[ \"\\\$\{\${nameof(name)}+x}\" = x ]" $ failed { return false }
     }
@@ -52,7 +52,7 @@ pub fun env_var_set(name: Text, val: Text | Int | Bool): Null? {
 pub fun env_var_get(name: Text): Text? {
     if {
         shellname() == "bash": return $ printf "%s\n" "\$\{!{nameof(name)}}" $?
-        shellname() == "zsh": return $ eval "printf \"%s\\n\" \"\$\{\$\{{nameof(name)}}}\"" $?
+        shellname() == "zsh": return $ printf "%s\n" "\$\{(P){nameof(name)}}" $?
         shellname() == "ksh": return  $ eval "echo \\\$\{\${nameof(name)}}" $?
     }
 }

--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -76,16 +76,16 @@ pub fun replace_regex(source: Text, search: Text, replace_text: Text, extended: 
             // GNU sed versions 4.0 through 4.2 support extended regex syntax,
             // but only via the "-r" option
             if sed_version == SED_VERSION_GNU {
-                return $ sed -r -e "s/{search}/{replace_text}/g" <<<"{source}" $
+                return $ command sed -r -e "s/{search}/{replace_text}/g" <<<"{source}" $
             } else {
-                return $ sed -E -e "s/{search}/{replace_text}/g" <<<"{source}" $
+                return $ command sed -E -e "s/{search}/{replace_text}/g" <<<"{source}" $
             }
         } else {
             if sed_version == SED_VERSION_GNU or sed_version == SED_VERSION_BUSYBOX {
                 // GNU Sed BRE handle \| as a metacharacter, but it is not POSIX standands. Disable it
                 search = replace(search, "\|", "|")
             }
-            return $ sed -e "s/{search}/{replace_text}/g" <<<"{source}" $
+            return $ command sed -e "s/{search}/{replace_text}/g" <<<"{source}" $
         }
     }
 }

--- a/src/std/text.ab
+++ b/src/std/text.ab
@@ -41,12 +41,12 @@ const SED_VERSION_BUSYBOX = 2
 fun sed_version(): Int {
     // We can't match against a word "GNU" because
     // alpine's busybox sed returns "This is not GNU sed version"
-    trust $ re='Copyright.+Free Software Foundation'; [[ \$(sed --version 2>/dev/null) =~ \$re ]] $
+    trust $ re='Copyright.+Free Software Foundation'; [[ \$(command sed --version 2>/dev/null) =~ \$re ]] $
     if status() == 0 {
         return SED_VERSION_GNU
     }
     // On BSD single `sed` waits for stdin. We must use `sed --help` to avoid this.
-    trust $ re='BusyBox'; [[ \$(sed --help 2>&1) =~ \$re ]] $
+    trust $ re='BusyBox'; [[ \$(command sed --help 2>&1) =~ \$re ]] $
     if status() == 0 {
         return SED_VERSION_BUSYBOX
     }
@@ -343,16 +343,16 @@ pub fun match_regex(source: Text, search: Text, extended: Bool = false): Bool {
             if sed_version == SED_VERSION_GNU {
                 // '\b' is not in POSIX standards. Disable it
                 search = replace(search, "\b", "\\b")
-                output = $ sed -r -ne "/{search}/p" <<<"{source}" $
+                output = $ command sed -r -ne "/{search}/p" <<<"{source}" $
             } else {
-                output = $ sed -E -ne "/{search}/p" <<<"{source}" $
+                output = $ command sed -E -ne "/{search}/p" <<<"{source}" $
             }
         } else {
             if sed_version == SED_VERSION_GNU or sed_version == SED_VERSION_BUSYBOX {
                 // GNU Sed BRE handle \| as a metacharacter, but it is not POSIX standands. Disable it
                 search = replace(search, "\|", "|")
             }
-            output = $ sed -ne "/{search}/p" <<<"{source}" $
+            output = $ command sed -ne "/{search}/p" <<<"{source}" $
         }
         if output != "" {
             return true
@@ -465,7 +465,7 @@ pub fun capitalized(text: Text): Text {
         }
         if sed_version() == SED_VERSION_GNU {
             // GNU sed supports \U
-            return $ printf '%s\n' "{text}" | sed 's/^\(.\)/\U\1/' $
+            return $ printf '%s\n' "{text}" | command sed 's/^\(.\)/\U\1/' $
         }
         const first_letter = uppercase(char_at(text, 0))
         return first_letter + slice(text, 1)

--- a/src/tests/compiling/ifchain_dynamic_then_constant_true.ab
+++ b/src/tests/compiling/ifchain_dynamic_then_constant_true.ab
@@ -1,0 +1,19 @@
+// Output
+// Succeeded
+
+main(args) {
+    if shellname() == "bash" {
+        trust $ enable -n true; true() \{ return 1; } $
+
+        if {
+            len(args) > 1 {
+                echo("dynamic")
+            }
+            shellname() == "bash" {
+                echo("Succeeded")
+            }
+        }
+    } else {
+        echo("Succeeded")
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -113,22 +113,78 @@ pub fn extract_output(code: impl Into<String>) -> String {
         .join("\n")
 }
 
+/// Extracts the expected output for `family` from `// Output [family]` blocks.
+/// Returns None when the file declares no tagged blocks (plain `// Output` format).
+/// Panics when tagged blocks are declared but none matches the current target.
+pub fn extract_targeted_output(code: &str, family: &str) -> Option<String> {
+    let lines: Vec<&str> = code.lines().collect();
+    let mut tags: Vec<String> = Vec::new();
+    let mut blocks: Vec<(String, String)> = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        match output_tag(lines[i]) {
+            Some(tag) => {
+                let mut content: Vec<&str> = Vec::new();
+                i += 1;
+                while i < lines.len()
+                    && lines[i].starts_with("//")
+                    && output_tag(lines[i]).is_none()
+                {
+                    content.push(lines[i].trim_start_matches("//").trim());
+                    i += 1;
+                }
+                tags.push(tag.clone());
+                blocks.push((tag, content.join("\n")));
+            }
+            None => i += 1,
+        }
+    }
+    if blocks.is_empty() {
+        return None;
+    }
+    match blocks.into_iter().find(|(tag, _)| tag == family) {
+        Some((_, content)) => Some(content),
+        None => panic!(
+            "per-target output declared for [{}] but no block for target '{family}'",
+            tags.join(", ")
+        ),
+    }
+}
+
+fn output_tag(line: &str) -> Option<String> {
+    let tag = line
+        .strip_prefix("// Output [")?
+        .strip_suffix("]")?
+        .to_string();
+    if tag.is_empty() {
+        return None;
+    }
+    Some(tag)
+}
+
 /// Inner test logic for testing script output in case of success or failure
 pub fn script_test(input: &str, target: TestOutcomeTarget) {
     let code =
         fs::read_to_string(input).unwrap_or_else(|_| panic!("Failed to open {input} test file"));
-    // Extract output from script comment
-    let mut output = extract_output(&code);
-    // If output is not in comment, try to read from .output.txt file
-    if output.is_empty() {
-        let path = PathBuf::from(input.replace(".ab", ".output.txt"));
-        output = if path.exists() {
-            fs::read_to_string(&path)
-                .unwrap_or_else(|_| panic!("Failed to open {} test file", path.display()))
-        } else {
-            SUCCEEDED.to_string()
-        };
-    }
+    // Per-target `// Output [target]` blocks take precedence over the plain
+    // `// Output` block and the .output.txt fallback.
+    let family = AmberCompiler::resolve_target_shell(None).family_name();
+    let output = match extract_targeted_output(&code, family) {
+        Some(targeted) => targeted,
+        None => {
+            let mut output = extract_output(&code);
+            if output.is_empty() {
+                let path = PathBuf::from(input.replace(".ab", ".output.txt"));
+                output = if path.exists() {
+                    fs::read_to_string(&path)
+                        .unwrap_or_else(|_| panic!("Failed to open {} test file", path.display()))
+                } else {
+                    SUCCEEDED.to_string()
+                };
+            }
+            output
+        }
+    };
     test_amber(&code, &output, target);
 }
 
@@ -158,5 +214,33 @@ not output
             ),
             "expected\noutput"
         );
+    }
+
+    #[test]
+    fn test_extract_targeted_output() {
+        let code = "\nsome code\n// Output [bash]\n// 1\n// Output [zsh]\n// 0\n// Output [ksh]\n// 0\n\nmore code\n";
+        assert_eq!(extract_targeted_output(code, "bash").as_deref(), Some("1"));
+        assert_eq!(extract_targeted_output(code, "zsh").as_deref(), Some("0"));
+        assert_eq!(extract_targeted_output(code, "ksh").as_deref(), Some("0"));
+    }
+
+    #[test]
+    fn test_extract_targeted_output_empty_block() {
+        let code = "// Output [bash]\n// 1\n// Output [zsh]\n// Output [ksh]\n";
+        assert_eq!(extract_targeted_output(code, "bash").as_deref(), Some("1"));
+        assert_eq!(extract_targeted_output(code, "zsh").as_deref(), Some(""));
+        assert_eq!(extract_targeted_output(code, "ksh").as_deref(), Some(""));
+    }
+
+    #[test]
+    fn test_extract_targeted_output_plain_format_returns_none() {
+        let code = "// Output\n// plain output\n";
+        assert_eq!(extract_targeted_output(code, "bash"), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "no block for target 'ksh'")]
+    fn test_extract_targeted_output_missing_family_panics() {
+        extract_targeted_output("// Output [bash]\n// 1\n", "ksh");
     }
 }

--- a/src/tests/optimizing/expression_folding.rs
+++ b/src/tests/optimizing/expression_folding.rs
@@ -69,6 +69,22 @@ fn and_preserves_right_side_effect() {
 }
 
 #[test]
+fn and_preserves_side_effect_in_interpolated_text() {
+    let code = r#"
+fun effectful_text_fn(): Text {
+    echo("side")
+    return "text"
+}
+
+main {
+    let result = false and ("{effectful_text_fn()}" == "text")
+    echo(result)
+}
+"#;
+    assert_side_effect_runs(code, "side");
+}
+
+#[test]
 fn and_none_branch_variable() {
     let code = compile_code(r#"main { let x = true echo("{x and true}") }"#);
     assert!(

--- a/src/tests/optimizing/expression_folding.rs
+++ b/src/tests/optimizing/expression_folding.rs
@@ -1,17 +1,13 @@
 //! Tests for constant folding in logical expressions (And, Or, Not)
-//! and the Expr::has_side_effects() method.
+//! and side-effect-aware boolean analysis.
 //!
 //! These tests cover the translate() branches in and.rs, or.rs, not.rs,
-//! the has_side_effects() match arms in expr.rs, and the with_math_var()
-//! fallback in fragment.rs.
-use crate::modules::expression::expr::Expr;
+//! preservation of effects from both operands, and the with_math_var() fallback in
+//! fragment.rs.
 use crate::modules::prelude::FragmentKind;
 use crate::tests::{compile_code, eval_bash};
-use heraclitus_compiler::prelude::*;
 
 const SIDE_EFFECT_FN: &str = "fun side_effect(): Bool {\n echo(\"side\")\n return true\n}\n";
-
-const SIMPLE_FN: &str = "fun f(): Bool {\n echo(\"f_called\")\n return true\n}\n";
 
 /// Compile Amber source, execute the resulting shell, and assert that
 /// `needle` appears in stdout — proving the side-effect was not folded away.
@@ -63,6 +59,14 @@ fn and_fold_false_and_true() {
 #[test]
 fn and_preserve_side_effects() {
     assert_side_effect_runs(
+        &(SIDE_EFFECT_FN.to_string() + r#"main { echo("{side_effect() and false}") }"#),
+        "side",
+    );
+}
+
+#[test]
+fn and_preserves_right_side_effect() {
+    assert_side_effect_runs(
         &(SIDE_EFFECT_FN.to_string() + r#"main { echo("{false and side_effect()}") }"#),
         "side",
     );
@@ -107,6 +111,14 @@ fn or_fold_false_or_false() {
 
 #[test]
 fn or_preserve_side_effects() {
+    assert_side_effect_runs(
+        &(SIDE_EFFECT_FN.to_string() + r#"main { echo("{side_effect() or true}") }"#),
+        "side",
+    );
+}
+
+#[test]
+fn or_preserves_right_side_effect() {
     assert_side_effect_runs(
         &(SIDE_EFFECT_FN.to_string() + r#"main { echo("{true or side_effect()}") }"#),
         "side",
@@ -168,76 +180,6 @@ fn not_none_branch_text_variable() {
     assert!(
         !code.contains("$(("),
         "not text should use condition-based NOT, not arithmetic\n--- output ---\n{code}"
-    );
-}
-
-// ===== Expr::has_side_effects() coverage (expr.rs) =====
-//
-// Each test below targets a specific match arm in has_side_effects().
-
-#[test]
-fn has_side_effects_bool_arm() {
-    // true and true: both operands are Bool -> has_side_effects returns false -> fold
-    assert_folds_to_one(r#"main { echo("{true and true}") }"#);
-}
-
-#[test]
-fn has_side_effects_variable_get_arm() {
-    // false and x: x is VariableGet -> has_side_effects returns false -> fold
-    assert_folds_to_zero(r#"main { let x = true echo("{false and x}") }"#);
-}
-
-#[test]
-fn has_side_effects_and_arm() {
-    // (false and true) and false: left is And -> delegates to And::has_side_effects
-    assert_folds_to_zero(r#"main { echo("{false and true and false}") }"#);
-}
-
-#[test]
-fn has_side_effects_or_arm() {
-    // (true or false) or true: left is Or -> delegates to Or::has_side_effects
-    let out = compile_code(r#"main { echo("{true or false or true}") }"#);
-    assert!(
-        out.contains("\"1\""),
-        "Should fold to 1\n--- output ---\n{out}"
-    );
-    assert!(
-        !out.contains("||"),
-        "Folded should not contain ||\n--- output ---\n{out}"
-    );
-}
-
-#[test]
-fn has_side_effects_not_arm() {
-    // false and not true: right is Not -> delegates to Not::has_side_effects
-    assert_folds_to_zero(r#"main { echo("{false and not true}") }"#);
-}
-
-#[test]
-fn has_side_effects_function_invocation_arm() {
-    assert_side_effect_runs(
-        &(SIMPLE_FN.to_string() + r#"main { echo("{false and f()}") }"#),
-        "f_called",
-    );
-}
-
-#[test]
-fn has_side_effects_some_wildcard_arm() {
-    // not (false and side_effect()): the Parentheses wrapping the And hits
-    // the Some(_) => true catch-all in has_side_effects.
-    assert_side_effect_runs(
-        &(SIDE_EFFECT_FN.to_string() + r#"main { echo("{not (false and side_effect())}") }"#),
-        "side",
-    );
-}
-
-#[test]
-fn has_side_effects_none_arm() {
-    // Expr::new() has value=None -> has_side_effects returns false
-    let expr = Expr::new();
-    assert!(
-        !expr.has_side_effects(),
-        "Default Expr (value=None) should have no side effects"
     );
 }
 

--- a/src/tests/optimizing/expression_folding.rs
+++ b/src/tests/optimizing/expression_folding.rs
@@ -1,16 +1,12 @@
-//! Tests for constant folding in logical expressions (And, Or, Not)
-//! and side-effect-aware boolean analysis.
-//!
-//! These tests cover the translate() branches in and.rs, or.rs, not.rs,
-//! preservation of effects from both operands, and the with_math_var() fallback in
-//! fragment.rs.
+//! Tests for constant folding in logical expressions (`And`, `Or`, and `Not`)
+//! driven by side-effect-aware control-flow analysis.
 use crate::modules::prelude::FragmentKind;
 use crate::tests::{compile_code, eval_bash};
 
 const SIDE_EFFECT_FN: &str = "fun side_effect(): Bool {\n echo(\"side\")\n return true\n}\n";
 
-/// Compile Amber source, execute the resulting shell, and assert that
-/// `needle` appears in stdout — proving the side-effect was not folded away.
+/// Compile and execute Amber source, then verify that constant folding preserved
+/// the observable output produced by a side effect.
 fn assert_side_effect_runs(code: &str, needle: &str) {
     let shell = compile_code(code);
     let (stdout, stderr) = eval_bash(shell);

--- a/src/tests/snapshots/amber__tests__compiling__array_get_negative_index_by_ref.ab__bash-3.2.snap
+++ b/src/tests/snapshots/amber__tests__compiling__array_get_negative_index_by_ref.ab__bash-3.2.snap
@@ -35,7 +35,7 @@ comp="$(
     done
     (( "${#left_comp[@]}" < "${#right_comp[@]}" )) && echo 1 || echo 0
 )"
-if { [[ "${EXEC_SHELL}" == "bash" ]] && [[ "${comp}" != 0 ]]; }; then
+if { true && [[ "${comp}" != 0 ]]; }; then
     echo "Succeeded"
     exit 0
 fi

--- a/src/tests/snapshots/amber__tests__compiling__ifchain_dynamic_then_constant_true.ab__bash-3.2.snap
+++ b/src/tests/snapshots/amber__tests__compiling__ifchain_dynamic_then_constant_true.ab__bash-3.2.snap
@@ -1,0 +1,15 @@
+---
+source: src/tests/compiling.rs
+expression: ast
+---
+# Output
+# Succeeded
+typeset -r args_0=("$0" "$@")
+: "${args_0[@]}"
+enable -n true; true() { return 1; } && __status=0 || __status=$?
+__length_1=("${args_0[@]}")
+if (( ${#__length_1[@]} > 1 )); then
+    echo "dynamic"
+else
+    echo "Succeeded"
+fi

--- a/src/tests/snapshots/amber__tests__compiling__ifchain_dynamic_then_constant_true.ab__bash-4.3.snap
+++ b/src/tests/snapshots/amber__tests__compiling__ifchain_dynamic_then_constant_true.ab__bash-4.3.snap
@@ -1,0 +1,15 @@
+---
+source: src/tests/compiling.rs
+expression: ast
+---
+# Output
+# Succeeded
+typeset -r args_0=("$0" "$@")
+: "${args_0[@]}"
+enable -n true; true() { return 1; } && __status=0 || __status=$?
+__length_1=("${args_0[@]}")
+if (( ${#__length_1[@]} > 1 )); then
+    echo "dynamic"
+else
+    echo "Succeeded"
+fi

--- a/src/tests/snapshots/amber__tests__compiling__ifchain_dynamic_then_constant_true.ab__ksh.snap
+++ b/src/tests/snapshots/amber__tests__compiling__ifchain_dynamic_then_constant_true.ab__ksh.snap
@@ -1,0 +1,9 @@
+---
+source: src/tests/compiling.rs
+expression: ast
+---
+# Output
+# Succeeded
+typeset -r args_0=("$0" "$@")
+: "${args_0[@]}"
+echo "Succeeded"

--- a/src/tests/snapshots/amber__tests__compiling__ifchain_dynamic_then_constant_true.ab__zsh.snap
+++ b/src/tests/snapshots/amber__tests__compiling__ifchain_dynamic_then_constant_true.ab__zsh.snap
@@ -1,0 +1,9 @@
+---
+source: src/tests/compiling.rs
+expression: ast
+---
+# Output
+# Succeeded
+typeset -r args_0=("$0" "$@")
+: "${args_0[@]}"
+echo "Succeeded"

--- a/src/tests/validity/expr_try_fold_constant.ab
+++ b/src/tests/validity/expr_try_fold_constant.ab
@@ -1,6 +1,8 @@
 // Test expression constant folding via try_fold_bool_constant
-// Output
+// Output [bash]
 // 1
+// Output [zsh]
+// Output [ksh]
 
 if (shellname() == "bash") {
     echo("1")

--- a/src/tests/validity/expr_try_fold_constant.ab
+++ b/src/tests/validity/expr_try_fold_constant.ab
@@ -1,0 +1,7 @@
+// Test expression constant folding via try_fold_bool_constant
+// Output
+// 1
+
+if (shellname() == "bash") {
+    echo("1")
+}

--- a/src/tests/validity/false_literal_ifchain.ab
+++ b/src/tests/validity/false_literal_ifchain.ab
@@ -1,0 +1,13 @@
+// Test ifchain with literal false condition
+// Output
+// Condition is always false, block will never execute
+// else_taken
+
+if {
+    false {
+        echo("skipped")
+    }
+    else {
+        echo("else_taken")
+    }
+}

--- a/src/tests/validity/ifchain_constant_false_first.ab
+++ b/src/tests/validity/ifchain_constant_false_first.ab
@@ -1,6 +1,9 @@
 // Test ifchain with constant-false first condition - should execute else
-// shellname() == "zsh" is always false for bash target, so else executes
-// Output
+// Output [bash]
+// B
+// Output [zsh]
+// A
+// Output [ksh]
 // B
 
 if shellname() == "zsh" {

--- a/src/tests/validity/ifchain_constant_false_first.ab
+++ b/src/tests/validity/ifchain_constant_false_first.ab
@@ -1,0 +1,10 @@
+// Test ifchain with constant-false first condition - should execute else
+// shellname() == "zsh" is always false for bash target, so else executes
+// Output
+// B
+
+if shellname() == "zsh" {
+    echo("A")
+} else {
+    echo("B")
+}

--- a/src/tests/validity/ifchain_constant_true_first.ab
+++ b/src/tests/validity/ifchain_constant_true_first.ab
@@ -1,0 +1,10 @@
+// Test ifchain with constant-true first condition - else should be pruned
+// shellname() == "bash" is always true for bash target, so else block is dead
+// Output
+// A
+
+if shellname() == "bash" {
+    echo("A")
+} else {
+    echo("B")
+}

--- a/src/tests/validity/ifchain_constant_true_first.ab
+++ b/src/tests/validity/ifchain_constant_true_first.ab
@@ -1,7 +1,10 @@
 // Test ifchain with constant-true first condition - else should be pruned
-// shellname() == "bash" is always true for bash target, so else block is dead
-// Output
+// Output [bash]
 // A
+// Output [zsh]
+// B
+// Output [ksh]
+// B
 
 if shellname() == "bash" {
     echo("A")

--- a/src/tests/validity/ifchain_constant_true_prunes_else.ab
+++ b/src/tests/validity/ifchain_constant_true_prunes_else.ab
@@ -1,6 +1,10 @@
 // Test ifchain where constant-true prunes the else block entirely
-// Output
+// Output [bash]
 // first
+// Output [zsh]
+// third
+// Output [ksh]
+// third
 
 if {
     shellname() == "bash" {

--- a/src/tests/validity/ifchain_constant_true_prunes_else.ab
+++ b/src/tests/validity/ifchain_constant_true_prunes_else.ab
@@ -1,0 +1,12 @@
+// Test ifchain where constant-true prunes the else block entirely
+// Output
+// first
+
+if {
+    shellname() == "bash" {
+        echo("first")
+    }
+    else {
+        echo("third")
+    }
+}

--- a/src/tests/validity/ifchain_dynamic_then_constant_true.ab
+++ b/src/tests/validity/ifchain_dynamic_then_constant_true.ab
@@ -1,14 +1,20 @@
-// Test ifchain with dynamic condition followed by constant-true
-// Dynamic x==1 (x is let, not const) then true constant becomes else
+// A target-known true branch only terminates the chain when every preceding
+// reachable branch also terminates.
 // Output
-// constant_true
+// dynamic
+// after-chain
 
-let x = 0
-if {
-    x == 1 {
-        echo("dynamic")
+fun run(flag: Bool): Text {
+    if {
+        flag {
+            echo("dynamic")
+        }
+        shellname() == "bash" {
+            return "bash-branch"
+        }
     }
-    true {
-        echo("constant_true")
-    }
+
+    return "after-chain"
 }
+
+echo(run(true))

--- a/src/tests/validity/ifchain_dynamic_then_constant_true.ab
+++ b/src/tests/validity/ifchain_dynamic_then_constant_true.ab
@@ -1,0 +1,14 @@
+// Test ifchain with dynamic condition followed by constant-true
+// Dynamic x==1 (x is let, not const) then true constant becomes else
+// Output
+// constant_true
+
+let x = 0
+if {
+    x == 1 {
+        echo("dynamic")
+    }
+    true {
+        echo("constant_true")
+    }
+}

--- a/src/tests/validity/ifchain_else_with_constant_true.ab
+++ b/src/tests/validity/ifchain_else_with_constant_true.ab
@@ -1,0 +1,14 @@
+// Test ifchain where constant-true after dynamic becomes else block
+// Dynamic x==1 (x is let, not const) then true constant becomes else
+// Output
+// constant_true
+
+let x = 0
+if {
+    x == 1 {
+        echo("dynamic")
+    }
+    true {
+        echo("constant_true")
+    }
+}

--- a/src/tests/validity/ifchain_multiple_conditions.ab
+++ b/src/tests/validity/ifchain_multiple_conditions.ab
@@ -1,7 +1,13 @@
 // Test ifchain with multiple conditions including constant-true
-// Output
+// Output [bash]
 // Condition is always false, block will never execute
 // constant
+// Output [zsh]
+// Condition is always false, block will never execute
+// also_never
+// Output [ksh]
+// Condition is always false, block will never execute
+// also_never
 
 if {
     false {

--- a/src/tests/validity/ifchain_multiple_conditions.ab
+++ b/src/tests/validity/ifchain_multiple_conditions.ab
@@ -1,0 +1,16 @@
+// Test ifchain with multiple conditions including constant-true
+// Output
+// Condition is always false, block will never execute
+// constant
+
+if {
+    false {
+        echo("first")
+    }
+    shellname() == "bash" {
+        echo("constant")
+    }
+    else {
+        echo("also_never")
+    }
+}

--- a/src/tests/validity/parentheses_bool.ab
+++ b/src/tests/validity/parentheses_bool.ab
@@ -1,0 +1,7 @@
+// Test parentheses with boolean expressions
+// Output
+// 1
+
+if (true) {
+    echo("1")
+}

--- a/src/tests/validity/parentheses_expr.ab
+++ b/src/tests/validity/parentheses_expr.ab
@@ -1,0 +1,5 @@
+// Test parentheses wrapping expressions
+// Output
+// 42
+
+echo((21 + 21))

--- a/src/tests/validity/parentheses_nested.ab
+++ b/src/tests/validity/parentheses_nested.ab
@@ -1,0 +1,5 @@
+// Test nested parentheses
+// Output
+// 100
+
+echo(((10 * 10)))

--- a/src/tests/validity/shellname_eq_bash.ab
+++ b/src/tests/validity/shellname_eq_bash.ab
@@ -1,7 +1,10 @@
 // Test shellname() == "bash" folding to constant based on target
-// For bash target, this should fold to "1" (true)
-// Output
+// Output [bash]
 // 1
+// Output [zsh]
+// 0
+// Output [ksh]
+// 0
 
 if shellname() == "bash" {
     echo("1")

--- a/src/tests/validity/shellname_eq_bash.ab
+++ b/src/tests/validity/shellname_eq_bash.ab
@@ -1,0 +1,10 @@
+// Test shellname() == "bash" folding to constant based on target
+// For bash target, this should fold to "1" (true)
+// Output
+// 1
+
+if shellname() == "bash" {
+    echo("1")
+} else {
+    echo("0")
+}

--- a/src/tests/validity/shellname_eq_nonbash.ab
+++ b/src/tests/validity/shellname_eq_nonbash.ab
@@ -1,6 +1,9 @@
 // Test shellname() == "zsh" folding to constant based on target
-// For bash target, this should fold to "0" (false)
-// Output
+// Output [bash]
+// 0
+// Output [zsh]
+// 1
+// Output [ksh]
 // 0
 
 if shellname() == "zsh" {

--- a/src/tests/validity/shellname_eq_nonbash.ab
+++ b/src/tests/validity/shellname_eq_nonbash.ab
@@ -1,0 +1,10 @@
+// Test shellname() == "zsh" folding to constant based on target
+// For bash target, this should fold to "0" (false)
+// Output
+// 0
+
+if shellname() == "zsh" {
+    echo("1")
+} else {
+    echo("0")
+}

--- a/src/tests/validity/shellname_eq_reversed.ab
+++ b/src/tests/validity/shellname_eq_reversed.ab
@@ -1,0 +1,10 @@
+// Test "bash" == shellname() folding (reversed order)
+// For bash target, this should fold to "1" (true)
+// Output
+// 1
+
+if "bash" == shellname() {
+    echo("1")
+} else {
+    echo("0")
+}

--- a/src/tests/validity/shellname_eq_reversed.ab
+++ b/src/tests/validity/shellname_eq_reversed.ab
@@ -1,7 +1,10 @@
 // Test "bash" == shellname() folding (reversed order)
-// For bash target, this should fold to "1" (true)
-// Output
+// Output [bash]
 // 1
+// Output [zsh]
+// 0
+// Output [ksh]
+// 0
 
 if "bash" == shellname() {
     echo("1")

--- a/src/tests/validity/shellname_neq_bash.ab
+++ b/src/tests/validity/shellname_neq_bash.ab
@@ -1,0 +1,10 @@
+// Test shellname() != "bash" folding to constant based on target
+// For bash target, this should fold to "0" (false)
+// Output
+// 0
+
+if shellname() != "bash" {
+    echo("1")
+} else {
+    echo("0")
+}

--- a/src/tests/validity/shellname_neq_bash.ab
+++ b/src/tests/validity/shellname_neq_bash.ab
@@ -1,7 +1,10 @@
 // Test shellname() != "bash" folding to constant based on target
-// For bash target, this should fold to "0" (false)
-// Output
+// Output [bash]
 // 0
+// Output [zsh]
+// 1
+// Output [ksh]
+// 1
 
 if shellname() != "bash" {
     echo("1")

--- a/src/tests/validity/shellname_neq_reversed.ab
+++ b/src/tests/validity/shellname_neq_reversed.ab
@@ -1,6 +1,9 @@
 // Test "zsh" != shellname() folding (reversed order)
-// For bash target, this should fold to "1" (true)
-// Output
+// Output [bash]
+// 1
+// Output [zsh]
+// 0
+// Output [ksh]
 // 1
 
 if "zsh" != shellname() {

--- a/src/tests/validity/shellname_neq_reversed.ab
+++ b/src/tests/validity/shellname_neq_reversed.ab
@@ -1,0 +1,10 @@
+// Test "zsh" != shellname() folding (reversed order)
+// For bash target, this should fold to "1" (true)
+// Output
+// 1
+
+if "zsh" != shellname() {
+    echo("1")
+} else {
+    echo("0")
+}

--- a/src/tests/validity/shellname_neq_zsh.ab
+++ b/src/tests/validity/shellname_neq_zsh.ab
@@ -1,6 +1,9 @@
 // Test shellname() != "zsh" folding to constant based on target
-// For bash target, this should fold to "1" (true)
-// Output
+// Output [bash]
+// 1
+// Output [zsh]
+// 0
+// Output [ksh]
 // 1
 
 if shellname() != "zsh" {

--- a/src/tests/validity/shellname_neq_zsh.ab
+++ b/src/tests/validity/shellname_neq_zsh.ab
@@ -1,0 +1,10 @@
+// Test shellname() != "zsh" folding to constant based on target
+// For bash target, this should fold to "1" (true)
+// Output
+// 1
+
+if shellname() != "zsh" {
+    echo("1")
+} else {
+    echo("0")
+}

--- a/src/tests/validity/shellname_standalone.ab
+++ b/src/tests/validity/shellname_standalone.ab
@@ -1,7 +1,10 @@
 // Test standalone shellname() usage (not in comparison)
-// This exercises the translate() path that sets shellname_used flag
-// Output
+// Output [bash]
 // bash
+// Output [zsh]
+// zsh
+// Output [ksh]
+// ksh
 
 const s = shellname()
 echo(s)

--- a/src/tests/validity/shellname_standalone.ab
+++ b/src/tests/validity/shellname_standalone.ab
@@ -1,0 +1,7 @@
+// Test standalone shellname() usage (not in comparison)
+// This exercises the translate() path that sets shellname_used flag
+// Output
+// bash
+
+const s = shellname()
+echo(s)

--- a/src/tests/validity/text_empty.ab
+++ b/src/tests/validity/text_empty.ab
@@ -1,0 +1,5 @@
+// Test empty string literal
+// Output
+// Succeeded
+
+echo("Succeeded")

--- a/src/tests/validity/text_simple_string.ab
+++ b/src/tests/validity/text_simple_string.ab
@@ -1,0 +1,5 @@
+// Test simple string literal (for as_simple_string coverage)
+// Output
+// hello world
+
+echo("hello world")

--- a/src/tests/validity/true_literal_ifchain.ab
+++ b/src/tests/validity/true_literal_ifchain.ab
@@ -1,0 +1,9 @@
+// Test ifchain with literal true condition
+// Output
+// taken
+
+if {
+    true {
+        echo("taken")
+    }
+}

--- a/src/tests/warning.rs
+++ b/src/tests/warning.rs
@@ -8,3 +8,40 @@ use test_generator::test_resources;
 fn test_warning(input: &str) {
     script_test(input, TestOutcomeTarget::Success);
 }
+
+#[test]
+fn target_dependent_dead_code_warnings() {
+    use crate::compiler::{AmberCompiler, CompilerOptions};
+    use crate::utils::ShellType;
+
+    for target in [ShellType::BashModern, ShellType::BashLegacy, ShellType::Zsh, ShellType::Ksh] {
+        for (condition, expected_warnings) in [
+            (r#"shellname() == "bash""#, 0),
+            (r#"shellname() != "bash""#, 0),
+            (r#"not (shellname() == "bash")"#, 0),
+            (r#"true and (shellname() == "bash")"#, 0),
+            (r#"false or (shellname() == "bash")"#, 0),
+            (r#"(shellname() == "bash") and false"#, 1),
+            (r#"false and (shellname() == "bash")"#, 1),
+            (r#"(shellname() == "bash") or true"#, 1),
+            (r#"true or (shellname() == "bash")"#, 1),
+        ] {
+            let code = format!(
+                "if {condition} {{ echo(\"yes\") }} else {{ echo(\"no\") }}"
+            );
+            let options = CompilerOptions::default().with_target(Some(target));
+            let (warnings, _) = AmberCompiler::new(code, None, options).compile().unwrap();
+            assert_eq!(warnings.len(), expected_warnings, "{condition} on {target:?}");
+        }
+
+        let code = r#"if {
+            shellname() == "bash": echo("bash")
+            shellname() == "zsh": echo("zsh")
+            shellname() == "ksh": echo("ksh")
+            else { echo("other") }
+        }"#;
+        let options = CompilerOptions::default().with_target(Some(target));
+        let (warnings, _) = AmberCompiler::new(code.into(), None, options).compile().unwrap();
+        assert!(warnings.is_empty(), "{warnings:?}");
+    }
+}

--- a/src/utils/metadata/mod.rs
+++ b/src/utils/metadata/mod.rs
@@ -2,3 +2,8 @@ mod parser;
 mod translate;
 pub use parser::*;
 pub use translate::*;
+
+#[derive(Debug)]
+pub struct TargetShell {
+    pub shell: ShellType,
+}

--- a/src/utils/metadata/parser.rs
+++ b/src/utils/metadata/parser.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeSet, HashMap};
 
+use crate::compiler::{AmberCompiler, CompilerOptions};
 use crate::modules::block::Block;
 use crate::modules::types::Type;
+use crate::utils::TargetShell;
 use crate::utils::context::{Context, FunctionDecl, ScopeUnit, VariableDecl};
 use crate::utils::function_cache::FunctionCache;
 use crate::utils::function_interface::FunctionInterface;
@@ -44,6 +46,9 @@ pub struct ParserMetadata {
     /// This is used to generally assess if a function is valid and emit errors if it is not
     #[context]
     pub first_pass_ctx: bool,
+    /// Contains information about specified target output
+    /// Only used at the `typecheck` layer
+    pub target: Option<TargetShell>,
 }
 
 impl ParserMetadata {
@@ -58,6 +63,11 @@ impl ParserMetadata {
 
 // Implement context methods
 impl ParserMetadata {
+    pub fn with_target_shell(&mut self, options: &CompilerOptions) {
+        let target_shell = AmberCompiler::resolve_target_shell(options.target);
+        self.target = Some(TargetShell { shell: target_shell });
+    }
+
     /* Scopes */
 
     /// Determines if the parser is in the global scope
@@ -313,6 +323,7 @@ impl Metadata for ParserMetadata {
             narrowed_types: Vec::new(),
             suppress_warnings: false,
             first_pass_ctx: false,
+            target: None
         }
     }
 

--- a/src/utils/metadata/translate.rs
+++ b/src/utils/metadata/translate.rs
@@ -11,7 +11,7 @@ use crate::raw_fragment;
 use crate::translate::compute::ArithType;
 use crate::utils::function_cache::FunctionCache;
 use crate::utils::function_metadata::FunctionMetadata;
-use crate::utils::is_all_caps;
+use crate::utils::{TargetShell, is_all_caps};
 use amber_meta::ContextManager;
 use clap::ValueEnum;
 
@@ -72,10 +72,6 @@ impl ShellType {
     pub fn is_bash_legacy(self) -> bool {
         matches!(self, ShellType::BashLegacy)
     }
-}
-
-pub struct TargetShell {
-    pub shell: ShellType,
 }
 
 #[derive(ContextManager)]


### PR DESCRIPTION
Ref: https://github.com/amber-lang/amber/issues/897

This fixes all the last errors reported by shellcheck and a regression of the previous PR.

# Recap of Rust changes

Per-target constant folding
When the output target is known at compile time (--target), comparisons of the form shellname() == "bash" / shellname() != "zsh" (either operand order) are folded to the constants 1/0 instead of emitting a runtime [[ "$EXEC_SHELL" == "bash" ]] test:
- src/modules/builtin/shellname.rs (+31) — new Shellname::try_fold_comparison(meta, other, is_eq): compares the target shell's family_name() against the literal and returns a 1/0 fragment (inverted for !=). Only applies when the other operand is a plain string literal. Standalone shellname() calls are untouched and still render as $EXEC_SHELL.
- src/modules/expression/binop/eq.rs / neq.rs (+53 each) — Eq/Neq gain analyze_control_flow(meta) which detects the shellname() vs literal pattern in either operand order. translate() tries the fold first and returns the constant fragment; when folded, meta.shellname_used is not set, so no shellname.sh preamble / EXEC_SHELL dispatch is emitted at all. Non-literal comparisons fall through to the normal rendering.
- src/modules/expression/expr.rs (+17) — new Expr::try_fold_bool_constant(meta): entry point that resolves a constant boolean through Bool literals, and/or/not, parentheses, ==, !=, and is nodes. This is what the condition translators call.
- src/modules/expression/literal/text.rs (+16) — Text::as_simple_string(): returns the content only for a literal with exactly one String part (no interpolation), guarding the fold against non-constant operands.
- src/modules/expression/parentheses.rs (+5) — Parentheses::get_expr() accessor so folding can see through parenthesized conditions.
Condition translation with folded constants
- src/modules/condition/ifcond.rs — a simple if now folds its condition via try_fold_bool_constant; a constant-true condition emits only the body, a constant-false one emits only the else body.
- src/modules/condition/ifchain.rs (+78/−42) — IfChain::translate reworked around the folded constants:
- constant-false branches are dropped entirely;
- the first constant-true branch stops the chain (later branches are dead code);
- a constant-true branch after dynamic branches is emitted as the else block;
- if it is the only taken branch, the body is emitted bare with no if/fi at all;
- the explicit else block is suppressed when a constant-true branch already dominates (dead code), and fi is emitted only when at least one if/elif was emitted.
Net effect: amber build --target bash emits pure bash (zero EXEC_SHELL dispatch), and the same holds for the zsh/ksh targets — no more polyglot shims in the output.
Target-aware test harness
- src/tests/mod.rs (+108/−26) — new extract_targeted_output(): fixtures may declare // Output [bash|zsh|ksh] tagged blocks, and the harness selects the block matching the active AMBER_TEST_TARGET (falling back to the plain // Output block, then .output.txt, then Succeeded). Every test now runs on every target with its own expectation — no per-shell test exclusion. Four new unit tests cover the selection logic.
Supporting (non-Rust) changes
- src/std/env.ab: zsh env_var_test existence check fixed — the ${(P)name} indirection tested the variable's value instead of its name; now a direct [[ -v "$name" ]].
- src/std/text.ab: sed probes use command sed.
- 21 new validity fixtures (shellname comparisons, ifchain constant folding, parentheses, empty text) with per-target // Output [target] blocks; one bash-3.2 snapshot update.
- .github/workflows/rust.yml: macOS job now runs the full suite in two phases with explicit AMBER_TEST_TARGET (zsh and bash-3.2) — no skipped tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conditional evaluation while preserving side effects and target-specific behavior.
  * Improved `shellname()` comparisons across Bash, Zsh, and Ksh.
  * Fixed Zsh environment-variable detection.
  * Prevented `sed` aliases from affecting text and regular-expression operations.
  * Improved handling of parenthesized expressions and boolean conditions.

* **Performance**
  * Streamlined constant-expression analysis for cleaner generated shell code.

* **Tests**
  * Expanded coverage for shell-specific behavior, conditionals, parentheses, and text handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->