### PR TITLE
fix(nix): update naersk for crates.io downloads

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,17 +1,40 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "naersk",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1752475459,
+        "narHash": "sha256-z6QEu4ZFuHiqdOPbYss4/Q8B0BFhacR8ts6jO/F/aOU=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "bf0d6f70f4c9a9cf8845f992105652173f4b617f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "naersk": {
       "inputs": {
+        "fenix": "fenix",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1739824009,
-        "narHash": "sha256-fcNrCMUWVLMG3gKC5M9CBqVOAnJtyRvGPxptQFl5mVg=",
+        "lastModified": 1782220280,
+        "narHash": "sha256-thLTFbp9D5Qknmh8q/v4FRpLGphUSijT3E86cbLYTXo=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "e5130d37369bfa600144c2424270c96f0ef0e11d",
+        "rev": "9aa07bb0256d300219b30622d2454e85f7f3667e",
         "type": "github"
       },
       "original": {
@@ -43,6 +66,23 @@
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay",
         "utils": "utils"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752428706,
+        "narHash": "sha256-EJcdxw3aXfP8Ex1Nm3s0awyH9egQvB2Gu+QEnJn2Sfg=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "591e3b7624be97e4443ea7b5542c191311aa141d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "rust-overlay": {


### PR DESCRIPTION
## Summary

Update the locked `naersk` revision to a version that uses `static.crates.io` for crate downloads instead of the crates.io API endpoint that now returns HTTP 403 for these Nix fetches.

This addresses the failing `nix build` on `staging`, where `anstream-0.6.19` could not be downloaded from `https://crates.io/api/v1/crates/.../download`.

## Context

The failing workflow still passes:

- `nix flake check --all-systems`
- `nix develop --command cargo build --release`

and fails only during the hermetic `nix build` dependency fetch.

Upstream `naersk` fixed this by switching crate downloads to `https://static.crates.io/crates/.../download`.

## Changes

- update the locked `naersk` revision
- add the transitive `fenix` and `rust-analyzer-src` lock nodes required by the newer `naersk` flake
- leave all other Amber flake inputs unchanged

## Verification

I could not run `nix build` locally in the execution environment because the local container has no network access, so full verification is deferred to GitHub Actions after this reaches a branch on which the Nix workflow runs.

The existing Nix workflow currently triggers only on pushes to `main` and `staging`, not on pull requests.