### PR TITLE
Fix eager function calls in ternary branches

### DIFF
--- a/src/modules/expression/ternop/ternary.rs
+++ b/src/modules/expression/ternop/ternary.rs
@@ -160,25 +160,29 @@ impl TranslateModule for Ternary {
                     .cond
                     .translate(meta)
                     .with_condition(true);
-                let true_expr = self
-                    .true_expr
-                    .as_ref()
-                    .map(|e| e.translate(meta))
-                    .unwrap_or(FragmentKind::Empty);
-                let false_expr = self
-                    .false_expr
-                    .as_ref()
-                    .map(|e| e.translate(meta))
-                    .unwrap_or(FragmentKind::Empty);
-                let expr = fragments!(
-                        "if ",
-                        cond,
-                        "; then printf '%s\n' ",
-                        true_expr,
-                        "; else printf '%s\n' ",
-                        false_expr,
-                        "; fi"
-                    );
+                let translate_branch = |expr: Option<&Box<Expr>>, meta: &mut TranslateMetadata| {
+                    let outer_queue = std::mem::take(&mut meta.stmt_queue);
+                    let value = expr
+                        .map(|expr| expr.translate(meta))
+                        .unwrap_or(FragmentKind::Empty);
+                    let mut statements = meta.stmt_queue.drain(..).collect::<Vec<_>>();
+                    meta.stmt_queue = outer_queue;
+                    statements.push(fragments!("printf '%s\n' ", value));
+                    BlockFragment::new(statements, true).to_frag()
+                };
+                let true_branch = translate_branch(self.true_expr.as_ref(), meta);
+                let false_branch = translate_branch(self.false_expr.as_ref(), meta);
+                let expr = BlockFragment::new(
+                    vec![
+                        fragments!("if ", cond, "; then"),
+                        true_branch,
+                        fragments!("else"),
+                        false_branch,
+                        fragments!("fi"),
+                    ],
+                    false,
+                )
+                .to_frag();
                 if is_array {
                     let id = meta.gen_value_id();
                     let value = SubprocessFragment::new(expr).with_quotes(false).to_frag();

--- a/src/tests/validity/ternary_function_branches.ab
+++ b/src/tests/validity/ternary_function_branches.ab
@@ -1,0 +1,15 @@
+// Output
+// called chosen true
+// chosen true
+// called chosen false
+// chosen false
+
+fun selected(label: Text): Text {
+    echo("called {label}")
+    return label
+}
+
+main(args) {
+    echo(len(args) >= 1 then selected("chosen true") else selected("skipped false"))
+    echo(len(args) < 1 then selected("skipped true") else selected("chosen false"))
+}


### PR DESCRIPTION
## Summary

- keep prerequisite statements produced by each dynamic ternary branch inside that branch
- preserve the enclosing statement queue for condition evaluation
- add a runtime regression covering function calls in both selected and skipped branches

## Testing

- cargo test --all-targets --all-features (856 passed)
- cargo clippy --all-targets --all-features with warnings denied
- compiled and ran the issue reproduction for Bash 4.3, Bash 3.2, zsh, and ksh
- ShellCheck passed for all four generated scripts

Fixes #1133
